### PR TITLE
fix: add missing resetDashboardPrefetchSession import

### DIFF
--- a/src/lib/utils/clear-account-state.ts
+++ b/src/lib/utils/clear-account-state.ts
@@ -77,6 +77,7 @@ import { GOVERNANCE_SNAPSHOT_CACHE_PREFIX } from '../dashboard/governance-snapsh
 import { SAFE_STATE_DISK_CACHE_PREFIX } from '../dashboard/safe-state-disk-cache';
 import { resetInviteAcceptState } from '../invites/accept-invite';
 import { resetCommonsPrefetchSession } from '../commons/commons-prefetch';
+import { resetDashboardPrefetchSession } from '../app/dashboard-parent-prefetch';
 import { INVITE_DECISION_SCOPED_PREFIXES } from '../../stores/invite-decisions';
 import { recentEmojisStore } from '../../stores/emojis';
 import { PACTO_COMMONS_BROADCASTS_PREFIX } from '../commons/local-broadcast-state';


### PR DESCRIPTION
## Problem
`src/lib/utils/clear-account-state.ts` calls `resetDashboardPrefetchSession()` during account state cleanup, but the function was not imported. This caused a `ReferenceError` at runtime whenever the account creation / unlock flow reset dashboard state.

## Change
Import `resetDashboardPrefetchSession` from `../app/dashboard-parent-prefetch` (the module that defines it) in `src/lib/utils/clear-account-state.ts`.

## Verification
- `resetDashboardPrefetchSession` is now referenced correctly at the call site in `clearAccountState()`.
- TypeScript compilation and existing tests continue to pass.

## Files changed
- `src/lib/utils/clear-account-state.ts`
