### PR TITLE
Message handling improvements + codebase audit doc

### DIFF
--- a/src-tauri/src/chat.rs
+++ b/src-tauri/src/chat.rs
@@ -101,6 +101,37 @@ impl Chat {
         true
     }
 
+    /// Update reply context for any messages in this chat that reference `original.id`.
+    /// Returns the updated messages so callers can emit UI updates.
+    /// For DM chats, `is_original_mine` is used to derive the author's npub because DM
+    /// messages do not store the sender's npub directly.
+    pub fn update_replies_to_message(
+        &mut self,
+        original: &Message,
+        is_original_mine: bool,
+    ) -> Vec<Message> {
+        let npub = if self.chat_type == ChatType::DirectMessage {
+            if is_original_mine {
+                crate::account_manager::get_current_account().ok()
+            } else {
+                self.participants.first().cloned()
+            }
+        } else {
+            original.npub.clone()
+        };
+
+        let mut updated = Vec::new();
+        for msg in self.messages.iter_mut() {
+            if msg.replied_to == original.id && msg.replied_to_content.is_none() {
+                msg.replied_to_content = Some(original.content.clone());
+                msg.replied_to_npub = npub.clone();
+                msg.replied_to_has_attachment = Some(!original.attachments.is_empty());
+                updated.push(msg.clone());
+            }
+        }
+        updated
+    }
+
     /// Add a Reaction - if it was not already added
     pub fn add_reaction(&mut self, reaction: crate::Reaction, message_id: &str) -> bool {
         // Find the message
@@ -318,4 +349,143 @@ pub async fn mark_as_read(chat_id: String, message_id: Option<String>) -> bool {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Message;
+
+    fn text_message(id: &str, content: &str) -> Message {
+        Message {
+            id: id.to_string(),
+            content: content.to_string(),
+            at: 1,
+            ..Default::default()
+        }
+    }
+
+    fn reply_message(id: &str, content: &str, replied_to: &str) -> Message {
+        Message {
+            id: id.to_string(),
+            content: content.to_string(),
+            replied_to: replied_to.to_string(),
+            at: 2,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn update_replies_fills_missing_reply_context() {
+        let mut chat = Chat::new_dm("npub1original".to_string());
+        let original = text_message("orig-id", "original message");
+        let reply = reply_message("reply-id", "reply message", "orig-id");
+        chat.internal_add_message(reply);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, false);
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].id, "reply-id");
+        assert_eq!(updated[0].replied_to_content.as_deref(), Some("original message"));
+        assert_eq!(updated[0].replied_to_npub.as_deref(), Some("npub1original"));
+        let reply_in_chat = chat.messages.iter().find(|m| m.id == "reply-id").unwrap();
+        assert_eq!(reply_in_chat.replied_to_content.as_deref(), Some("original message"));
+        assert_eq!(reply_in_chat.replied_to_npub.as_deref(), Some("npub1original"));
+    }
+
+    #[test]
+    fn update_replies_uses_current_account_for_own_messages() {
+        // For a DM, when the original message is ours, the method looks up the current
+        // account. In a test environment there is no current account, so the npub falls
+        // back to None, but the content is still filled.
+        let mut chat = Chat::new_dm("npub1original".to_string());
+        let original = text_message("orig-id", "original message");
+        let reply = reply_message("reply-id", "reply message", "orig-id");
+        chat.internal_add_message(reply);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, true);
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].replied_to_content.as_deref(), Some("original message"));
+        let reply_in_chat = chat.messages.iter().find(|m| m.id == "reply-id").unwrap();
+        assert_eq!(reply_in_chat.replied_to_content.as_deref(), Some("original message"));
+    }
+
+    #[test]
+    fn update_replies_skips_messages_with_existing_context() {
+        let mut chat = Chat::new_dm("npub1original".to_string());
+        let original = text_message("orig-id", "new original");
+        let reply = Message {
+            id: "reply-id".to_string(),
+            content: "reply".to_string(),
+            replied_to: "orig-id".to_string(),
+            replied_to_content: Some("old original".to_string()),
+            at: 2,
+            ..Default::default()
+        };
+        chat.internal_add_message(reply);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, false);
+
+        assert!(updated.is_empty());
+        let reply_in_chat = chat.messages.iter().find(|m| m.id == "reply-id").unwrap();
+        assert_eq!(reply_in_chat.replied_to_content.as_deref(), Some("old original"));
+    }
+
+    #[test]
+    fn update_replies_only_affects_messages_referencing_original() {
+        let mut chat = Chat::new_dm("npub1original".to_string());
+        let original = text_message("orig-id", "original");
+        let unrelated = reply_message("unrelated-id", "unrelated", "other-id");
+        let reply = reply_message("reply-id", "reply", "orig-id");
+        chat.internal_add_message(unrelated);
+        chat.internal_add_message(reply);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, false);
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].id, "reply-id");
+        assert_eq!(updated[0].replied_to_npub.as_deref(), Some("npub1original"));
+        let unrelated_in_chat = chat.messages.iter().find(|m| m.id == "unrelated-id").unwrap();
+        assert!(unrelated_in_chat.replied_to_content.is_none());
+    }
+
+    #[test]
+    fn update_replies_updates_multiple_replies() {
+        let mut chat = Chat::new_dm("npub1original".to_string());
+        let original = text_message("orig-id", "original");
+        let reply1 = reply_message("reply-1", "first", "orig-id");
+        let reply2 = reply_message("reply-2", "second", "orig-id");
+        chat.internal_add_message(reply1);
+        chat.internal_add_message(reply2);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, false);
+
+        assert_eq!(updated.len(), 2);
+    }
+
+    #[test]
+    fn update_replies_uses_message_npub_for_group_chats() {
+        let mut chat = Chat::new("group-1".to_string(), ChatType::MlsGroup, vec![]);
+        let original = Message {
+            id: "orig-id".to_string(),
+            content: "original".to_string(),
+            npub: Some("npub1sender".to_string()),
+            at: 1,
+            ..Default::default()
+        };
+        let reply = reply_message("reply-id", "reply", "orig-id");
+        chat.internal_add_message(reply);
+        chat.internal_add_message(original.clone());
+
+        let updated = chat.update_replies_to_message(&original, false);
+
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].replied_to_npub.as_deref(), Some("npub1sender"));
+    }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -3876,7 +3876,7 @@ async fn get_reply_contexts<R: Runtime>(
     }
 
     // Do all SQLite work synchronously in a block to avoid Send issues
-    let (events, edits): (Vec<(String, i32, String, Option<String>)>, Vec<(String, String)>) = {
+    let (events, edits): (Vec<(String, i32, String, Option<String>, i32)>, Vec<(String, String)>) = {
         let conn = crate::account_manager::get_db_connection(handle)?;
 
         // Build placeholders for IN clause
@@ -3888,7 +3888,7 @@ async fn get_reply_contexts<R: Runtime>(
         // Query original messages
         let sql = format!(
             r#"
-            SELECT id, kind, content, npub
+            SELECT id, kind, content, npub, mine
             FROM events
             WHERE id IN ({})
             "#,
@@ -3908,10 +3908,11 @@ async fn get_reply_contexts<R: Runtime>(
                 row.get::<_, i32>(1)?,    // kind
                 row.get::<_, String>(2)?, // content
                 row.get::<_, Option<String>>(3)?, // npub
+                row.get::<_, i32>(4)?,    // mine
             ))
         }).map_err(|e| format!("Failed to query reply contexts: {}", e))?;
 
-        let events_result: Vec<(String, i32, String, Option<String>)> = rows.filter_map(|r| r.ok()).collect();
+        let events_result: Vec<(String, i32, String, Option<String>, i32)> = rows.filter_map(|r| r.ok()).collect();
         drop(stmt);
 
         // Query latest edits for these messages (most recent edit per message)
@@ -3952,8 +3953,17 @@ async fn get_reply_contexts<R: Runtime>(
 
     // Process events and decrypt content (async part)
     let mut contexts = HashMap::new();
-    for (id, kind, original_content, npub) in events {
+    for (id, kind, original_content, npub, mine) in events {
         let has_attachment = kind == event_kind::FILE_ATTACHMENT as i32;
+
+        // DM messages don't store the sender npub directly. For our own outbound DMs
+        // the npub column is NULL, so derive it from the current account so reply
+        // bars can render "You" instead of "Unknown".
+        let npub = if mine != 0 && npub.is_none() {
+            crate::account_manager::get_current_account().ok()
+        } else {
+            npub
+        };
 
         // Use latest edit content if available, otherwise use original
         let content_to_decrypt = latest_edits.get(&id).cloned().unwrap_or(original_content);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1637,6 +1637,28 @@ async fn handle_text_message(mut msg: Message, contact: &str, is_mine: bool, is_
             })).unwrap();
         }
 
+        // Backfill reply context for any messages that arrived earlier and reference this one.
+        // This fixes the race where a bot reply (which references the original message's rumor id)
+        // is processed before the user's own outbound message has been persisted under its real id.
+        let updated_replies = {
+            let mut state = STATE.lock().await;
+            if let Some(chat) = state.get_chat_mut(contact) {
+                chat.update_replies_to_message(&msg, is_mine)
+            } else {
+                Vec::new()
+            }
+        };
+        for reply in updated_replies {
+            eprintln!("[handle_text_message] emitting message_update for backfilled reply: {}", reply.id);
+            if let Some(handle) = TAURI_APP.get() {
+                let _ = handle.emit("message_update", serde_json::json!({
+                    "old_id": reply.id,
+                    "message": reply,
+                    "chat_id": contact
+                }));
+            }
+        }
+
         // OS notification: incoming DMs, and outgoing `wallet_tx_announcement` (transfer completed)
         if is_new {
             if !is_mine {
@@ -1690,6 +1712,8 @@ async fn handle_text_message(mut msg: Message, contact: &str, is_mine: bool, is_
         if let Some(handle) = TAURI_APP.get() {
             let _ = update_unread_counter(handle.clone()).await;
         }
+    } else {
+        // Message was not added to state (duplicate or filtered)
     }
 
     was_msg_added_to_state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1649,10 +1649,10 @@ async fn handle_text_message(mut msg: Message, contact: &str, is_mine: bool, is_
             }
         };
         for reply in updated_replies {
-            eprintln!("[handle_text_message] emitting message_update for backfilled reply: {}", reply.id);
             if let Some(handle) = TAURI_APP.get() {
+                let reply_id = reply.id.clone();
                 let _ = handle.emit("message_update", serde_json::json!({
-                    "old_id": reply.id,
+                    "old_id": reply_id,
                     "message": reply,
                     "chat_id": contact
                 }));

--- a/src-tauri/src/message.rs
+++ b/src-tauri/src/message.rs
@@ -817,31 +817,49 @@ pub async fn message(
                         {
                             let pending_id_for_early_update = Arc::clone(&pending_id);
                             let mut state = STATE.lock().await;
-                            if let Some(msg) = state.chats.iter_mut()
+                            if let Some(chat) = state.chats.iter_mut()
                                 .find(|chat| chat.id() == &receiver || chat.has_participant(&receiver))
-                                .and_then(|chat| chat.messages.iter_mut().find(|m| m.id == *pending_id_for_early_update))
                             {
-                                // Update the message ID and clear pending state
-                                msg.id = rumor_id.to_hex();
-                                msg.pending = false;
-                                msg.wrapper_event_id = Some(wrapper_id);
+                                // Update the message in-place and capture a clone for the backfill.
+                                let original = chat.messages.iter_mut()
+                                    .find(|m| m.id == *pending_id_for_early_update)
+                                    .map(|msg| {
+                                        msg.id = rumor_id.to_hex();
+                                        msg.pending = false;
+                                        msg.wrapper_event_id = Some(wrapper_id);
+                                        msg.clone()
+                                    });
                                 
-                                // Emit update to frontend for immediate visual feedback
-                                let handle = TAURI_APP.get().unwrap();
-                                let _ = handle.emit("message_update", serde_json::json!({
-                                    "old_id": pending_id_for_early_update.as_ref(),
-                                    "message": &msg,
-                                    "chat_id": &receiver
-                                }));
-                                
-                                // Save to DB immediately (don't wait for self-send)
-                                let message_to_save = msg.clone();
-                                let chat_to_save = state.get_chat(&receiver).cloned();
-                                drop(state); // Release lock before async DB operations
-                                
-                                if let Some(chat) = chat_to_save {
-                                    let _ = save_chat(handle.clone(), &chat).await;
-                                    let _ = crate::db::save_message(handle.clone(), &receiver, &message_to_save).await;
+                                if let Some(original) = original {
+                                    // Backfill reply context for any messages that arrived before
+                                    // this outbound message was persisted under its real rumor id.
+                                    // The bot can reply faster than we receive the relay's publish ack,
+                                    // so its reply may already be in state with empty context.
+                                    let updated_replies = chat.update_replies_to_message(&original, true);
+                                    
+                                    // Emit update to frontend for immediate visual feedback
+                                    let handle = TAURI_APP.get().unwrap();
+                                    let _ = handle.emit("message_update", serde_json::json!({
+                                        "old_id": pending_id_for_early_update.as_ref(),
+                                        "message": &original,
+                                        "chat_id": &receiver
+                                    }));
+                                    
+                                    // Also emit updates for replies whose context was backfilled
+                                    for reply in updated_replies {
+                                        let _ = handle.emit("message_update", serde_json::json!({
+                                            "old_id": reply.id,
+                                            "message": reply,
+                                            "chat_id": &receiver
+                                        }));
+                                    }
+                                    
+                                    // Save to DB immediately (don't wait for self-send)
+                                    let chat_to_save = chat.clone();
+                                    drop(state); // Release lock before async DB operations
+                                    
+                                    let _ = save_chat(handle.clone(), &chat_to_save).await;
+                                    let _ = crate::db::save_message(handle.clone(), &receiver, &original).await;
                                 }
                             }
                         }

--- a/src-tauri/src/message.rs
+++ b/src-tauri/src/message.rs
@@ -847,8 +847,9 @@ pub async fn message(
                                     
                                     // Also emit updates for replies whose context was backfilled
                                     for reply in updated_replies {
+                                        let reply_id = reply.id.clone();
                                         let _ = handle.emit("message_update", serde_json::json!({
-                                            "old_id": reply.id,
+                                            "old_id": reply_id,
                                             "message": reply,
                                             "chat_id": &receiver
                                         }));

--- a/src/lib/api/relays.test.ts
+++ b/src/lib/api/relays.test.ts
@@ -7,9 +7,18 @@ describe('validateRelayUrlInput', () => {
     expect(validateRelayUrlInput('  wss://relay.example.com/path  ')).toBeNull();
   });
 
-  it('rejects empty and non-wss URLs', () => {
+  it('accepts ws:// localhost dev relays', () => {
+    expect(validateRelayUrlInput('ws://localhost:7000')).toBeNull();
+    expect(validateRelayUrlInput('ws://localhost')).toBeNull();
+    expect(validateRelayUrlInput('ws://127.0.0.1:7000')).toBeNull();
+  });
+
+  it('rejects empty and non-local ws:// URLs', () => {
     expect(validateRelayUrlInput('')).toBeTruthy();
     expect(validateRelayUrlInput('ws://relay.example.com')).toBeTruthy();
+    expect(validateRelayUrlInput('ws://127.0.0.1')).toBeTruthy();
+    expect(validateRelayUrlInput('ws://localhost.evil.com')).toBeTruthy();
+    expect(validateRelayUrlInput('ws://user@localhost:7000')).toBeTruthy();
     expect(validateRelayUrlInput('https://relay.example.com')).toBeTruthy();
     expect(validateRelayUrlInput('wss://')).toBeTruthy();
   });

--- a/src/lib/api/relays.test.ts
+++ b/src/lib/api/relays.test.ts
@@ -16,7 +16,6 @@ describe('validateRelayUrlInput', () => {
   it('rejects empty and non-local ws:// URLs', () => {
     expect(validateRelayUrlInput('')).toBeTruthy();
     expect(validateRelayUrlInput('ws://relay.example.com')).toBeTruthy();
-    expect(validateRelayUrlInput('ws://127.0.0.1')).toBeTruthy();
     expect(validateRelayUrlInput('ws://localhost.evil.com')).toBeTruthy();
     expect(validateRelayUrlInput('ws://user@localhost:7000')).toBeTruthy();
     expect(validateRelayUrlInput('https://relay.example.com')).toBeTruthy();

--- a/src/lib/api/relays.ts
+++ b/src/lib/api/relays.ts
@@ -32,10 +32,27 @@ export interface CustomRelay {
 export function validateRelayUrlInput(url: string): string | null {
   const trimmed = url.trim();
   if (!trimmed) return 'Enter a relay URL.';
-  if (!trimmed.startsWith('wss://')) return 'Relay URL must start with wss://';
-  const host = trimmed.slice('wss://'.length).replace(/\/+$/, '');
-  if (!host) return 'Relay URL must include a host.';
-  return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return 'Relay URL must start with wss:// (ws:// is allowed only for localhost/127.0.0.1 development relays)';
+  }
+
+  if (!parsed.host) return 'Relay URL must include a host.';
+  if (parsed.username || parsed.password) return 'Relay URL must not contain userinfo.';
+
+  if (parsed.protocol === 'wss:') return null;
+
+  if (parsed.protocol === 'ws:') {
+    const host = parsed.hostname;
+    const isLocalhost = host === 'localhost';
+    const isLoopbackWithPort = host === '127.0.0.1' && parsed.port !== '';
+    if (isLocalhost || isLoopbackWithPort) return null;
+  }
+
+  return 'Relay URL must start with wss:// (ws:// is allowed only for localhost/127.0.0.1 development relays)';
 }
 
 export function relayModeLabel(mode: string): string {

--- a/src/lib/api/relays.ts
+++ b/src/lib/api/relays.ts
@@ -48,8 +48,8 @@ export function validateRelayUrlInput(url: string): string | null {
   if (parsed.protocol === 'ws:') {
     const host = parsed.hostname;
     const isLocalhost = host === 'localhost';
-    const isLoopbackWithPort = host === '127.0.0.1' && parsed.port !== '';
-    if (isLocalhost || isLoopbackWithPort) return null;
+    const isLoopback = host === '127.0.0.1';
+    if (isLocalhost || isLoopback) return null;
   }
 
   return 'Relay URL must start with wss:// (ws:// is allowed only for localhost/127.0.0.1 development relays)';


### PR DESCRIPTION
Improve message handling reliability for local development and bot reply races.

What changed:
- Relaxes relay URL validation for local ws:// development hosts (localhost/127.0.0.1) so dev relays work without TLS.
- Backfills reply context for bot replies that arrived before the original message was persisted, closing a race in DM threads.

Why it matters:
- Local development currently requires TLS-only relays; this change lets contributors run the bundled dev relay without workarounds.
- Bot replies can beat original-message persistence during high-latency syncs; the backfill ensures reply context is shown correctly once the parent arrives.

Testing:
- Existing relay validation tests still require wss:// for non-local hosts.
- DM reply ordering should be verified with rapid-send/receive scenarios.
