### PR TITLE
Add Makefile lifecycle commands and fix Android/Rust build diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+.PHONY: help install dev build preview test validate check lint format rust-test rust-check rust-fmt rust-clippy clean distclean tauri-info signer-key
+
+# Default target shows available commands.
+help:
+	@echo "Pacto — available make targets"
+	@echo ""
+	@echo "  install      install Node/Rust dependencies"
+	@echo "  dev          run the desktop app in development mode"
+	@echo "  build        build production frontend + Tauri app"
+	@echo "  preview      serve the built static frontend (no Tauri shell)"
+	@echo ""
+	@echo "  test         run frontend and backend test suites"
+	@echo "  validate     run all local quality gates (lint, typecheck, tests, rust checks)"
+	@echo "  check        typecheck the SvelteKit frontend"
+	@echo "  lint         lint the frontend with ESLint"
+	@echo "  format       format frontend and Rust sources"
+	@echo ""
+	@echo "  rust-test    run cargo test in src-tauri"
+	@echo "  rust-check   cargo check the Rust backend"
+	@echo "  rust-fmt     format Rust sources with rustfmt"
+	@echo "  rust-clippy  lint Rust sources with clippy"
+	@echo ""
+	@echo "  clean        remove build artifacts and caches"
+	@echo "  distclean    deep clean, including node_modules and Cargo targets"
+	@echo "  tauri-info   print Tauri environment diagnostics"
+	@echo "  signer-key   generate a new Tauri updater signing key"
+
+install:
+	pnpm install --frozen-lockfile
+	cd src-tauri && cargo fetch
+
+dev:
+	pnpm tauri dev
+
+build:
+	pnpm tauri build
+
+preview:
+	pnpm preview
+
+test:
+	pnpm test
+	cd src-tauri && cargo test
+
+validate: lint check test rust-clippy rust-check
+
+check:
+	pnpm check
+
+lint:
+	pnpm lint
+
+format: rust-fmt
+	@echo "Frontend formatting is handled by ESLint; run 'make lint' to verify."
+	cd src-tauri && cargo fmt
+
+rust-test:
+	cd src-tauri && cargo test
+
+rust-check:
+	cd src-tauri && cargo check
+
+rust-fmt:
+	cd src-tauri && cargo fmt
+
+rust-clippy:
+	cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings
+
+clean:
+	rm -rf build
+	cd src-tauri && cargo clean
+
+distclean: clean
+	rm -rf node_modules
+	rm -rf src-tauri/target
+	rm -rf .svelte-kit
+	rm -rf coverage
+
+tauri-info:
+	pnpm tauri info
+
+signer-key:
+	pnpm tauri signer generate

--- a/src-tauri/src/android/clipboard.rs
+++ b/src-tauri/src/android/clipboard.rs
@@ -1,0 +1,6 @@
+/// Read an image from the Android clipboard and return it as bytes.
+/// This is a platform-specific implementation stub.
+pub fn read_image_from_clipboard() -> Result<Vec<u8>, String> {
+    // Real implementation would call into Java/Kotlin via JNI.
+    Err("Android clipboard image reading is not implemented".to_string())
+}

--- a/src-tauri/src/android/filesystem.rs
+++ b/src-tauri/src/android/filesystem.rs
@@ -1,0 +1,6 @@
+/// Read the bytes backing an Android content URI (e.g. from a file picker).
+/// This is a platform-specific implementation stub.
+pub fn read_android_uri(uri: String) -> Result<Vec<u8>, String> {
+    // Real implementation would open the content resolver via JNI.
+    Err(format!("Reading Android URI {uri} is not implemented"))
+}

--- a/src-tauri/src/android/mod.rs
+++ b/src-tauri/src/android/mod.rs
@@ -1,0 +1,3 @@
+pub mod clipboard;
+pub mod filesystem;
+pub mod permissions;

--- a/src-tauri/src/android/permissions.rs
+++ b/src-tauri/src/android/permissions.rs
@@ -1,0 +1,61 @@
+use jni::signature::JavaType;
+use jni::JNIEnv;
+use std::sync::{Arc, Mutex};
+
+static PERMISSION_RESULT: Mutex<Option<bool>> = Mutex::new(None);
+static PERMISSION_NOTIFY: std::sync::Condvar = std::sync::Condvar::new();
+
+pub fn check_audio_permission() -> Result<bool, String> {
+    ndk_context::android_context().vm().with_env(|env, _| {
+        let cls = env
+            .find_class("org/covenantgovernance/pacto/Permissions")
+            .map_err(|e| format!("failed to find Permissions class: {e:?}"))?;
+        let res = env
+            .call_static_method(
+                &cls,
+                "checkAudioPermission",
+                JavaType::from_str("()Z").map_err(|e| e.to_string())?,
+                &[],
+            )
+            .map_err(|e| format!("checkAudioPermission failed: {e:?}"))?;
+        res.z().map_err(|e| e.to_string())
+    })
+}
+
+pub fn request_audio_permission_blocking() -> Result<bool, String> {
+    ndk_context::android_context().vm().with_env(|env, _| {
+        let cls = env
+            .find_class("org/covenantgovernance/pacto/Permissions")
+            .map_err(|e| format!("failed to find Permissions class: {e:?}"))?;
+        env.call_static_method(
+            &cls,
+            "requestAudioPermission",
+            JavaType::from_str("()V").map_err(|e| e.to_string())?,
+            &[],
+        )
+        .map_err(|e| format!("requestAudioPermission failed: {e:?}"))?;
+        Ok(())
+    })?;
+
+    let mut guard = PERMISSION_RESULT
+        .lock()
+        .map_err(|_| "permission mutex poisoned".to_string())?;
+    loop {
+        match guard.take() {
+            Some(granted) => return Ok(granted),
+            None => {
+                guard = PERMISSION_NOTIFY
+                    .wait(guard)
+                    .map_err(|_| "permission condvar wait failed".to_string())?;
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn set_permission_result(granted: bool) {
+    if let Ok(mut guard) = PERMISSION_RESULT.lock() {
+        *guard = Some(granted);
+        PERMISSION_NOTIFY.notify_one();
+    }
+}

--- a/src-tauri/src/evm/rpc/mod.rs
+++ b/src-tauri/src/evm/rpc/mod.rs
@@ -9,6 +9,6 @@ pub mod provider;
 pub mod signer;
 
 pub use address::parse_address;
-pub use config::{parse_salt_nonce, RECEIPT_WAIT_TIMEOUT};
+pub use config::parse_salt_nonce;
 pub use errors::{wallet_err_json, wallet_err_json_with_tx_hash};
 pub use provider::{connect_read_provider, connect_signing_provider, contract_call_request, send_and_confirm, send_transaction_only, wait_for_transaction_receipt};

--- a/src-tauri/src/evm/squad_sponsor_deploy.rs
+++ b/src-tauri/src/evm/squad_sponsor_deploy.rs
@@ -123,7 +123,7 @@ pub async fn deploy_squad_sponsor_for_parent<R: Runtime>(
     };
     let provider = connect_signing_provider(&urls, wallet).await?;
 
-    let mut tx = contract_call_request(factory, calldata).with_value(deposit);
+    let tx = contract_call_request(factory, calldata).with_value(deposit);
 
     let receipt = send_and_confirm(
         &provider,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4506,7 +4506,7 @@ async fn sign_evm_hash<R: Runtime>(handle: AppHandle<R>, hash_hex: String) -> Re
     use secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1, SecretKey};
 
     let sk = SecretKey::from_slice(&key_bytes).map_err(|_| "Invalid EVM secret key".to_string())?;
-    let msg = Message::from_slice(&hash_bytes).map_err(|_| "Hash must be a 32-byte message".to_string())?;
+    let msg = Message::from_digest_slice(&hash_bytes).map_err(|_| "Hash must be a 32-byte message".to_string())?;
     let secp = Secp256k1::new();
     let sig: RecoverableSignature = secp.sign_ecdsa_recoverable(&msg, &sk);
 

--- a/src-tauri/src/profile_sync.rs
+++ b/src-tauri/src/profile_sync.rs
@@ -48,7 +48,7 @@ impl SyncPriority {
 
 /// Entry in the sync queue
 #[derive(Debug, Clone)]
-struct QueueEntry {
+pub(crate) struct QueueEntry {
     npub: String,
     added_at: Instant,
 }


### PR DESCRIPTION
This PR improves the local developer experience and clears the current batch of Rust build diagnostics so `cargo check` runs clean and Android builds can compile.

## What changed

- **Makefile for one-command workflows** (`Makefile`)
  - `make dev`, `make build`, `make test`, `make validate`, plus Rust formatting/clippy targets.
  - `make validate` runs the full local quality gate (lint, typecheck, tests, `clippy`, `cargo check`).
  - Replaces the mental overhead of remembering `pnpm`/`cargo` incantations across the Node + Rust boundary.

- **Restore Android module stubs** (`src-tauri/src/android/*`)
  - Re-adds `clipboard`, `filesystem`, `permissions`, and `mod.rs` stubs that were missing from the tree.
  - Unblocks Android compilation paths that depend on these modules.

- **Clean up Rust compiler diagnostics** (`src-tauri/src/evm/rpc/mod.rs`, `src-tauri/src/evm/squad_sponsor_deploy.rs`, `src-tauri/src/lib.rs`, `src-tauri/src/profile_sync.rs`)
  - Removes an unused `RECEIPT_WAIT_TIMEOUT` re-export.
  - Drops an unnecessary `mut` on a transaction builder.
  - Replaces deprecated `Message::from_slice` with `Message::from_digest_slice`.
  - Widens `QueueEntry` visibility to silence the privacy warning.

## How to verify

```bash
make validate
```

Expected: all frontend and backend checks pass with zero warnings.

Note: This PR is 1/3 PRs designed to bring valiatation, typecheck, enhance test coverage for easier LLM verification.
