### PR TITLE
docs: add strategy, concepts, and architecture docs

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,65 @@
+---
+name: Pacto Concepts
+last_updated: 2026-07-07
+---
+
+# Pacto Concepts
+
+A shared vocabulary for humans and coding agents working on Pacto. Terms are ordered from identity outward.
+
+## Identity
+
+| Term | Definition |
+|------|------------|
+| **npub** | Nostr public key. The user's human-readable identifier and the root of trust. |
+| **nsec** | Nostr secret key. Stored encrypted; never exposed to the frontend or network. |
+| **BIP-39 seed** | The same mnemonic seed that derives the Nostr keypair and the embedded EVM wallet. See `docs/wallet/HD_DERIVATION_V1.md`. |
+| **squad key** | A phrase-derived EVM account whose purpose is `squad`. Used for treasury, governance, and roster-bound actions. |
+| **advanced key** | A phrase-derived or imported EVM account whose purpose is `advanced`. Restricted to the Settings → Advanced contract-call panel. |
+
+## Messaging
+
+| Term | Definition |
+|------|------------|
+| **DM** | Direct message. End-to-end encrypted NIP-17/NIP-59 Gift Wrap (kind 1059) addressed to a peer's npub. |
+| **Rumor** | The inner, decrypted Nostr event after a Gift Wrap is opened. Kinds include 14 (text), 15 (file), 7 (reaction), 30078 (typing), and structured application rumors. |
+| **MLS** | Messaging Layer Security. The open protocol used for private group messaging; implemented via the `mdk` engine. |
+| **Squad** | A private community hub — a group of people sharing MLS channels and optionally a treasury. Stable id = announcements MLS group id. |
+| **Network** | An inter-organizational hub — a "Squad of Squads" — for cross-group coordination. |
+| **Squad-pair** | Partner coordination link between two anchor squads. Uses the same announcements-group-id rule as squads. See `docs/communities/DESIGN.md`. |
+| **Channel** | A chat stream inside a Squad or Network. Each channel is backed by an MLS group id. |
+| **Announcements** | The first channel of every squad/network. Its MLS group id is the parent's stable identifier. |
+| **Commons** | Public discovery feed for squads and time-bounded broadcasts; top-level navigation. |
+| **Gift Wrap** | NIP-59 outer envelope (kind 1059). Hides sender, recipient, and metadata from relays. |
+| **MlsWelcome / kind 443** | MLS group invitation payload delivered inside a Gift Wrap. |
+| **MlsGroupMessage / kind 444** | MLS-encrypted group traffic on the wire; `h` tag = wire group id. |
+
+## Governance and finance
+
+| Term | Definition |
+|------|------------|
+| **pacto-gov** | Upstream governance contract library for modular voting and decision rules. See `docs/wallet/PACTO_GOV.md`. |
+| **pacto-squad-sponsor** | Upstream factory for deploying squad infrastructure (treasury, governance, hats). See `docs/wallet/PACTO_SQUAD_SPONSOR.md`. |
+| **Squad infra** | On-chain artifacts deployed for a squad: Safe treasury, governance module, and Hats tree. Persisted in SQLite (`squad_infra`). |
+| **Safe** | Gnosis Safe multi-signature contract used as the squad treasury. |
+| **Hats Protocol** | On-chain role management. Hats define roles that can be granted, revoked, and checked by contracts. |
+| **Proposal** | A pacto-gov governance action (spend, role change, etc.) voted on by squad members. |
+| **WalletBar** | The in-thread wallet UI for sending tokens, requesting payments, and announcing transactions. |
+
+## Architecture
+
+| Term | Definition |
+|------|------------|
+| **Tauri v2** | Desktop app framework: Svelte frontend in a webview, Rust backend. |
+| **invoke** | Frontend -> backend typed RPC via `tauri-apps/api/core`. |
+| **emit** | Backend -> frontend event pushed through `AppHandle::emit`. |
+| **per-account SQLite** | Two databases per npub: `vector.db` (app data) and `vector-mls.db` (engine state). |
+| **read-plane** | Frontend viem read-only chain access: balances, contract observation, receipt polling. |
+| **Rust send** | WalletBar and governance writes are signed and broadcast from the Rust backend using Alloy. |
+| **Greenfield** | Repo posture: no public alpha shipped yet; prefer breaking, minimal paths over compatibility shims. |
+
+## See also
+
+- `docs/README.md` — authoritative docs index
+- `STRATEGY.md` — why these concepts matter and what the product is trying to achieve
+- `docs/ARCHITECTURE.md` — how the concepts connect in code

--- a/README.md
+++ b/README.md
@@ -21,9 +21,37 @@ Squad / Network
 - Modular Governance Platform to accommodate various models of democracy and decision making
 - Safe Wallet for collective management of financial resources
 
-## Architecture Diagram
+## Architecture
 
-[WIP]
+Pacto is a Tauri v2 desktop app: a SvelteKit/Svelte frontend backed by a Rust backend. Encrypted messaging runs over Nostr; governance and treasury operations run over EVM chains via an embedded wallet derived from the same seed.
+
+```mermaid
+flowchart TB
+    subgraph Frontend["SvelteKit SPA (src/)"]
+        A[pages + components]
+        B[stores / lib modules]
+    end
+    subgraph Tauri["Tauri v2 webview bridge"]
+        C[invoke + event emit]
+    end
+    subgraph Backend["Rust backend (src-tauri/src/)"]
+        D[Nostr / MLS]
+        E[SQLite per npub]
+        F[EVM wallet + contracts]
+        G[crypto / media]
+    end
+    subgraph Network["External network"]
+        H[Nostr relays]
+        I[EVM / Aztec RPCs]
+    end
+    A <--> |invoke / listen| C
+    C <--> |commands + events| D
+    D <--> |read/write| E
+    D <--> |kinds 1059, 443, 444| H
+    F <--> |send / read| I
+```
+
+For a deeper walkthrough, see **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)**.
 
 ## Fork
 

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,54 @@
+---
+name: Pacto
+last_updated: 2026-07-07
+---
+
+# Pacto Strategy
+
+## Target problem
+
+Existing community platforms force a trade-off between privacy and enforceability: chat apps can be private but cannot govern shared money or votes, while blockchains can enforce scarcity but expose identities and activity. Grassroots groups, DAOs, and private collectives need both — private coordination and enforceable collective decisions — without surrendering personal data to a platform or passing KYC.
+
+## Our approach
+
+Pacto fuses encrypted, metadata-protected messaging with embedded wallets and on-chain governance in a single desktop app. The core bet is that the same cryptographic identity (a Nostr keypair) can power both private conversations and scarce collective actions, so users can organize, vote, and manage treasuries without trusting a centralized service or exposing their activity.
+
+## Who it's for
+
+**Primary:** DAO and collective organizers — people running funded, membership-driven groups who need private discussion, transparent governance, and shared treasury control in one place.
+
+**Also served:** Privacy-conscious community members who want Discord-style group chat without exposing their social graph or wallet activity to platforms or surveillance.
+
+## Key metrics
+
+- **7-day squad message volume per active member** — measures whether private group coordination is becoming a habit; measured in per-account `events` table.
+- **Squad invite accept rate** — share of invites that result in a member joining and sending at least one message; signals onboarding simplicity and trust.
+- **Treasury proposals created and executed** — number of on-chain governance actions initiated and completed through the app; signals enforceable collective action.
+- **Commons follows → squad joins** — users who discover a squad via the public Commons feed and join; signals cross-community discovery.
+- **30-day retention of new squad members** — members who were active in week 1 and remain active in week 4; the ultimate health check for replacing siloed chat tools.
+
+## Tracks
+
+### Embedded treasury & governance
+
+Make collective money and decisions as easy as group chat: Safe wallets, pacto-gov proposals, and role enforcement all anchored to the same MLS squad identity.
+
+_Why it serves the approach:_ enforceability is the reason to accept the complexity of on-chain logic; without it, Pacto is just another chat app.
+
+### Private group coordination
+
+MLS-backed Squads and Networks with Discord-style channels, but metadata-protected and decentralized over Nostr.
+
+_Why it serves the approach:_ privacy is the non-negotiable differentiator; if coordination leaks identity or relationships, the product fails its core promise.
+
+### Discovery & Commons
+
+Help users find and join aligned squads through the Commons feed, public broadcasts, and a searchable squad catalog, while keeping membership itself private.
+
+_Why it serves the approach:_ network effects come from discovery; a private tool that nobody can find is self-limiting.
+
+### Trust & safety
+
+Protect users from spam, abuse, and key loss without introducing central gatekeepers: invite gating, evictions, roster verification, and clear alpha-grade risk messaging.
+
+_Why it serves the approach:_ privacy-first infrastructure is easily abused; trust mechanisms must exist but stay under community control, not platform control.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,181 @@
+# Pacto Architecture
+
+High-level view of how Pacto is built and how data flows. For deeper per-area docs, see `docs/README.md`.
+
+## System overview
+
+Pacto is a **Tauri v2 desktop application**: a **SvelteKit/Svelte** frontend (static SPA) backed by a **Rust** crate.
+
+```mermaid
+flowchart TB
+    subgraph Frontend["SvelteKit SPA (src/)"]
+        A[pages + components]
+        B[stores / lib modules]
+    end
+    subgraph Tauri["Tauri v2 webview bridge"]
+        C[invoke + event emit]
+    end
+    subgraph Backend["Rust backend (src-tauri/src/)"]
+        D[Nostr / MLS]
+        E[SQLite per npub]
+        F[EVM wallet + contracts]
+        G[crypto / media]
+    end
+    subgraph Network["External network"]
+        H[Nostr relays]
+        I[EVM / Aztec RPCs]
+    end
+    A <-->|invoke / listen| C
+    C <-->|commands + events| D
+    D <-->|read/write| E
+    D <-->|kinds 1059, 443, 444| H
+    F <-->|send / read| I
+```
+
+## Layer responsibilities
+
+| Layer | Role | Key files |
+|-------|------|-----------|
+| **Frontend** | UI, state, user flows | `src/routes/+page.svelte`, `src/stores/`, `src/components/`, `src/lib/` |
+| **Tauri bridge** | Typed frontend ⇄ backend RPC and events | `src-tauri/src/lib.rs` (`invoke_handler` + `AppHandle::emit`) |
+| **Rust backend** | Crypto, Nostr/MLS relay logic, EVM signing, SQLite, media | `src-tauri/src/lib.rs`, `src-tauri/src/{nostr,mls,chat,message,rumor,db,account_manager,evm}/` |
+| **Network** | Nostr relays for messaging; RPCs for chain reads and sends | `TRUSTED_RELAYS`, `ALCHEMY_RPC_KEY`, user RPC prefs |
+
+## Data flows
+
+### 1. Messaging
+
+Nostr events flow in two parallel paths depending on the conversation type.
+
+```mermaid
+flowchart LR
+    subgraph Receiving["Receiving"]
+        A[Nostr GiftWrap / MLSGroupMessage] --> B{kind?}
+        B -->|1059| C[unwrap]
+        B -->|444| D[verify membership]
+        C -->|443 inner| E[MLS engine: process_welcome]
+        C -->|other| F[process_rumor: DM]
+        D --> G[MLS engine: process_message]
+        G --> H[process_rumor: MlsGroup]
+        F --> I[(SQLite events)]
+        H --> I
+        I --> J[emit message_new / mls_message_new]
+    end
+    subgraph Sending["Sending"]
+        K[invoke message] --> L{receiver}
+        L -->|npub| M[GiftWrap to peer]
+        L -->|group_id| N[send_mls_message kind 444]
+        M --> O[Nostr client publish]
+        N --> O
+    end
+```
+
+- **DMs** use NIP-59 Gift Wraps (kind 1059). The inner rumor uses kinds 14 (text), 15 (file), 7 (reaction), 30078 (typing), etc.
+- **MLS groups** use kind 444 on the wire; kind 443 welcomes arrive inside a Gift Wrap.
+- Both DM and MLS decrypted messages land in the same unified `Chat` / `Message` model in SQLite.
+
+### 2. EVM wallet
+
+Key derivation, reads, and writes are split across layers on purpose.
+
+```mermaid
+flowchart LR
+    subgraph Wallet["Wallet flow"]
+        A[mnemonic seed] --> B[bip44_v1]
+        B --> C[phrase-derived squad key]
+        B --> D[phrase-derived advanced key]
+        E[imported key] --> D
+        C -->|WalletBar / treasury / gov| F[Rust send: Alloy sign + broadcast]
+        D -->|Settings → Advanced| G[evm_send_advanced_contract_call]
+        H[viem read-plane] --> I[frontend balances, Safe reads, receipt polling]
+        F --> J[SQLite squad_infra]
+    end
+```
+
+- The same BIP-39 seed derives both Nostr keys and EVM addresses.
+- **Reads** (balances, contract observation, receipt polling) happen in the frontend via viem.
+- **Writes** (WalletBar sends, treasury deployments, governance transactions) happen in Rust using Alloy.
+- Signer purpose matters: `squad` keys can act on treasury and governance; `advanced` keys are restricted to the Advanced panel.
+
+### 3. Storage
+
+Each account is isolated under its npub.
+
+```mermaid
+flowchart TB
+    subgraph Account["Tauri app_data_dir/<npub>/"]
+        A[vector.db]
+        B[mls/vector-mls.db]
+        C[attachments / media]
+    end
+    subgraph Engine["MDK engine"]
+        D[group state, epochs, keypackages]
+    end
+    subgraph AppData["App data"]
+        E[events, chats, profiles, squad_infra, settings]
+    end
+    B --> D
+    A --> E
+```
+
+- `vector-mls.db` is owned by the MDK engine; do not edit it by hand.
+- `vector.db` holds chat metadata, Nostr-shaped events, profiles, and squad infrastructure pointers.
+- Frontend state is npub-scoped via `localStorage` keys built with `persistenceKey(prefix)`.
+
+## Key directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | Svelte frontend source |
+| `src/routes/` | Single-page static SPA shell |
+| `src/stores/` | Svelte writable/derived stores |
+| `src/lib/` | Typed Tauri wrappers, domain logic, helpers |
+| `src/components/` | Svelte UI components grouped by domain |
+| `src-tauri/src/` | Rust backend crate |
+| `src-tauri/src/evm/` | Wallet, key derivation, RPC, contract bindings, governance |
+| `src-tauri/src/evm/contracts/` | `alloy::sol!` bindings for pacto-gov, sponsor, Safe, ERC-20, Hats |
+| `static/` | Static assets (twemoji SVGs, etc.) |
+| `docs/` | Authoritative tracked architecture and operational docs |
+| `.cursor/rules/` | Editor-enforced project policies |
+| `.github/workflows/` | Cross-platform release CI |
+
+## Frontend architecture
+
+- `src/routes/+page.svelte` is the single root container.
+- `src/lib/app/tauri-subscriptions.ts` is the central bridge for backend → UI events (`message_new`, `mls_message_new`, `profile_update`, etc.).
+- `src/stores/app.ts` is a thin re-export barrel; new code should import directly from domain slices (`auth.ts`, `dm.ts`, `squads.ts`, `mls-chat.ts`, etc.).
+- State persistence is npub-scoped. Use `persistenceKey(prefix)` from `src/stores/persistence-context.ts` for any new `localStorage` key.
+
+## Backend architecture
+
+- `src-tauri/src/main.rs` calls `pacto_lib::run()`.
+- `src-tauri/src/lib.rs` bootstraps the Tauri app, holds global mutable state (`STATE`, `NOSTR_CLIENT`, `MNEMONIC_SEED`, `TAURI_APP`, `ENCRYPTION_KEY`), and registers the `invoke_handler`.
+- `src-tauri/src/rumor.rs` is the protocol-agnostic processor: DM and MLS decrypted events produce `RumorProcessingResult` and are stored as flat `StoredEvent` rows.
+- `src-tauri/src/db.rs` implements most `#[tauri::command]` database entry points using pooled connections from `account_manager.rs`.
+- `src-tauri/src/evm/mod.rs` is the EVM module root; `evm/rpc/` handles providers, signers, and structured errors.
+
+## Security and trust model
+
+- No KYC; identity is cryptographic (npub / nsec).
+- The EVM private key is decrypted in Rust only for approved operations and is not exposed to the frontend.
+- Message content and secrets are stored encrypted; profile and indexing metadata is plaintext for search and performance.
+- There is no independent third-party security audit yet. See `docs/audits/README.md`.
+
+## Cross-cutting conventions
+
+- **Greenfield:** no public alpha shipped yet; prefer breaking, minimal paths over legacy compatibility shims.
+- **Brief inline comments:** explain behavior, not architecture. Point to `docs/` for details.
+- **No tracker IDs, spec section markers, or checklist breadcrumbs in source.**
+- **Public protocol addresses** belong in tracked JSON (`src/lib/evm/pacto-protocol-addresses.json`), not `.env`.
+
+## Related docs
+
+- `docs/README.md` — docs index
+- `docs/messaging/OVERVIEW.md` — DM vs MLS in detail
+- `docs/nostr/ARCHITECTURE.md` — Nostr kinds and subscriptions
+- `docs/mls/ARCHITECTURE.md` — MLS engine and storage split
+- `docs/communities/DESIGN.md` — squads, networks, and stable ids
+- `docs/wallet/README.md` — embedded EVM wallet
+- `docs/storage-layout/SQLITE_AND_FILES.md` — per-account SQLite layout
+- `STRATEGY.md` — product strategy
+- `CONCEPTS.md` — shared vocabulary

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ These docs are **tracked in git** and are the primary map for humans and coding 
 
 | Area | Purpose |
 |------|---------|
+| **[ARCHITECTURE.md](./ARCHITECTURE.md)** | High-level system architecture, data flows, and layer responsibilities |
 | **[messaging/OVERVIEW.md](./messaging/OVERVIEW.md)** | DM vs MLS: kinds, events, Tauri commands, frontend hooks |
 | **[nostr/](./nostr/)** | Relay-facing behavior, rumor pipeline, module index |
 | **[mls/](./mls/)** | MDK engine, storage split, invites, eviction & leave |
@@ -15,6 +16,11 @@ These docs are **tracked in git** and are the primary map for humans and coding 
 | **[wallet/](./wallet/)** | Embedded EVM wallet, RPC, chain config, DM payment messages ([on-chain read pattern](./wallet/ONCHAIN_READ_PATTERN.md)) |
 | **[audits/](./audits/)** | **Alpha / no external audit:** wallet and key-handling assurance posture ([README](./audits/README.md)) |
 | **[build/](./build/)** | Desktop build guides (macOS, Windows, Ubuntu) |
+
+**Cross-cutting:**
+- Strategy: **[`STRATEGY.md`](../STRATEGY.md)** — what the product is, who it serves, and where the team is investing
+- Vocabulary: **[`CONCEPTS.md`](../CONCEPTS.md)** — shared terms for humans and coding agents
+- System architecture: **[`ARCHITECTURE.md`](./ARCHITECTURE.md)** — high-level data flows and layer responsibilities
 
 **Design specs (`ai-docs/`):** governance + dashboard architecture notes live under [`../ai-docs/gov-core/`](../ai-docs/gov-core/README.md) (ModPol channels, single-group MLS virtual defaults, governance library). Shell refactor history: [`../ai-docs/shell-refactor/SHELL_MODULARIZATION_PLAN.md`](../ai-docs/shell-refactor/SHELL_MODULARIZATION_PLAN.md). **UX speed backlog:** [`../ai-docs/speed/UX_SPEED_AND_DATA_READ_PLAN.md`](../ai-docs/speed/UX_SPEED_AND_DATA_READ_PLAN.md).
 

--- a/docs/pacto_ecosystem_research.md
+++ b/docs/pacto_ecosystem_research.md
@@ -1,0 +1,310 @@
+# Pacto Ecosystem Research Summary
+
+**Organization:** `covenant-gov`  
+**Main Repository:** `pacto-app`  
+**Date Researched:** June 2026
+
+---
+
+## Table of Contents
+
+1. [The Five Ws](#the-five-ws)
+2. [Parent Organization: covenant-gov](#parent-organization-covenant-gov)
+3. [Subprojects](#subprojects)
+4. [Integration Architecture](#integration-architecture)
+5. [The "Why" — Plain English](#the-why--plain-english)
+6. [Key Integration Points](#key-integration-points)
+7. [Glossary of Terms](#glossary-of-terms)
+
+---
+
+## The Five Ws
+
+### What
+Pacto is a **private, censorship-resistant, and governable community organizing platform** that requires no KYC (identity verification). It combines encrypted messaging with blockchain governance and financial tools. It features end-to-end encrypted DMs, private community "Squads" (like Discord/Slack channels), and "Networks" (inter-organizational hubs). It also includes a modular governance platform, a Safe Wallet for collective treasury management, and embedded wallets that work out of the box.
+
+### Who
+Pacto is built by **covenant-gov** (the GitHub organization). It is a fork of **Vector**, a private decentralized messenger built on Nostr. The project targets communities, activists, DAOs, or any group that needs private, uncensorable coordination with on-chain governance and financial capabilities.
+
+### Where
+The project lives on GitHub at `github.com/covenant-gov/pacto-app`. It is a cross-platform application (Ubuntu, macOS, Windows) that runs as a decentralized client. Communications route through **Nostr relays** (a distributed, censorship-resistant network), while governance and financial operations execute on **EVM-compatible blockchains** (Ethereum) or the **Aztec** privacy-focused blockchain.
+
+### When
+Pacto is an active work-in-progress project (the architecture diagram is still marked as WIP). It exists in the current wave of post-2023 privacy and decentralization tooling, riding the momentum of Nostr's growth and the demand for zero-knowledge privacy in blockchain applications.
+
+### Why
+The core motivation is to solve a critical gap: existing platforms force a trade-off between **privacy** and **enforceability**. Social platforms offer privacy but no governance; blockchains offer governance but poor privacy. Pacto aims to give communities **both** — private, metadata-protected communications (via Nostr's NIP-17, NIP-44, NIP-59 standards and MLS group encryption) combined with **governable, scarce resources** (votes, treasury) enforced by zero-knowledge proofs on Ethereum or Aztec. The goal is to let people organize, vote, and manage money collectively without exposing their identities or activities to censorship or surveillance.
+
+---
+
+## Parent Organization: covenant-gov
+
+**Covenant Gov** is a GitHub organization building **Pacto** — a privacy-first, censorship-resistant, governable community platform. The org operates under a pseudonymous, no-KYC philosophy and uses a "pirate ship" governance metaphor ("Nave Pirata") for its on-chain squad mechanics. The entire stack is designed to let communities **communicate privately** (via Nostr), **govern transparently** (via EVM/Hats Protocol), and **act privately** (via Aztec ZK) — all from a single identity root.
+
+The organization has **9 public repositories** spanning Rust, Solidity, Noir, and JavaScript.
+
+---
+
+## Subprojects
+
+### 1. `pacto-app` (Rust / Tauri)
+The flagship desktop application. Cross-platform (Windows, macOS, Ubuntu).
+
+**Features:**
+- E2EE Direct Messaging (NIP-17 private DMs)
+- **Squads** — private Discord/Slack-style community hubs with text channels
+- **Networks** — inter-organizational coordination (Squad of Squads)
+- **Embedded wallets** — zero-configuration crypto wallets
+- **Web3-integrated dashboard widgets**
+
+**Fork origin:** Forks the **Vector** messenger (Rust backend) for MLS group messaging.
+
+---
+
+### 2. `pacto-gov` — "Nave Pirata" (Solidity)
+The core governance engine. Every squad deploys a "pirate ship" — a Hats Protocol-governed mesh of role contracts sitting atop a **Gnosis Safe**. Deployed via a one-shot factory.
+
+**Key contracts:**
+| Contract | Purpose |
+|----------|---------|
+| `Quartermaster` | Timelocked crew roster; admin of the crew hat |
+| `MutinyModule` | 51% crew vote can replace the captain (or captain can resign) |
+| `TreasuryAuthority` | Two-body democracy: crew vote + captain approval required for spending |
+| `SquadAdmin` | Captain-gated on-chain executor roles for app integrations |
+| `NavePirataFactory` | Atomic one-shot deployment of Safe + hat tree + clones + wiring |
+| `AssetRescuer` | Permissionless sweep of accidentally-received assets |
+
+**Why it matters:** On-chain governance prevents "organizational amnesia" if relays go down. Roles, votes, and permissions are tamper-evident and replayable.
+
+---
+
+### 3. `pacto-squad-sponsor` (Solidity)
+A squad-scoped **gas fee sponsorship** contract. It lets squads subsidize transaction costs for their members, removing the "you need ETH to do anything" barrier for new users.
+
+---
+
+### 4. `pacto-aztec` (Noir / TypeScript)
+Aztec privacy layer. Uses **Noir** (ZK language) to build private smart contracts for:
+- **Private voting** — votes cast without revealing choice or voter
+- **Private payments** — shielded transfers
+- **Private-to-public execution** — private functions enqueue public state updates
+
+Includes automated benchmarking (Gates, DA Gas, L2 Gas) via GitHub Actions and auto-generated TypeScript bindings.
+
+---
+
+### 5. `nostr-k-derivs` (Rust)
+**Key derivation bridge.** Derives Ethereum and Aztec cryptographic keys directly from a **Nostr nsec/npub**. This creates a single identity root:
+- One Nostr keypair → multiple chain addresses
+- No separate wallet setup required
+- Enables the "embedded wallet" experience in `pacto-app`
+
+---
+
+### 6. `delegated-security-manager` (Solidity)
+A **multi-layer on-chain security module** leveraging **Hats Protocol**. It provides:
+- Role-based access control delegation
+- Formal verification readiness (Halmos / Medusa tooling)
+- Defense-in-depth for squad treasuries and admin functions
+
+---
+
+### 7. `contributor-pool` (Solidity) — ARCHIVED
+A staking pool for coordinating open-source development. Contributors stake tokens, complete work, and receive **autonomous payouts** based on on-chain coordination. It served as the project's own dogfooding mechanism for decentralized labor.
+
+---
+
+### 8. `pacto-download` (JavaScript)
+Simple distribution website for the desktop app. Handles installer delivery and release management.
+
+---
+
+### 9. `.github`
+Organization templates, contribution norms, issue/PR templates, and community participation guidelines.
+
+---
+
+## Integration Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  LAYER 1: USER INTERFACE                                        │
+│  ┌──────────────┐  ┌──────────────┐                             │
+│  │ pacto-app    │  │ pacto-      │                             │
+│  │ (Rust/Tauri) │  │ download    │                             │
+│  │ E2EE DMs,    │  │ (JS)        │                             │
+│  │ Squads,      │  │ Distribution│                             │
+│  │ Networks     │  │ Portal      │                             │
+│  └──────┬───────┘  └─────────────┘                             │
+└─────────┼─────────────────────────────────────────────────────────┘
+          │ E2EE msgs
+┌─────────▼─────────────────────────────────────────────────────────┐
+│  LAYER 2: COMMUNICATION (NOSTR)                                   │
+│  ┌────────────────────────────┐  ┌──────────────────────────┐   │
+│  │ Nostr Protocol             │  │ nostr-k-derivs           │   │
+│  │ Decentralized relays       │  │ Key Derivation (Rust)    │   │
+│  │ NIP-17, NIP-44, NIP-59    │  │ Nostr → Eth/Aztec keys   │   │
+│  │ MLS Group Messaging        │  │ Single identity root     │   │
+│  └────────────┬───────────────┘  └────────────┬─────────────┘   │
+└───────────────┼─────────────────────────────────┼─────────────────┘
+                │                                 │ derived keys
+┌───────────────▼─────────────────────────────────▼─────────────────┐
+│  LAYER 3: GOVERNANCE & SECURITY (EVM)                             │
+│  ┌────────────────────────────┐  ┌──────────────────────────┐   │
+│  │ pacto-gov (Nave Pirata)    │  │ delegated-security-    │   │
+│  │ Hats + Safe Governance     │  │ manager                  │   │
+│  │ Quartermaster, Mutiny,   │  │ Multi-layer security     │   │
+│  │ Treasury, SquadAdmin       │  │ Role-based access        │   │
+│  └────────────┬───────────────┘  └────────────┬─────────────┘   │
+│               │ governance calls              │ secures         │
+│  ┌────────────▼──────────────┐  ┌────────────▼─────────────┐   │
+│  │ pacto-squad-sponsor     │  │                            │   │
+│  │ Gas fee sponsorship     │  │                            │   │
+│  └─────────────────────────┘  └────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+                │
+┌───────────────▼─────────────────────────────────────────────────┐
+│  LAYER 4: PRIVACY (AZTEC)                                       │
+│  ┌────────────────────────────┐                                 │
+│  │ pacto-aztec                │                                 │
+│  │ Noir ZK Contracts          │                                 │
+│  │ Private voting & payments  │                                 │
+│  │ Zero-knowledge proofs      │                                 │
+│  └────────────────────────────┘                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│  LAYER 5: INFRASTRUCTURE & FUNDING                              │
+│  ┌────────────────────────────┐  ┌──────────────────────────┐   │
+│  │ contributor-pool           │  │ .github                  │   │
+│  │ (ARCHIVED) Staking pool    │  │ Org templates & norms    │   │
+│  │ Autonomous payouts         │  │ Community guidelines     │   │
+│  └────────────────────────────┘  └──────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## The "Why" — Plain English
+
+### The Problem
+
+Today, if you want to organize a group of people online, you have two bad choices:
+
+**Choice A: Use a normal app** (Discord, WhatsApp, Signal)
+- **Pros:** Easy to chat privately.
+- **Cons:** The company running it can ban you, read your metadata (who talked to whom, when), or hand data over to governments. There is no built-in way to vote on spending group money or manage a shared treasury. If the app kicks you out, your community history and relationships vanish.
+
+**Choice B: Use a blockchain DAO** (Snapshot, Aragon, etc.)
+- **Pros:** No one can censor your votes or steal the treasury (rules are enforced by code).
+- **Cons:** Every vote and transaction is **public** on a blockchain. Everyone can see who voted, how much money you have, and who sent what to whom. Also, setting up wallets and paying "gas fees" is a nightmare for normal people.
+
+**Pacto wants both:** the privacy of Signal *and* the enforceable rules of a DAO, without the complexity.
+
+### Why Two Different Networks?
+
+Pacto splits the job between two specialized networks because **chat and money need different things**.
+
+**1. Nostr (the chat layer)**
+Think of Nostr as a global network of public bulletin boards (relays). Anyone can run a bulletin board. Your app posts encrypted messages to them, and your friends' apps read those messages off any board they want.
+- **Why this matters:** If one bulletin board bans you, you just use another. There is no central company to shut down. It is "censorship-resistant."
+- **Privacy:** They use modern encryption so only the intended recipient can read the message. They also wrap messages in extra layers so even the bulletin board operator cannot see who is talking to whom.
+- **Why not blockchain for chat?** Putting every "lol" and "brb" on a blockchain would be absurdly expensive and slow. Nostr is basically free.
+
+**2. Ethereum / Aztec (the money & rules layer)**
+When you need to do things that *must* be enforced — like "only spend treasury money if 5 people vote yes" — you need a blockchain. This is where scarcity matters: there is only one vote, or one dollar, and the network makes sure no one cheats.
+- **Ethereum (EVM):** The standard blockchain where they run the governance rules (who is in the group, who can spend, how to replace a leader).
+- **Aztec:** A special privacy blockchain. Instead of everyone seeing "Alice voted YES and sent Bob $50," Aztec uses math tricks (zero-knowledge proofs) to prove the vote or payment is valid **without revealing who did it or how much it was**. Think of it as a sealed envelope that the blockchain can open just enough to verify it is real, then close again.
+
+### Why the Pirate Ship Governance?
+
+Pacto calls their governance system **"Nave Pirata"** (Pirate Ship). It is a metaphor for a small, tight-knit crew with clear rules.
+
+**The Captain and the Crew**
+- **Captain:** The leader. Can be a person, a group of people, or even another smart contract.
+- **Crew:** The regular members.
+
+**Two-Body Democracy**
+Most groups fail because one person has all the power (dictatorship) or because nothing can get done without a 3-hour vote (paralysis). Pacto splits the power:
+- **The crew** must vote to approve spending money or major decisions.
+- **The captain** must also sign off.
+- **Why both?** The crew cannot drain the treasury without the captain noticing. The captain cannot steal the treasury because the crew must approve withdrawals. It is a check-and-balance system.
+
+**Mutiny**
+If the captain goes rogue, disappears, or starts acting against the group, the crew can vote to replace them (51% vote). This is called "mutiny." It is a formal, on-chain process so there is no ambiguity or "he said, she said" about who is in charge.
+
+**Why put roles on-chain?**
+If your group rules live only inside a chat app, and that chat server goes down or bans you, you lose your entire organizational memory. By putting "who is the captain," "who is in the crew," and "what did we vote on" on a blockchain, that record is permanent and verifiable by anyone, even if you have to move to a new chat server tomorrow.
+
+### Why One Key for Everything?
+
+Normally, you have a login for Discord, a separate wallet for Ethereum, another for Bitcoin, etc. Pacto asks: **what if one key could unlock everything?**
+
+You create one Nostr keypair (like a username/password, but cryptographic). From that single key, Pacto mathematically derives your Ethereum wallet address and your Aztec wallet address.
+- **Why?** You do not need to manage multiple passwords, seed phrases, or browser extensions. One identity, many networks. This is how they achieve "embedded wallets that require no configuration."
+
+### Why No KYC?
+
+KYC = "Know Your Customer," the process where apps force you to upload a passport or driver's license. Pacto deliberately avoids this.
+- **Why?** The target users are activists, labor unions, cooperatives, and dissidents in places where revealing your identity can get you arrested, fired, or harassed. By design, you can join a squad, vote, and manage money without ever proving your real-world name.
+
+### The Big Picture Analogy
+
+Imagine you and your friends want to start a pirate co-op to fund a community garden.
+
+- **Chat:** You use Pacto to talk privately in your "Squad" (like a group chat). No company can read it. No government can subpoena a central server because there is not one.
+- **Money:** You all chip in money to a shared safe (the **Safe Wallet**). The safe has a rule: two people must agree to open it.
+- **Governance:** You elect a captain to manage day-to-day stuff, but the crew can vote to fire the captain if they mess up. All of this is recorded on a public ledger so there is no argument later about what was agreed.
+- **Privacy:** When you vote on whether to buy a new shovel, you use the privacy layer so the local newspaper cannot see who voted or how much money is in the safe.
+- **Gas:** The squad sponsor pays the network fees so your aunt who knows nothing about crypto can still vote without buying "ETH" first.
+
+---
+
+## Key Integration Points
+
+1. **Nostr Identity Root:** All crypto keys derive from a single Nostr nsec.
+2. **Vector Fork:** MLS group messaging comes from Vector (Rust backend).
+3. **Hats Protocol:** Role-based authority across all governance.
+4. **Safe Wallet:** Squad treasuries via the Zodiac module pattern.
+5. **Two-Body Democracy:** Crew vote + Captain approval required for spending.
+6. **ZK Privacy:** Aztec Noir for private votes and payments.
+7. **Embedded Wallets:** Zero-config onboarding.
+8. **No KYC:** Pseudonymous by design.
+9. **NavePirataFactory:** Atomic one-shot squad deployment.
+10. **Hats-Pointer Upgradeability:** Role upgrades via `transferHat`, not proxy migrations.
+
+---
+
+## Glossary of Terms
+
+| Term | Meaning |
+|------|---------|
+| **Nostr** | A decentralized, censorship-resistant social protocol. Like Twitter but with no central server. |
+| **NIP** | Nostr Improvement Proposal. A standard for how Nostr clients and relays behave. |
+| **EVM** | Ethereum Virtual Machine. The runtime environment for Ethereum smart contracts. |
+| **Aztec** | A privacy-focused blockchain that uses zero-knowledge proofs to hide transaction details. |
+| **ZK / Zero-Knowledge** | A cryptographic method to prove something is true without revealing the underlying data. |
+| **Noir** | A programming language for writing zero-knowledge circuits (used on Aztec). |
+| **Hats Protocol** | An on-chain role management system. "Hats" are roles that can be worn, transferred, and revoked. |
+| **Safe (Gnosis Safe)** | A multi-signature smart contract wallet. Requires multiple people to approve a transaction. |
+| **Zodiac** | A modular framework for adding governance modules to Safe wallets. |
+| **KYC** | "Know Your Customer." The process of verifying real-world identity (passport, ID, etc.). |
+| **Gas** | The fee paid to process a transaction on a blockchain. |
+| **MLS** | Messaging Layer Security. A modern standard for end-to-end encrypted group chats. |
+| **E2EE** | End-to-End Encryption. Only the sender and recipient can read the message. |
+| **DAO** | Decentralized Autonomous Organization. A group governed by code instead of traditional hierarchy. |
+| **Mutiny** | In Pacto, the formal process where the crew votes to replace the captain. |
+| **Two-Body Democracy** | Pacto's governance model where both the crew and the captain must approve actions. |
+| **Treasury** | The shared pool of money controlled by a squad. |
+| **Squad** | A private community hub inside Pacto (like a Discord server). |
+| **Network** | A group of squads that can coordinate across organizational boundaries. |
+| **Relay** | A server in the Nostr network that stores and forwards messages. |
+| **nsec / npub** | Nostr secret key (private) and public key. Like a username/password pair but cryptographic. |
+| **Tauri** | A framework for building desktop apps using web frontends and Rust backends. |
+| **Foundry** | A toolkit for developing and testing Ethereum smart contracts. |
+| **Bulloak** | A tool for generating Solidity tests from behavior trees. |
+| **Halmos / Medusa** | Tools for formal verification and fuzz testing of smart contracts. |
+
+---
+
+*Document generated from research of github.com/covenant-gov and its subprojects.*


### PR DESCRIPTION
## Summary

Adds the foundational documentation needed for both human contributors and coding agents to understand Pacto's purpose, vocabulary, and system architecture.

## What's included

- `STRATEGY.md` — product strategy: target problem, approach, primary persona, key metrics, and investment tracks.
- `CONCEPTS.md` — shared vocabulary covering identity, messaging, governance/finance, and architecture terms.
- `docs/ARCHITECTURE.md` — detailed architecture doc with Mermaid diagrams for system overview, messaging flow, EVM wallet flow, and storage layout.
- `README.md` — replaces the `[WIP]` architecture diagram section with an architecture overview + diagram and a link to `docs/ARCHITECTURE.md`.
- `docs/README.md` — adds `ARCHITECTURE.md` to the docs index and cross-links `STRATEGY.md`, `CONCEPTS.md`, and `ARCHITECTURE.md`.

## Verification

- All internal links checked (`STRATEGY.md`, `CONCEPTS.md`, `docs/ARCHITECTURE.md`, README, docs/README).
- Mermaid diagrams render in GitHub markdown preview.
- No source code changes; docs-only PR.
