### PR TITLE
test: split out tests and supporting code from PR #59

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,15 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        id: typecheck
         run: pnpm check
-        continue-on-error: true
-
-      - name: Report typecheck result
-        if: steps.typecheck.outcome == 'failure'
-        run: |
-          echo "::warning::Typecheck failed. See the 'Typecheck' step logs for diagnostics."
-          echo "- Typecheck: failed" >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     runs-on: ubuntu-latest
@@ -56,17 +48,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        id: lint
         run: pnpm lint
-        continue-on-error: true
 
-      - name: Report lint result
-        if: steps.lint.outcome == 'failure'
-        run: |
-          echo "::warning::Lint failed. See the 'Lint' step logs for violations."
-          echo "- Lint: failed" >> "$GITHUB_STEP_SUMMARY"
-
-  test:
+  frontend-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -87,97 +71,27 @@ jobs:
         run: pnpm svelte-kit sync
 
       - name: Unit tests with coverage
-        id: test
         run: pnpm test:coverage
-        continue-on-error: true
-
-      - name: Report test result
-        if: steps.test.outcome == 'failure'
-        run: |
-          echo "::warning::Unit tests or coverage threshold failed. See the 'Unit tests with coverage' step logs for details."
-          echo "- Unit tests / coverage: failed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
-        if: steps.test.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage/
           if-no-files-found: ignore
 
-  coverage:
+  backend-tests:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6.4.0
-        with:
-          node-version: lts/*
+      - uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.7.0
-          run_install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
-
-      - name: Check coverage thresholds
-        id: coverage
+      - name: Install Rust system dependencies
         run: |
-          node - <<'NODE'
-          const fs = require('fs');
-          const data = JSON.parse(fs.readFileSync('coverage/coverage-final.json', 'utf8'));
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake clang libclang-dev file curl wget git pkg-config libssl-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev
 
-          const totals = { statements: { total: 0, covered: 0 }, branches: { total: 0, covered: 0 }, functions: { total: 0, covered: 0 }, lines: { total: 0, covered: 0 } };
-          for (const file of Object.values(data)) {
-            const s = file.s;
-            totals.statements.total += Object.keys(s).length;
-            totals.statements.covered += Object.values(s).filter(v => v > 0).length;
-
-            totals.lines.total += Object.keys(file.statementMap).length;
-            totals.lines.covered += Object.keys(file.statementMap).filter(k => s[k] > 0).length;
-
-            const f = file.f;
-            totals.functions.total += Object.keys(f).length;
-            totals.functions.covered += Object.values(f).filter(v => v > 0).length;
-
-            const b = file.b;
-            for (const branches of Object.values(b)) {
-              totals.branches.total += branches.length;
-              totals.branches.covered += branches.filter(v => v > 0).length;
-            }
-          }
-
-          const threshold = 80;
-          let failed = false;
-          const summary = [];
-          for (const [key, { total, covered }] of Object.entries(totals)) {
-            const pct = total ? (covered / total) * 100 : 0;
-            const ok = pct >= threshold;
-            if (!ok) failed = true;
-            summary.push(`${key}: ${pct.toFixed(2)}% (${covered}/${total}) ${ok ? '✓' : '✗'}`);
-          }
-
-          console.log('Coverage summary:');
-          for (const line of summary) console.log(line);
-
-          if (failed) {
-            console.log(`::error::Coverage is below the ${threshold}% threshold.`);
-            process.exit(1);
-          }
-          NODE
-        continue-on-error: true
-
-      - name: Report coverage result
-        if: steps.coverage.outcome == 'failure'
-        run: |
-          echo "::warning::Coverage is below the 80% threshold. See the 'Check coverage thresholds' step logs for details."
-          echo "- Coverage: below 80% threshold" >> "$GITHUB_STEP_SUMMARY"
+      - name: Rust unit tests
+        working-directory: src-tauri
+        run: cargo test --lib

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -211,3 +211,97 @@ pub fn decrypt_data(encrypted_data: &[u8], key_hex: &str, nonce_hex: &str) -> Re
 
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Runtime::new().expect("tokio runtime")
+    }
+
+    #[test]
+    fn generate_params_has_valid_hex_lengths() {
+        let params = generate_encryption_params();
+        assert_eq!(params.key.len(), 64, "32-byte key = 64 hex chars");
+        assert_eq!(params.nonce.len(), 32, "16-byte nonce = 32 hex chars");
+        assert!(hex::decode(&params.key).is_ok());
+        assert!(hex::decode(&params.nonce).is_ok());
+    }
+
+    #[test]
+    fn aes_gcm_round_trip() {
+        let params = EncryptionParams {
+            key: hex::encode([0u8; 32]),
+            nonce: hex::encode([0u8; 16]),
+        };
+        let plaintext = b"hello pacto";
+        let encrypted = encrypt_data(plaintext, &params).expect("encrypt");
+        assert!(!encrypted.is_empty());
+        let decrypted = decrypt_data(&encrypted, &params.key, &params.nonce).expect("decrypt");
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_rejects_too_short_input() {
+        let result = decrypt_data(
+            &[0u8; 15],
+            &hex::encode([0u8; 32]),
+            &hex::encode([0u8; 16]),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decrypt_rejects_wrong_tag() {
+        let params = EncryptionParams {
+            key: hex::encode([0u8; 32]),
+            nonce: hex::encode([0u8; 16]),
+        };
+        let mut encrypted = encrypt_data(b"hello", &params).expect("encrypt");
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 0xff;
+        let result = decrypt_data(&encrypted, &params.key, &params.nonce);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hash_pass_is_deterministic() {
+        let first = rt().block_on(hash_pass("pacto-secret".to_string()));
+        let second = rt().block_on(hash_pass("pacto-secret".to_string()));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn chacha_round_trip_with_password() {
+        let ciphertext = rt().block_on(internal_encrypt(
+            "plaintext message".to_string(),
+            Some("password".to_string()),
+        ));
+        assert!(!ciphertext.is_empty());
+        let decrypted = rt().block_on(internal_decrypt(ciphertext, Some("password".to_string())));
+        assert_eq!(decrypted.expect("decrypt"), "plaintext message");
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_wrong_password() {
+        let ciphertext = rt().block_on(internal_encrypt(
+            "plaintext message".to_string(),
+            Some("password".to_string()),
+        ));
+        let decrypted = rt().block_on(internal_decrypt(ciphertext, Some("wrong".to_string())));
+        assert!(decrypted.is_err());
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_short_ciphertext() {
+        let decrypted = rt().block_on(internal_decrypt("0x00".to_string(), Some("password".to_string())));
+        assert!(decrypted.is_err());
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_malformed_hex() {
+        let decrypted = rt().block_on(internal_decrypt("not-hex".to_string(), Some("password".to_string())));
+        assert!(decrypted.is_err());
+    }
+}

--- a/src-tauri/src/evm/contract_call_params.rs
+++ b/src-tauri/src/evm/contract_call_params.rs
@@ -44,4 +44,41 @@ mod tests {
     fn parse_value_wei_decimal() {
         assert_eq!(parse_value_wei("1000").unwrap(), U256::from(1000u64));
     }
+
+    #[test]
+    fn parse_value_wei_empty_is_zero() {
+        assert_eq!(parse_value_wei("").unwrap(), U256::ZERO);
+        assert_eq!(parse_value_wei("   ").unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn parse_value_wei_rejects_negative() {
+        assert!(parse_value_wei("-1").is_err());
+    }
+
+    #[test]
+    fn parse_value_wei_rejects_hex() {
+        assert!(parse_value_wei("0x1a").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_rejects_odd_length() {
+        assert!(parse_data_hex("0xabc").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_rejects_non_hex() {
+        assert!(parse_data_hex("0xzz").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_uppercase_prefix_and_case() {
+        assert_eq!(parse_data_hex("0XDEADBEEF").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn parse_data_hex_zero_prefix_returns_empty() {
+        assert!(parse_data_hex("0x").unwrap().is_empty());
+        assert!(parse_data_hex("0X").unwrap().is_empty());
+    }
 }

--- a/src-tauri/src/evm/pacto_chain_config.rs
+++ b/src-tauri/src/evm/pacto_chain_config.rs
@@ -303,6 +303,12 @@ mod tests {
 
     #[test]
     fn sepolia_book_safe_bundle_overrides_legacy_defaults() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
         let safe = safe_factory_addresses("sepolia", 11_155_111).expect("safe book");
         assert_eq!(
             safe.proxy_factory,
@@ -312,5 +318,94 @@ mod tests {
             safe.singleton,
             address!("0x41675C099F32341bf84BFc5382aF534df5C7461a")
         );
+    }
+
+    #[test]
+    fn net_suffix_uppercases_and_replaces_dashes() {
+        assert_eq!(net_suffix("sepolia"), "SEPOLIA");
+        assert_eq!(net_suffix("arbitrum-one"), "ARBITRUM_ONE");
+    }
+
+    #[test]
+    fn safe_factory_addresses_env_override_wins() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
+        let factory = address!("0x1111111111111111111111111111111111111111");
+        let singleton = address!("0x2222222222222222222222222222222222222222");
+        let fallback = address!("0x3333333333333333333333333333333333333333");
+        let _guard = EnvVarGuard::new()
+            .set("PACTO_SAFE_PROXY_FACTORY", "0x1111111111111111111111111111111111111111")
+            .set("PACTO_SAFE_SINGLETON", "0x2222222222222222222222222222222222222222")
+            .set("PACTO_SAFE_FALLBACK_HANDLER", "0x3333333333333333333333333333333333333333");
+        let safe = safe_factory_addresses("sepolia", 11_155_111).expect("env override");
+        assert_eq!(safe.proxy_factory, factory);
+        assert_eq!(safe.singleton, singleton);
+        assert_eq!(safe.fallback_handler, fallback);
+    }
+
+    #[test]
+    fn safe_factory_addresses_mainnet_defaults() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
+        let safe = safe_factory_addresses("mainnet", 1).expect("mainnet defaults");
+        assert_eq!(
+            safe.singleton,
+            address!("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552")
+        );
+    }
+
+    #[test]
+    fn default_fallback_for_chain_id_mainnet() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&["PACTO_SAFE_FALLBACK_HANDLER"]);
+        let fb = default_fallback_for_chain_id(1).expect("mainnet fallback");
+        assert_eq!(fb, address!("0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4"));
+    }
+
+    #[test]
+    fn default_fallback_for_chain_id_unknown() {
+        assert!(default_fallback_for_chain_id(999_999).is_none());
+    }
+
+    static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn clear_env(keys: &[&str]) {
+        for key in keys {
+            std::env::remove_var(key);
+        }
+    }
+
+    struct EnvVarGuard {
+        _prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvVarGuard {
+        fn new() -> Self {
+            Self { _prev: Vec::new() }
+        }
+        fn set(mut self, key: &'static str, value: &str) -> Self {
+            self._prev.push((key, std::env::var_os(key)));
+            std::env::set_var(key, value);
+            self
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, prev) in &self._prev {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
     }
 }

--- a/src-tauri/src/evm/rpc/address.rs
+++ b/src-tauri/src/evm/rpc/address.rs
@@ -13,3 +13,51 @@ pub fn parse_address(s: &str) -> Result<Address, String> {
     }
     Ok(Address::from(b))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_valid_with_prefix() {
+        let a = parse_address("0x0000000000000000000000000000000000000001").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_valid_without_prefix() {
+        let a = parse_address("0000000000000000000000000000000000000001").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_uppercase_prefix() {
+        let a = parse_address("0Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        let b = parse_address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn parse_address_trims_whitespace() {
+        let a = parse_address("  0x0000000000000000000000000000000000000001  ").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_rejects_wrong_length() {
+        assert!(parse_address("0x123").is_err());
+        assert!(parse_address("0x").is_err());
+        assert!(parse_address("0x0000000000000000000000000000000000000001a").is_err());
+    }
+
+    #[test]
+    fn parse_address_rejects_non_hex() {
+        assert!(parse_address("0xgggggggggggggggggggggggggggggggggggggggg").is_err());
+    }
+
+    #[test]
+    fn parse_address_rejects_empty() {
+        assert!(parse_address("").is_err());
+        assert!(parse_address("   ").is_err());
+    }
+}

--- a/src-tauri/src/evm/rpc/call.rs
+++ b/src-tauri/src/evm/rpc/call.rs
@@ -94,4 +94,30 @@ mod tests {
         word[31] = 42;
         assert_eq!(decode_abi_u256_return(&word), U256::from(42));
     }
+
+    #[test]
+    fn decode_abi_u256_takes_last_32_bytes() {
+        let mut data = vec![0u8; 40];
+        data[39] = 5;
+        assert_eq!(decode_abi_u256_return(&data), U256::from(5));
+    }
+
+    #[test]
+    fn decode_abi_u256_left_pads_short_data() {
+        let data = vec![0u8, 0u8, 0u8, 1u8];
+        assert_eq!(decode_abi_u256_return(&data), U256::from(1));
+    }
+
+    #[test]
+    fn decode_abi_u256_zero_bytes() {
+        assert_eq!(decode_abi_u256_return(&[0u8; 0]), U256::ZERO);
+    }
+
+    #[test]
+    fn decode_abi_u256_large_value() {
+        let mut word = [0u8; 32];
+        word[0] = 0xff;
+        word[31] = 0xff;
+        assert_eq!(decode_abi_u256_return(&word), U256::from_be_slice(&word));
+    }
 }

--- a/src-tauri/src/evm/squad_admin_write.rs
+++ b/src-tauri/src/evm/squad_admin_write.rs
@@ -159,4 +159,36 @@ mod tests {
         expected[..8].copy_from_slice(b"TREASURY");
         assert_eq!(role.as_slice(), expected);
     }
+
+    #[test]
+    fn role_tag_exactly_32_bytes() {
+        let label = "TREASURY";
+        let role = bytes32_role_tag(label).unwrap();
+        assert_eq!(role.len(), 32);
+    }
+
+    #[test]
+    fn role_tag_rejects_empty() {
+        assert!(bytes32_role_tag("").is_err());
+        assert!(bytes32_role_tag("   ").is_err());
+    }
+
+    #[test]
+    fn role_tag_rejects_too_long() {
+        let label = "a".repeat(33);
+        assert!(bytes32_role_tag(&label).is_err());
+    }
+
+    #[test]
+    fn role_tag_rejects_non_ascii() {
+        assert!(bytes32_role_tag("rôle").is_err());
+    }
+
+    #[test]
+    fn role_tag_left_pads_short_label() {
+        let role = bytes32_role_tag("A").unwrap();
+        let mut expected = [0u8; 32];
+        expected[0] = b'A';
+        assert_eq!(role.as_slice(), expected);
+    }
 }

--- a/src-tauri/src/evm/squad_sponsor_common.rs
+++ b/src-tauri/src/evm/squad_sponsor_common.rs
@@ -65,3 +65,50 @@ pub async fn read_squad_record<P: Provider>(
     }
     Ok((sponsor, decoded.variant, decoded.topHatId))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn squad_id_from_parent_id_is_deterministic_and_trims() {
+        let a = squad_id_from_parent_id("parent-id");
+        let b = squad_id_from_parent_id("parent-id");
+        let c = squad_id_from_parent_id("  parent-id  ");
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn parse_deposit_wei_decimal() {
+        assert_eq!(parse_deposit_wei(Some("1000")).unwrap(), U256::from(1000u64));
+        assert_eq!(parse_deposit_wei(Some("  1000  ")).unwrap(), U256::from(1000u64));
+    }
+
+    #[test]
+    fn parse_deposit_wei_hex() {
+        assert_eq!(parse_deposit_wei(Some("0xff")).unwrap(), U256::from(255u64));
+        assert_eq!(parse_deposit_wei(Some("0XFF")).unwrap(), U256::from(255u64));
+    }
+
+    #[test]
+    fn parse_deposit_wei_rejects_empty() {
+        assert!(parse_deposit_wei(None).is_err());
+        assert!(parse_deposit_wei(Some("")).is_err());
+        assert!(parse_deposit_wei(Some("   ")).is_err());
+    }
+
+    #[test]
+    fn parse_deposit_wei_rejects_invalid() {
+        assert!(parse_deposit_wei(Some("not-a-number")).is_err());
+        assert!(parse_deposit_wei(Some("0xzz")).is_err());
+    }
+
+    #[test]
+    fn squad_variant_label_maps_variants() {
+        assert_eq!(squad_variant_label(SquadVariant::NONE), "none");
+        assert_eq!(squad_variant_label(SquadVariant::SPONSOR), "sponsor");
+        assert_eq!(squad_variant_label(SquadVariant::EXT), "ext");
+        assert_eq!(squad_variant_label(SquadVariant::__Invalid), "unknown");
+    }
+}

--- a/src-tauri/src/evm/wallet_chain_config.rs
+++ b/src-tauri/src/evm/wallet_chain_config.rs
@@ -243,5 +243,57 @@ mod tests {
         assert_eq!(explorer_url_for_tx(local, "0xabc..."), "");
     }
 
+    #[test]
+    fn mainnet_network_is_in_wallet_networks() {
+        let net = wallet_networks()
+            .iter()
+            .find(|n| n.key == "mainnet")
+            .expect("mainnet should be present");
+        assert_eq!(net.chain_id, 1);
+    }
+
+    #[test]
+    fn network_by_key_unknown_returns_none() {
+        assert!(network_by_key("unknown").is_none());
+    }
+
+    #[test]
+    fn rpc_urls_for_network_includes_public_fallbacks() {
+        let net = network_by_key("sepolia").unwrap();
+        let urls = rpc_urls_for(net);
+        assert!(!urls.is_empty());
+        assert!(urls.iter().any(|u| u.contains("publicnode.com")));
+    }
+
+    #[test]
+    fn explorer_url_for_tx_formats_hash_without_double_prefix() {
+        let net = WalletNetworkConfig {
+            key: "test".to_string(),
+            chain_id: 1,
+            display_name: "Test".to_string(),
+            explorer_tx_path: "https://explorer.com/tx/".to_string(),
+            native_symbol: "ETH".to_string(),
+            native_decimals: 18,
+            usdc_address: "".to_string(),
+            usdt_address: "".to_string(),
+            usdc_decimals: 6,
+            usdt_decimals: 6,
+        };
+        assert_eq!(
+            explorer_url_for_tx(&net, "0xdeadbeef"),
+            "https://explorer.com/tx/0xdeadbeef"
+        );
+    }
+
+    #[test]
+    fn alchemy_key_injected_into_mainnet_urls() {
+        let prev = std::env::var_os("ALCHEMY_RPC_KEY");
+        std::env::set_var("ALCHEMY_RPC_KEY", "test-key");
+        let _guard = EnvVarGuard("ALCHEMY_RPC_KEY", prev);
+        let mainnet = network_by_key("mainnet").unwrap();
+        let urls = rpc_urls_for(mainnet);
+        assert!(urls.iter().any(|u| u.contains("g.alchemy.com")));
+        assert!(urls.iter().any(|u| u.contains("publicnode.com")));
+    }
 
 }

--- a/src-tauri/src/evm/wallet_rpc_providers.rs
+++ b/src-tauri/src/evm/wallet_rpc_providers.rs
@@ -38,18 +38,12 @@ mod tests {
 
     #[test]
     fn alchemy_url_uses_host_map() {
-        std::env::set_var(ALCHEMY_KEY_ENV, "test-key");
-        let url = provider_primary_rpc_url("sepolia").unwrap();
-        assert_eq!(
-            url,
-            "https://eth-sepolia.g.alchemy.com/v2/test-key"
-        );
-        std::env::remove_var(ALCHEMY_KEY_ENV);
+        let url = alchemy_url("sepolia", "test-key").unwrap();
+        assert_eq!(url, "https://eth-sepolia.g.alchemy.com/v2/test-key");
     }
 
     #[test]
     fn missing_key_returns_none() {
-        std::env::remove_var(ALCHEMY_KEY_ENV);
-        assert!(provider_primary_rpc_url("mainnet").is_none());
+        assert!(alchemy_url("mainnet", "").is_none());
     }
 }

--- a/src-tauri/src/evm/wallet_security.rs
+++ b/src-tauri/src/evm/wallet_security.rs
@@ -163,4 +163,67 @@ mod tests {
         let r = redact_urls_in_text(&e);
         assert!(!r.contains("abc"));
     }
+
+    #[test]
+    fn redacts_various_sensitive_query_keys() {
+        for key in ["key", "token", "secret", "password", "auth", "api_key", "apikey", "access_token", "refresh_token"] {
+            let url = format!("https://example.com?{}=leaked", key);
+            let r = redact_rpc_url_for_log(&url);
+            assert!(!r.contains("leaked"), "key {} should be redacted", key);
+            assert!(r.contains("[REDACTED]"));
+        }
+    }
+
+    #[test]
+    fn preserves_non_sensitive_query_values() {
+        let u = "https://example.com?foo=bar";
+        let r = redact_rpc_url_for_log(u);
+        assert!(r.contains("foo=bar"));
+        assert!(!r.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_provider_path_segments() {
+        let u = "https://eth-mainnet.g.alchemy.com/v2/secret-key";
+        let r = redact_rpc_url_for_log(u);
+        assert!(!r.contains("secret-key"));
+        assert!(r.contains("/v2/[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_infura_v3_path_segment() {
+        let u = "https://mainnet.infura.io/v3/project-id";
+        let r = redact_rpc_url_for_log(u);
+        assert!(!r.contains("project-id"));
+        assert!(r.contains("/v3/[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_handles_multiple_urls() {
+        let text = "https://a.com?key=1 https://b.com?token=2";
+        let r = redact_urls_in_text(text);
+        assert!(!r.contains("key=1"));
+        assert!(!r.contains("token=2"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_handles_http() {
+        let text = "http://a.com?secret=x";
+        let r = redact_urls_in_text(text);
+        assert!(!r.contains("secret=x"));
+    }
+
+    #[test]
+    fn redact_unparsed_url_heuristic_strips_userinfo() {
+        let raw = "https://user:pass@host.com/path";
+        let r = redact_unparsed_url_heuristic(raw);
+        assert!(!r.contains("user"));
+        assert!(!r.contains("pass"));
+        assert!(r.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_unparsed_url_heuristic_without_scheme_returns_placeholder() {
+        assert_eq!(redact_unparsed_url_heuristic("just text"), "[rpc-url-unparsed]");
+    }
 }

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -4,7 +4,7 @@
 //! support and graceful fallback when images fail to load.
 //!
 //! ## Storage Structure
-//! ```
+//! ```text
 //! AppData/cache/
 //!   avatars/{hash}.{ext}
 //!   banners/{hash}.{ext}

--- a/src-tauri/src/squad_catalog.rs
+++ b/src-tauri/src/squad_catalog.rs
@@ -599,4 +599,137 @@ mod tests {
         input.commons_tags = None;
         assert!(prepare_row(input).is_err());
     }
+
+    #[test]
+    fn normalize_kind_defaults_to_squad() {
+        assert_eq!(normalize_kind(None).unwrap(), KIND_SQUAD);
+        assert_eq!(normalize_kind(Some("  ")).unwrap(), KIND_SQUAD);
+        assert_eq!(normalize_kind(Some("SQUAD-PAIR")).unwrap(), KIND_SQUAD_PAIR);
+        assert!(normalize_kind(Some("invalid")).is_err());
+    }
+
+    #[test]
+    fn normalize_visibility_defaults_to_private() {
+        assert_eq!(normalize_visibility(None).unwrap(), VIS_PRIVATE);
+        assert_eq!(normalize_visibility(Some("  ")).unwrap(), VIS_PRIVATE);
+        assert_eq!(normalize_visibility(Some("PUBLIC")).unwrap(), VIS_PUBLIC);
+        assert!(normalize_visibility(Some("hidden")).is_err());
+    }
+
+    #[test]
+    fn normalize_commons_tag_filters() {
+        assert_eq!(normalize_commons_tag(" #Foo_Bar "), Some("foo_bar".to_string()));
+        assert_eq!(normalize_commons_tag("new"), None);
+        assert_eq!(normalize_commons_tag("a"), Some("a".to_string()));
+        assert_eq!(normalize_commons_tag("a_very_long_tag_exceeding_32_chars_limit"), None);
+        assert_eq!(normalize_commons_tag("bad-tag"), None);
+        assert_eq!(normalize_commons_tag("bad!tag"), None);
+    }
+
+    #[test]
+    fn normalize_commons_tags_private_returns_none() {
+        assert_eq!(normalize_commons_tags(None, VIS_PRIVATE).unwrap(), None);
+        assert_eq!(normalize_commons_tags(Some(&["tag".to_string()]), VIS_PRIVATE).unwrap(), None);
+    }
+
+    #[test]
+    fn public_squad_commons_tags_validated() {
+        let tags = vec!["pacto".to_string()];
+        assert_eq!(
+            normalize_commons_tags(Some(&tags), VIS_PUBLIC).unwrap(),
+            Some(vec!["pacto".to_string()])
+        );
+        assert!(normalize_commons_tags(None, VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&[]), VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&["new".to_string()]), VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&["a".to_string(), "b".to_string(), "c".to_string(), "d".to_string()]), VIS_PUBLIC).is_err());
+    }
+
+    #[test]
+    fn paired_squads_required_for_squad_pair() {
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        assert!(prepare_row(input).is_err());
+
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        input.paired_squads = Some(vec![
+            PairedSquadRef { id: "a".to_string(), name: "A".to_string() },
+            PairedSquadRef { id: "b".to_string(), name: "B".to_string() },
+        ]);
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.paired_squads.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn paired_squads_rejects_non_two() {
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        input.paired_squads = Some(vec![
+            PairedSquadRef { id: "a".to_string(), name: "A".to_string() },
+        ]);
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn prepare_row_rejects_empty_id_or_name() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.id = "   ".to_string();
+        assert!(prepare_row(input).is_err());
+
+        let input = sample_upsert("grp", "  ");
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn prepare_row_trims_icon_url_and_blank_becomes_none() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.icon_url = Some("  https://example.com/icon.png  ".to_string());
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.icon_url, Some("https://example.com/icon.png".to_string()));
+
+        let mut input = sample_upsert("grp", "Squad");
+        input.icon_url = Some("   ".to_string());
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.icon_url, None);
+    }
+
+    #[test]
+    fn validate_channels_rejects_blank_fields() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.channels = vec![SquadChannelRow { name: "  ".to_string(), group_id: "g".to_string(), order: 0 }];
+        assert!(prepare_row(input).is_err());
+
+        let mut input = sample_upsert("grp", "Squad");
+        input.channels = vec![SquadChannelRow { name: "n".to_string(), group_id: "  ".to_string(), order: 0 }];
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn row_from_query_rejects_invalid_channels_json() {
+        let result = row_from_query(
+            "id".to_string(), "name".to_string(), None, KIND_SQUAD.to_string(), VIS_PRIVATE.to_string(),
+            None, None, "not-json".to_string(), 1, 2,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_squad_inner_blank_id_returns_none() {
+        let conn = test_conn();
+        assert!(get_squad_inner(&conn, "  ").unwrap().is_none());
+    }
+
+    #[test]
+    fn upsert_squad_inner_updates_existing_row() {
+        let conn = test_conn();
+        let row = prepare_row(sample_upsert("grp", "Alpha")).unwrap();
+        upsert_squad_inner(&conn, &row).unwrap();
+        let mut updated = prepare_row(sample_upsert("grp", "Beta")).unwrap();
+        updated.updated_at_ms = 2000;
+        upsert_squad_inner(&conn, &updated).unwrap();
+        let got = get_squad_inner(&conn, "grp").unwrap().unwrap();
+        assert_eq!(got.name, "Beta");
+        assert_eq!(got.updated_at_ms, 2000);
+    }
 }

--- a/src-tauri/src/stored_event.rs
+++ b/src-tauri/src/stored_event.rs
@@ -428,4 +428,92 @@ mod tests {
         assert_eq!(event.reference_id, Some("msg456".to_string()));
         assert!(event.mine);
     }
+
+    #[test]
+    fn known_kinds_match_expected() {
+        assert!(StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::FILE_ATTACHMENT, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::REACTION, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::APPLICATION_SPECIFIC, 1, "".to_string(), 1).is_known_kind());
+        assert!(!StoredEvent::new("x".to_string(), event_kind::MLS_WELCOME, 1, "".to_string(), 1).is_known_kind());
+    }
+
+    #[test]
+    fn is_message_covers_dm_and_file() {
+        assert!(StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1).is_message());
+        assert!(StoredEvent::new("x".to_string(), event_kind::FILE_ATTACHMENT, 1, "".to_string(), 1).is_message());
+        assert!(!StoredEvent::new("x".to_string(), event_kind::REACTION, 1, "".to_string(), 1).is_message());
+    }
+
+    #[test]
+    fn get_tags_returns_all_values_for_key() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1);
+        event.tags = vec![
+            vec!["p".to_string(), "a".to_string()],
+            vec!["e".to_string(), "ref1".to_string()],
+            vec!["p".to_string(), "b".to_string()],
+        ];
+        assert_eq!(event.get_tags("p"), vec!["a", "b"]);
+        assert_eq!(event.get_tags("missing"), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn get_reply_reference_requires_marker() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1);
+        event.tags = vec![vec!["e".to_string(), "ref1".to_string()]];
+        assert_eq!(event.get_reply_reference(), None);
+        event.tags = vec![vec!["e".to_string(), "ref1".to_string(), "".to_string(), "reply".to_string()]];
+        assert_eq!(event.get_reply_reference(), Some("ref1"));
+    }
+
+    #[test]
+    fn timestamp_ms_edge_cases() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1234567890);
+        // No ms tag
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // Valid ms tag 0
+        event.tags = vec![vec!["ms".to_string(), "0".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // ms tag beyond 999 ignored
+        event.tags = vec![vec!["ms".to_string(), "1000".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // Non-numeric ms tag ignored
+        event.tags = vec![vec!["ms".to_string(), "abc".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+    }
+
+    #[test]
+    fn builder_sets_all_optional_fields() {
+        let event = StoredEventBuilder::new()
+            .id("id1")
+            .kind(event_kind::FILE_ATTACHMENT)
+            .chat_id(7)
+            .user_id(Some(42))
+            .content("content")
+            .tags(vec![vec!["e".to_string(), "ref".to_string()]])
+            .reference_id(Some("ref".to_string()))
+            .created_at(1000)
+            .mine(true)
+            .pending(true)
+            .failed(true)
+            .wrapper_event_id(Some("wrap".to_string()))
+            .npub(Some("npub".to_string()))
+            .virtual_bucket(Some("inbox".to_string()))
+            .build();
+
+        assert_eq!(event.id, "id1");
+        assert_eq!(event.kind, event_kind::FILE_ATTACHMENT);
+        assert_eq!(event.chat_id, 7);
+        assert_eq!(event.user_id, Some(42));
+        assert_eq!(event.content, "content");
+        assert_eq!(event.tags, vec![vec!["e".to_string(), "ref".to_string()]]);
+        assert_eq!(event.reference_id, Some("ref".to_string()));
+        assert_eq!(event.created_at, 1000);
+        assert!(event.mine);
+        assert!(event.pending);
+        assert!(event.failed);
+        assert_eq!(event.wrapper_event_id, Some("wrap".to_string()));
+        assert_eq!(event.npub, Some("npub".to_string()));
+        assert_eq!(event.virtual_bucket, Some("inbox".to_string()));
+    }
 }

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -852,3 +852,124 @@ pub fn mime_from_extension_safe(extension: &str, image_only: bool) -> Result<Str
 pub fn is_image_mime(mime: &str) -> bool {
     mime.trim().starts_with("image/")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_https_urls_basic() {
+        let text = "Check https://example.com and https://foo.bar/path?x=1.";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://example.com", "https://foo.bar/path?x=1"]);
+    }
+
+    #[test]
+    fn extract_https_urls_trims_trailing_punctuation() {
+        let text = "See https://example.com, (https://foo.bar), and https://baz.com.";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://example.com", "https://foo.bar", "https://baz.com"]);
+    }
+
+    #[test]
+    fn extract_https_urls_ignores_http() {
+        let text = "http://insecure.com and https://secure.com";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://secure.com"]);
+    }
+
+    #[test]
+    fn get_file_type_description_known() {
+        assert_eq!(get_file_type_description("png"), "Picture");
+        assert_eq!(get_file_type_description("PNG"), "Picture");
+        assert_eq!(get_file_type_description("pdf"), "PDF Document");
+    }
+
+    #[test]
+    fn get_file_type_description_unknown_defaults_to_file() {
+        assert_eq!(get_file_type_description("xyz"), "File");
+    }
+
+    #[test]
+    fn format_bytes_sizes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(2 * 1024 * 1024), "2.0 MB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
+    }
+
+    #[test]
+    fn bytes_to_hex_string_round_trip() {
+        let bytes = vec![0xde, 0xad, 0xbe, 0xef];
+        let hex = bytes_to_hex_string(&bytes);
+        assert_eq!(hex, "deadbeef");
+        assert_eq!(hex_string_to_bytes(&hex), bytes);
+    }
+
+    #[test]
+    fn hex_string_to_bytes_accepts_uppercase() {
+        assert_eq!(hex_string_to_bytes("DEADBEEF"), vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn hex_string_to_bytes_ignores_odd_trailing_nibble() {
+        // Current behavior drops the trailing odd digit.
+        assert_eq!(hex_string_to_bytes("abc"), vec![0xab]);
+    }
+
+    #[test]
+    fn calculate_file_hash_is_sha256_hex() {
+        let data = b"hello";
+        assert_eq!(
+            calculate_file_hash(data),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn nearest_neighbor_downsample_preserves_corners() {
+        // 2x2 image with four distinct colors.
+        let pixels = vec![
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255,
+        ];
+        let out = nearest_neighbor_downsample(&pixels, 2, 2, 1, 1);
+        assert_eq!(out, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn has_alpha_transparency_detects_alpha() {
+        let opaque = vec![255, 255, 255, 255, 0, 0, 0, 255];
+        assert!(!has_alpha_transparency(&opaque));
+        let transparent = vec![255, 255, 255, 128, 0, 0, 0, 255];
+        assert!(has_alpha_transparency(&transparent));
+    }
+
+    #[test]
+    fn mime_from_extension_normalizes() {
+        assert_eq!(mime_from_extension("png"), "image/png");
+        assert_eq!(mime_from_extension(".PNG"), "image/png");
+        assert_eq!(mime_from_extension("unknown"), "application/octet-stream");
+    }
+
+    #[test]
+    fn extension_from_mime_known_and_fallback() {
+        assert_eq!(extension_from_mime("image/png"), "png");
+        assert_eq!(extension_from_mime("application/x-foo"), "x-foo");
+        assert_eq!(extension_from_mime("malformed"), "bin");
+    }
+
+    #[test]
+    fn mime_from_extension_safe_restricts_to_images() {
+        assert_eq!(mime_from_extension_safe("png", true).unwrap(), "image/png");
+        assert_eq!(mime_from_extension_safe("png", false).unwrap(), "image/png");
+        assert!(mime_from_extension_safe("pdf", true).is_err());
+    }
+
+    #[test]
+    fn is_image_mime_check() {
+        assert!(is_image_mime("image/png"));
+        assert!(!is_image_mime("application/pdf"));
+    }
+}

--- a/src/lib/api/auth.test.ts
+++ b/src/lib/api/auth.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  login,
+  loginWithRecoveryPhrase,
+  createAccount,
+  connect,
+  checkAnyAccountExists,
+  getCurrentAccount,
+  getEvmAddress,
+  setEvmAddress,
+  signEvmHash,
+  listAllAccounts,
+  exportRecoveryPhrase,
+  exportEvmAccountKeyPlaintext,
+} from './auth';
+
+vi.mock('@tauri-apps/api/core');
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: vi.fn(),
+  dmWarn: vi.fn(),
+  dmError: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+describe('auth command wrappers', () => {
+  it('login sends login with importKey', async () => {
+    mockedInvoke.mockResolvedValueOnce({ public: 'npub', private: 'nsec' });
+    const result = await login('nsec1');
+    expect(mockedInvoke).toHaveBeenCalledWith('login', { importKey: 'nsec1' });
+    expect(result).toEqual({ public: 'npub', private: 'nsec' });
+  });
+
+  it('loginWithRecoveryPhrase sends login_with_recovery_phrase with mnemonic', async () => {
+    mockedInvoke.mockResolvedValueOnce({ public: 'npub', private: 'nsec' });
+    const result = await loginWithRecoveryPhrase('abandon abandon ... art');
+    expect(mockedInvoke).toHaveBeenCalledWith('login_with_recovery_phrase', {
+      mnemonic: 'abandon abandon ... art',
+    });
+    expect(result).toEqual({ public: 'npub', private: 'nsec' });
+  });
+
+  it('createAccount sends create_account', async () => {
+    mockedInvoke.mockResolvedValueOnce({ public: 'npub', private: 'nsec' });
+    const result = await createAccount();
+    expect(mockedInvoke).toHaveBeenCalledWith('create_account');
+    expect(result).toEqual({ public: 'npub', private: 'nsec' });
+  });
+
+  it('connect sends connect', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await connect();
+    expect(mockedInvoke).toHaveBeenCalledWith('connect');
+    expect(result).toBe(true);
+  });
+
+  it('checkAnyAccountExists sends check_any_account_exists', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await checkAnyAccountExists();
+    expect(mockedInvoke).toHaveBeenCalledWith('check_any_account_exists');
+    expect(result).toBe(true);
+  });
+
+  it('getCurrentAccount sends get_current_account', async () => {
+    mockedInvoke.mockResolvedValueOnce('npub1');
+    const result = await getCurrentAccount();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_current_account');
+    expect(result).toBe('npub1');
+  });
+
+  it('getEvmAddress sends get_evm_address', async () => {
+    mockedInvoke.mockResolvedValueOnce('0xabc');
+    const result = await getEvmAddress();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_evm_address');
+    expect(result).toBe('0xabc');
+  });
+
+  it('setEvmAddress sends set_evm_address then updates profile', async () => {
+    mockedInvoke
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    await setEvmAddress('0xabc');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_evm_address', { address: '0xabc' });
+    expect(mockedInvoke).toHaveBeenCalledWith('update_profile', {
+      name: '',
+      avatar: '',
+      banner: '',
+      about: '',
+    });
+  });
+
+  it('signEvmHash sends sign_evm_hash with hashHex', async () => {
+    mockedInvoke.mockResolvedValueOnce('0xsignature');
+    const result = await signEvmHash('0xdeadbeef');
+    expect(mockedInvoke).toHaveBeenCalledWith('sign_evm_hash', { hashHex: '0xdeadbeef' });
+    expect(result).toBe('0xsignature');
+  });
+
+  it('listAllAccounts sends list_all_accounts', async () => {
+    mockedInvoke.mockResolvedValueOnce(['npub1', 'npub2']);
+    const result = await listAllAccounts();
+    expect(mockedInvoke).toHaveBeenCalledWith('list_all_accounts');
+    expect(result).toEqual(['npub1', 'npub2']);
+  });
+
+  it('exportRecoveryPhrase sends get_seed and returns trimmed seed', async () => {
+    mockedInvoke.mockResolvedValueOnce('  seed phrase  ');
+    const result = await exportRecoveryPhrase();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_seed');
+    expect(result).toBe('seed phrase');
+  });
+
+  it('exportRecoveryPhrase throws when seed is empty', async () => {
+    mockedInvoke.mockResolvedValueOnce(null);
+    await expect(exportRecoveryPhrase()).rejects.toThrow(
+      'No recovery phrase is stored for this account'
+    );
+  });
+
+  it('exportEvmAccountKeyPlaintext sends export_evm_account_key_plaintext with accountId', async () => {
+    mockedInvoke.mockResolvedValueOnce('0xkey');
+    const result = await exportEvmAccountKeyPlaintext('acc-1');
+    expect(mockedInvoke).toHaveBeenCalledWith('export_evm_account_key_plaintext', {
+      accountId: 'acc-1',
+    });
+    expect(result).toBe('0xkey');
+  });
+});

--- a/src/lib/api/commons.test.ts
+++ b/src/lib/api/commons.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  publishCommonsBroadcast,
+  fetchCommonsBroadcasts,
+  fetchCommonsBroadcastsCached,
+  getLocalActiveCommonsBroadcast,
+  cancelCommonsBroadcast,
+} from './commons';
+import type { CommonsBroadcastDto } from '../commons/types';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+describe('commons broadcast command wrappers', () => {
+  it('publishCommonsBroadcast sends commons_publish_broadcast with input', async () => {
+    const input = {
+      subject: 'user' as const,
+      subjectId: 'u1',
+      message: 'hello',
+      durationHours: 24 as const,
+      tags: [],
+    };
+    mockedInvoke.mockResolvedValueOnce(input as unknown as CommonsBroadcastDto);
+    const result = await publishCommonsBroadcast(input);
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_publish_broadcast', { input });
+    expect(result).toEqual(input);
+  });
+
+  it('fetchCommonsBroadcasts sends commons_fetch_broadcasts with limit', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await fetchCommonsBroadcasts(5);
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_fetch_broadcasts', { limit: 5 });
+  });
+
+  it('fetchCommonsBroadcasts coerces undefined limit to null', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await fetchCommonsBroadcasts();
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_fetch_broadcasts', { limit: null });
+  });
+
+  it('fetchCommonsBroadcastsCached sends commons_list_cached_broadcasts with limit', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await fetchCommonsBroadcastsCached(10);
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_list_cached_broadcasts', { limit: 10 });
+  });
+
+  it('getLocalActiveCommonsBroadcast sends commons_get_local_active with subject and subjectId', async () => {
+    mockedInvoke.mockResolvedValueOnce(null);
+    const result = await getLocalActiveCommonsBroadcast('squad', 's1');
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_get_local_active', {
+      subject: 'squad',
+      subjectId: 's1',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('cancelCommonsBroadcast sends commons_cancel_broadcast with subject and subjectId', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await cancelCommonsBroadcast('user', 'u1');
+    expect(mockedInvoke).toHaveBeenCalledWith('commons_cancel_broadcast', {
+      subject: 'user',
+      subjectId: 'u1',
+    });
+  });
+});

--- a/src/lib/api/encryption.test.ts
+++ b/src/lib/api/encryption.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  hasStoredKey,
+  encryptAndSaveKey,
+  encryptAndSaveEvmKey,
+  loadAndDecryptKey,
+  clearStoredKey,
+} from './encryption';
+
+vi.mock('@tauri-apps/api/core');
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: vi.fn(),
+  dmWarn: vi.fn(),
+  dmError: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+describe('encryption / key storage command wrappers', () => {
+  it('hasStoredKey returns true for non-empty key', async () => {
+    mockedInvoke.mockResolvedValueOnce('encrypted-key');
+    const result = await hasStoredKey();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_pkey');
+    expect(result).toBe(true);
+  });
+
+  it('hasStoredKey returns false when key is empty', async () => {
+    mockedInvoke.mockResolvedValueOnce('');
+    const result = await hasStoredKey();
+    expect(result).toBe(false);
+  });
+
+  it('hasStoredKey returns false on invoke error', async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error('backend failure'));
+    const result = await hasStoredKey();
+    expect(result).toBe(false);
+  });
+
+  it('encryptAndSaveKey encrypts then stores pkey', async () => {
+    mockedInvoke
+      .mockResolvedValueOnce('encrypted-private-key')
+      .mockResolvedValueOnce(undefined);
+    await encryptAndSaveKey('private-key', '123456');
+    expect(mockedInvoke).toHaveBeenCalledWith('encrypt', {
+      input: 'private-key',
+      password: '123456',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('set_pkey', {
+      pkey: 'encrypted-private-key',
+    });
+  });
+
+  it('encryptAndSaveEvmKey encrypts, stores evm pkey, and sets evm address', async () => {
+    mockedInvoke
+      .mockResolvedValueOnce('encrypted-evm-key')
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    await encryptAndSaveEvmKey('evm-private-key', '0xabc', '123456');
+    expect(mockedInvoke).toHaveBeenCalledWith('encrypt', {
+      input: 'evm-private-key',
+      password: '123456',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('set_evm_pkey', {
+      evmPkey: 'encrypted-evm-key',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('set_evm_address', {
+      address: '0xabc',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('update_profile', {
+      name: '',
+      avatar: '',
+      banner: '',
+      about: '',
+    });
+  });
+
+  it('loadAndDecryptKey returns decrypted key when PIN is correct', async () => {
+    mockedInvoke
+      .mockResolvedValueOnce('encrypted-key')
+      .mockResolvedValueOnce('decrypted-key');
+    const result = await loadAndDecryptKey('123456');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_pkey');
+    expect(mockedInvoke).toHaveBeenCalledWith('decrypt', {
+      ciphertext: 'encrypted-key',
+      password: '123456',
+    });
+    expect(result).toBe('decrypted-key');
+  });
+
+  it('loadAndDecryptKey throws when no key is stored', async () => {
+    mockedInvoke.mockResolvedValueOnce(null);
+    await expect(loadAndDecryptKey('123456')).rejects.toThrow('No stored key found');
+  });
+
+  it('loadAndDecryptKey throws Incorrect PIN on decrypt failure', async () => {
+    mockedInvoke
+      .mockResolvedValueOnce('encrypted-key')
+      .mockRejectedValueOnce(new Error('bad pin'));
+    await expect(loadAndDecryptKey('000000')).rejects.toThrow('Incorrect PIN');
+  });
+
+  it('clearStoredKey sends set_pkey with empty string', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await clearStoredKey();
+    expect(mockedInvoke).toHaveBeenCalledWith('set_pkey', { pkey: '' });
+  });
+});

--- a/src/lib/api/nostr.test.ts
+++ b/src/lib/api/nostr.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  fetchNostrProfile,
+  loadNostrProfile,
+  refreshProfileNow,
+  fetchMessages,
+  startNotifs,
+  getChatMessageCount,
+  deleteDmChatBackend,
+  getDmMessages,
+  syncAllProfiles,
+  updateProfile,
+  uploadAvatar,
+  setNickname,
+  toggleDmBlock,
+  queueProfileSync,
+  startTyping,
+  markAsRead,
+  sendDmMessage,
+  createGroupChat,
+  listMlsGroups,
+  getSafe,
+  setSafe,
+  listParentTreasurySafes,
+  addParentTreasurySafe,
+  getMlsGroupMetadata,
+  parseSquadInviteMessage,
+  formatSquadInviteMessage,
+  parseChannelInSquadMessage,
+  formatChannelInSquadMessage,
+  listPendingMlsWelcomes,
+  acceptMlsWelcome,
+  inviteMemberToGroup,
+  getMlsGroupMembers,
+  backfillSquadMemberEvmFromProfiles,
+  leaveMlsGroup,
+  syncMlsGroupsNow,
+  listDashboardPolls,
+  sendDashboardPollCreate,
+  sendDashboardPollVote,
+  type MlsVirtualBucket,
+} from './nostr';
+
+vi.mock('@tauri-apps/api/core');
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: vi.fn(),
+  dmWarn: vi.fn(),
+  dmError: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+// Profile
+
+describe('fetchNostrProfile', () => {
+  it('invokes get_profile with npub', async () => {
+    mockedInvoke.mockResolvedValueOnce({ id: 'npub1' });
+    const result = await fetchNostrProfile('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_profile', { npub: 'npub1' });
+    expect(result.id).toBe('npub1');
+  });
+});
+
+describe('loadNostrProfile', () => {
+  it('invokes load_profile with npub', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await loadNostrProfile('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('load_profile', { npub: 'npub1' });
+    expect(result).toBe(true);
+  });
+});
+
+describe('refreshProfileNow', () => {
+  it('invokes refresh_profile_now with npub', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await refreshProfileNow('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('refresh_profile_now', { npub: 'npub1' });
+  });
+});
+
+// Messages / DMs
+
+describe('fetchMessages', () => {
+  it('invokes fetch_messages with init and relay_url', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await fetchMessages(true, 'wss://relay.example.com');
+    expect(mockedInvoke).toHaveBeenCalledWith('fetch_messages', {
+      init: true,
+      relay_url: 'wss://relay.example.com',
+    });
+  });
+
+  it('coerces undefined relay to null', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await fetchMessages(false);
+    expect(mockedInvoke).toHaveBeenCalledWith('fetch_messages', { init: false, relay_url: null });
+  });
+});
+
+describe('startNotifs', () => {
+  it('invokes notifs and returns boolean', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await startNotifs();
+    expect(mockedInvoke).toHaveBeenCalledWith('notifs');
+    expect(result).toBe(true);
+  });
+});
+
+describe('getChatMessageCount', () => {
+  it('invokes get_chat_message_count with chatId', async () => {
+    mockedInvoke.mockResolvedValueOnce(42);
+    const result = await getChatMessageCount('chat-id');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_chat_message_count', { chatId: 'chat-id' });
+    expect(result).toBe(42);
+  });
+});
+
+describe('deleteDmChatBackend', () => {
+  it('invokes delete_dm_chat with chatId', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await deleteDmChatBackend('chat-id');
+    expect(mockedInvoke).toHaveBeenCalledWith('delete_dm_chat', { chatId: 'chat-id' });
+  });
+});
+
+describe('getDmMessages', () => {
+  it('invokes get_message_views with bucket filter', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await getDmMessages('chat-id', 10, 0, { virtualBucketFilter: 'inbox' });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_message_views', {
+      chatId: 'chat-id',
+      limit: 10,
+      offset: 0,
+      virtualBucketFilter: 'inbox',
+    });
+  });
+
+  it('coerces undefined bucket filter to null', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await getDmMessages('chat-id', 5, 10);
+    expect(mockedInvoke).toHaveBeenCalledWith('get_message_views', {
+      chatId: 'chat-id',
+      limit: 5,
+      offset: 10,
+      virtualBucketFilter: null,
+    });
+  });
+});
+
+describe('syncAllProfiles', () => {
+  it('invokes sync_all_profiles', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await syncAllProfiles();
+    expect(mockedInvoke).toHaveBeenCalledWith('sync_all_profiles');
+  });
+});
+
+describe('updateProfile', () => {
+  it('invokes update_profile with stringified fields', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await updateProfile({ name: 'Alice', avatar: 'url', banner: 'banner', about: 'hi' });
+    expect(mockedInvoke).toHaveBeenCalledWith('update_profile', {
+      name: 'Alice',
+      avatar: 'url',
+      banner: 'banner',
+      about: 'hi',
+    });
+  });
+
+  it('coerces undefined fields to empty strings', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await updateProfile({ name: 'Alice', avatar: undefined, banner: undefined, about: undefined } as unknown as Parameters<typeof updateProfile>[0]);
+    expect(mockedInvoke).toHaveBeenCalledWith('update_profile', {
+      name: 'Alice',
+      avatar: '',
+      banner: '',
+      about: '',
+    });
+  });
+});
+
+describe('uploadAvatar', () => {
+  it('invokes upload_avatar with filepath and upload_type', async () => {
+    mockedInvoke.mockResolvedValueOnce('https://url');
+    const result = await uploadAvatar('/path/to/img', 'avatar');
+    expect(mockedInvoke).toHaveBeenCalledWith('upload_avatar', {
+      filepath: '/path/to/img',
+      upload_type: 'avatar',
+    });
+    expect(result).toBe('https://url');
+  });
+});
+
+describe('setNickname', () => {
+  it('invokes set_nickname with npub and nickname', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await setNickname('npub1', 'Nick');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_nickname', { npub: 'npub1', nickname: 'Nick' });
+    expect(result).toBe(true);
+  });
+
+  it('coerces undefined nickname to empty string', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    await setNickname('npub1', undefined as unknown as string);
+    expect(mockedInvoke).toHaveBeenCalledWith('set_nickname', { npub: 'npub1', nickname: '' });
+  });
+});
+
+describe('toggleDmBlock', () => {
+  it('invokes toggle_blocked with npub', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await toggleDmBlock('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('toggle_blocked', { npub: 'npub1' });
+    expect(result).toBe(true);
+  });
+});
+
+describe('queueProfileSync', () => {
+  it('invokes queue_profile_sync with defaults', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await queueProfileSync('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('queue_profile_sync', {
+      npub: 'npub1',
+      priority: 'medium',
+      force_refresh: false,
+    });
+  });
+
+  it('invokes queue_profile_sync with explicit options', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await queueProfileSync('npub1', 'critical', true);
+    expect(mockedInvoke).toHaveBeenCalledWith('queue_profile_sync', {
+      npub: 'npub1',
+      priority: 'critical',
+      force_refresh: true,
+    });
+  });
+});
+
+describe('startTyping', () => {
+  it('invokes start_typing with receiver', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await startTyping('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('start_typing', { receiver: 'npub1' });
+    expect(result).toBe(true);
+  });
+});
+
+describe('markAsRead', () => {
+  it('invokes mark_as_read with chatId and messageId', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await markAsRead('chat-id', 'msg-id');
+    expect(mockedInvoke).toHaveBeenCalledWith('mark_as_read', { chatId: 'chat-id', messageId: 'msg-id' });
+    expect(result).toBe(true);
+  });
+
+  it('passes null messageId', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    await markAsRead('chat-id', null);
+    expect(mockedInvoke).toHaveBeenCalledWith('mark_as_read', { chatId: 'chat-id', messageId: null });
+  });
+});
+
+describe('sendDmMessage', () => {
+  it('invokes message with content and defaults', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await sendDmMessage('npub1', 'hello');
+    expect(mockedInvoke).toHaveBeenCalledWith('message', {
+      receiver: 'npub1',
+      content: 'hello',
+      repliedTo: '',
+      file: null,
+      virtualBucket: null,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('passes repliedTo and virtualBucket', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    await sendDmMessage('npub1', 'hello', 'reply-id', { virtualBucket: 'polls' as MlsVirtualBucket });
+    expect(mockedInvoke).toHaveBeenCalledWith('message', {
+      receiver: 'npub1',
+      content: 'hello',
+      repliedTo: 'reply-id',
+      file: null,
+      virtualBucket: 'polls',
+    });
+  });
+});
+
+// MLS / Squads
+
+describe('createGroupChat', () => {
+  it('invokes create_group_chat with name and members', async () => {
+    mockedInvoke.mockResolvedValueOnce('group-id');
+    const result = await createGroupChat('Squad', ['npub1', 'npub2']);
+    expect(mockedInvoke).toHaveBeenCalledWith('create_group_chat', {
+      groupName: 'Squad',
+      memberIds: ['npub1', 'npub2'],
+    });
+    expect(result).toBe('group-id');
+  });
+});
+
+describe('listMlsGroups', () => {
+  it('invokes list_mls_groups', async () => {
+    mockedInvoke.mockResolvedValueOnce(['g1', 'g2']);
+    const result = await listMlsGroups();
+    expect(mockedInvoke).toHaveBeenCalledWith('list_mls_groups');
+    expect(result).toEqual(['g1', 'g2']);
+  });
+});
+
+describe('getSafe', () => {
+  it('invokes get_safe with parentId and returns address', async () => {
+    mockedInvoke.mockResolvedValueOnce('0xabc');
+    const result = await getSafe('parent-1');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_safe', { parentId: 'parent-1' });
+    expect(result).toBe('0xabc');
+  });
+
+  it('normalizes null to null', async () => {
+    mockedInvoke.mockResolvedValueOnce(null);
+    const result = await getSafe('parent-1');
+    expect(result).toBeNull();
+  });
+});
+
+describe('setSafe', () => {
+  it('invokes set_safe with parentId and safeAddress', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await setSafe('parent-1', '0xabc');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_safe', { parentId: 'parent-1', safeAddress: '0xabc' });
+  });
+});
+
+describe('listParentTreasurySafes', () => {
+  it('invokes list_parent_treasury_safes with parentId', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await listParentTreasurySafes('parent-1');
+    expect(mockedInvoke).toHaveBeenCalledWith('list_parent_treasury_safes', { parentId: 'parent-1' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('addParentTreasurySafe', () => {
+  it('invokes add_parent_treasury_safe with all fields', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await addParentTreasurySafe('parent-1', '0xabc', { chain: 'sepolia', label: 'Treasury', entryId: 'e1' });
+    expect(mockedInvoke).toHaveBeenCalledWith('add_parent_treasury_safe', {
+      parentId: 'parent-1',
+      safeAddress: '0xabc',
+      chain: 'sepolia',
+      label: 'Treasury',
+      entryId: 'e1',
+    });
+  });
+
+  it('coerces undefined options to null', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await addParentTreasurySafe('parent-1', '0xabc');
+    expect(mockedInvoke).toHaveBeenCalledWith('add_parent_treasury_safe', {
+      parentId: 'parent-1',
+      safeAddress: '0xabc',
+      chain: null,
+      label: null,
+      entryId: null,
+    });
+  });
+});
+
+describe('getMlsGroupMetadata', () => {
+  it('invokes get_mls_group_metadata', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await getMlsGroupMetadata();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_mls_group_metadata');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('parseSquadInviteMessage', () => {
+  const payload = {
+    type: 'squad_invite' as const,
+    squadName: 'Alpha',
+    groupId: 'g1',
+    kind: 'squad' as const,
+    pairedSquads: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }] as const,
+    invitedByNpub: 'npub1',
+  };
+
+  it('parses valid squad invite payload', () => {
+    const result = parseSquadInviteMessage(JSON.stringify(payload));
+    expect(result).toEqual(payload);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseSquadInviteMessage('not json')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(parseSquadInviteMessage(JSON.stringify({ type: 'squad_invite' }))).toBeNull();
+  });
+
+  it('normalizes kind to squad-pair or squad', () => {
+    const raw = { type: 'squad_invite', squadName: 'A', groupId: 'g1', kind: 'squad-pair' };
+    expect(parseSquadInviteMessage(JSON.stringify(raw))?.kind).toBe('squad-pair');
+  });
+});
+
+describe('formatSquadInviteMessage', () => {
+  it('serializes payload to JSON', () => {
+    const payload = { type: 'squad_invite' as const, squadName: 'A', groupId: 'g1' };
+    expect(formatSquadInviteMessage(payload)).toBe(JSON.stringify(payload));
+  });
+});
+
+describe('parseChannelInSquadMessage', () => {
+  const payload = {
+    type: 'channel_in_squad' as const,
+    squadName: 'Alpha',
+    announcementsGroupId: 'a1',
+    channelGroupId: 'c1',
+    channelName: 'general',
+  };
+
+  it('parses valid channel payload', () => {
+    expect(parseChannelInSquadMessage(JSON.stringify(payload))).toEqual(payload);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseChannelInSquadMessage('not json')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(parseChannelInSquadMessage(JSON.stringify({ type: 'channel_in_squad' }))).toBeNull();
+  });
+});
+
+describe('formatChannelInSquadMessage', () => {
+  it('serializes payload to JSON', () => {
+    expect(formatChannelInSquadMessage({
+      type: 'channel_in_squad',
+      squadName: 'A',
+      announcementsGroupId: 'a1',
+      channelGroupId: 'c1',
+      channelName: 'general',
+    })).toBe(JSON.stringify({
+      type: 'channel_in_squad',
+      squadName: 'A',
+      announcementsGroupId: 'a1',
+      channelGroupId: 'c1',
+      channelName: 'general',
+    }));
+  });
+});
+
+describe('listPendingMlsWelcomes', () => {
+  it('invokes list_pending_mls_welcomes', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await listPendingMlsWelcomes();
+    expect(mockedInvoke).toHaveBeenCalledWith('list_pending_mls_welcomes');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('acceptMlsWelcome', () => {
+  it('invokes accept_mls_welcome with welcome id', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await acceptMlsWelcome('welcome-id');
+    expect(mockedInvoke).toHaveBeenCalledWith('accept_mls_welcome', { welcomeEventIdHex: 'welcome-id' });
+    expect(result).toBe(true);
+  });
+});
+
+describe('inviteMemberToGroup', () => {
+  it('invokes invite_member_to_group with groupId and memberNpub', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await inviteMemberToGroup('g1', 'npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('invite_member_to_group', { groupId: 'g1', memberNpub: 'npub1' });
+  });
+});
+
+describe('getMlsGroupMembers', () => {
+  it('invokes get_mls_group_members and returns members', async () => {
+    mockedInvoke.mockResolvedValueOnce({ group_id: 'g1', members: ['npub1'], admins: ['npub1'] });
+    const result = await getMlsGroupMembers('g1');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_mls_group_members', { groupId: 'g1' });
+    expect(result.members).toEqual(['npub1']);
+  });
+});
+
+describe('backfillSquadMemberEvmFromProfiles', () => {
+  it('invokes backfill_squad_member_evm_missing_from_profiles', async () => {
+    mockedInvoke.mockResolvedValueOnce(3);
+    const result = await backfillSquadMemberEvmFromProfiles('parent-1', ['npub1', 'npub2']);
+    expect(mockedInvoke).toHaveBeenCalledWith('backfill_squad_member_evm_missing_from_profiles', {
+      parentId: 'parent-1',
+      memberNpubs: ['npub1', 'npub2'],
+    });
+    expect(result).toBe(3);
+  });
+});
+
+describe('leaveMlsGroup', () => {
+  it('invokes leave_mls_group with groupId', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await leaveMlsGroup('g1');
+    expect(mockedInvoke).toHaveBeenCalledWith('leave_mls_group', { groupId: 'g1' });
+  });
+});
+
+describe('syncMlsGroupsNow', () => {
+  it('invokes sync_mls_groups_now with all groups when no groupId', async () => {
+    mockedInvoke.mockResolvedValueOnce([2, 5]);
+    const result = await syncMlsGroupsNow();
+    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { group_id: null });
+    expect(result).toEqual({ synced: 2, total: 5 });
+  });
+
+  it('invokes sync_mls_groups_now with a specific groupId', async () => {
+    mockedInvoke.mockResolvedValueOnce([1, 1]);
+    const result = await syncMlsGroupsNow('g1');
+    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { group_id: 'g1' });
+    expect(result).toEqual({ synced: 1, total: 1 });
+  });
+});
+
+// Dashboard polls
+
+describe('listDashboardPolls', () => {
+  it('invokes list_dashboard_polls with parentId', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await listDashboardPolls('parent-1');
+    expect(mockedInvoke).toHaveBeenCalledWith('list_dashboard_polls', { parentId: 'parent-1' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('sendDashboardPollCreate', () => {
+  it('invokes send_dashboard_poll_create with all params', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await sendDashboardPollCreate({
+      mlsGroupId: 'g1',
+      parentId: 'parent-1',
+      pollId: 'p1',
+      title: 'Title',
+      description: 'Desc',
+      options: [{ id: 'o1', label: 'Yes' }],
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('send_dashboard_poll_create', {
+      mlsGroupId: 'g1',
+      parentId: 'parent-1',
+      pollId: 'p1',
+      title: 'Title',
+      description: 'Desc',
+      options: [{ id: 'o1', label: 'Yes' }],
+    });
+  });
+});
+
+describe('sendDashboardPollVote', () => {
+  it('invokes send_dashboard_poll_vote with all params', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await sendDashboardPollVote({
+      mlsGroupId: 'g1',
+      parentId: 'parent-1',
+      pollId: 'p1',
+      optionId: 'o1',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('send_dashboard_poll_vote', {
+      mlsGroupId: 'g1',
+      parentId: 'parent-1',
+      pollId: 'p1',
+      optionId: 'o1',
+    });
+  });
+});

--- a/src/lib/api/relays.test.ts
+++ b/src/lib/api/relays.test.ts
@@ -1,5 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { relayModeLabel, relayStatusLabel, validateRelayUrlInput } from './relays';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  validateRelayUrlInput,
+  relayModeLabel,
+  relayStatusLabel,
+  listRelays,
+  addCustomRelay,
+  removeCustomRelay,
+  toggleCustomRelay,
+  toggleDefaultRelay,
+  setRelayEnabled,
+} from './relays';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
 
 describe('validateRelayUrlInput', () => {
   it('accepts wss URLs with host', () => {
@@ -31,9 +51,96 @@ describe('relayModeLabel', () => {
   });
 });
 
-describe('relayStatusLabel', () => {
-  it('maps connected and disabled', () => {
-    expect(relayStatusLabel('connected')).toBe('Connected');
-    expect(relayStatusLabel('disabled')).toBe('Disabled');
+describe('setRelayEnabled', () => {
+  it('routes custom relays to toggleCustomRelay', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await setRelayEnabled(
+      { url: 'wss://custom', status: 'connected', is_default: false, is_custom: true, enabled: true, mode: 'both' },
+      false
+    );
+    expect(mockedInvoke).toHaveBeenCalledWith('toggle_custom_relay', {
+      url: 'wss://custom',
+      enabled: false,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('routes default relays to toggleDefaultRelay', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await setRelayEnabled(
+      { url: 'wss://default', status: 'connected', is_default: true, is_custom: false, enabled: true, mode: 'both' },
+      false
+    );
+    expect(mockedInvoke).toHaveBeenCalledWith('toggle_default_relay', {
+      url: 'wss://default',
+      enabled: false,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('throws for unknown relay type', async () => {
+    await expect(
+      setRelayEnabled(
+        { url: 'wss://unknown', status: 'connected', is_default: false, is_custom: false, enabled: true, mode: 'both' },
+        false
+      )
+    ).rejects.toThrow('Unknown relay type');
   });
 });
+
+describe('relay command wrappers', () => {
+  it('listRelays sends get_relays', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await listRelays();
+    expect(mockedInvoke).toHaveBeenCalledWith('get_relays');
+    expect(result).toEqual([]);
+  });
+
+  it('addCustomRelay sends add_custom_relay with default mode', async () => {
+    const relay = { url: 'wss://custom', enabled: true, mode: 'both' as const };
+    mockedInvoke.mockResolvedValueOnce(relay);
+    const result = await addCustomRelay('wss://custom');
+    expect(mockedInvoke).toHaveBeenCalledWith('add_custom_relay', {
+      url: 'wss://custom',
+      mode: 'both',
+    });
+    expect(result).toEqual(relay);
+  });
+
+  it('addCustomRelay passes custom mode', async () => {
+    mockedInvoke.mockResolvedValueOnce({ url: 'wss://custom', enabled: true, mode: 'read' as const });
+    await addCustomRelay('wss://custom', 'read');
+    expect(mockedInvoke).toHaveBeenCalledWith('add_custom_relay', {
+      url: 'wss://custom',
+      mode: 'read',
+    });
+  });
+
+  it('removeCustomRelay sends remove_custom_relay', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await removeCustomRelay('wss://custom');
+    expect(mockedInvoke).toHaveBeenCalledWith('remove_custom_relay', { url: 'wss://custom' });
+    expect(result).toBe(true);
+  });
+
+  it('toggleCustomRelay sends toggle_custom_relay', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await toggleCustomRelay('wss://custom', true);
+    expect(mockedInvoke).toHaveBeenCalledWith('toggle_custom_relay', {
+      url: 'wss://custom',
+      enabled: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('toggleDefaultRelay sends toggle_default_relay', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    const result = await toggleDefaultRelay('wss://default', false);
+    expect(mockedInvoke).toHaveBeenCalledWith('toggle_default_relay', {
+      url: 'wss://default',
+      enabled: false,
+    });
+    expect(result).toBe(true);
+  });
+});
+

--- a/src/lib/api/wallet-peers.test.ts
+++ b/src/lib/api/wallet-peers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { getDmPeerEvmAddress, setDmPeerEvmAddress } from './wallet-peers';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+describe('wallet-peers command wrappers', () => {
+  it('getDmPeerEvmAddress sends get_dm_peer_evm_address with peerNpub', async () => {
+    mockedInvoke.mockResolvedValueOnce('0xabc');
+    const result = await getDmPeerEvmAddress('npub1');
+    expect(mockedInvoke).toHaveBeenCalledWith('get_dm_peer_evm_address', { peerNpub: 'npub1' });
+    expect(result).toBe('0xabc');
+  });
+
+  it('setDmPeerEvmAddress sends set_dm_peer_evm_address with peer and address', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await setDmPeerEvmAddress('npub1', '0xabc');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_dm_peer_evm_address', {
+      peerNpub: 'npub1',
+      address: '0xabc',
+    });
+  });
+});

--- a/src/lib/app/dashboard-prefetch.test.ts
+++ b/src/lib/app/dashboard-prefetch.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scheduleDashboardChannelPrefetch } from './dashboard-parent-prefetch';
+import { scheduleDashboardPrefetch } from './dashboard-prefetch';
+
+vi.mock('./dashboard-parent-prefetch', () => ({
+  scheduleDashboardChannelPrefetch: vi.fn(),
+}));
+
+describe('scheduleDashboardPrefetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to scheduleDashboardChannelPrefetch', () => {
+    const parent = { id: 'parent-1', name: 'Test' } as unknown as Parameters<
+      typeof scheduleDashboardPrefetch
+    >[0];
+    scheduleDashboardPrefetch(parent);
+    expect(scheduleDashboardChannelPrefetch).toHaveBeenCalledWith(parent);
+  });
+
+  it('passes null through', () => {
+    scheduleDashboardPrefetch(null);
+    expect(scheduleDashboardChannelPrefetch).toHaveBeenCalledWith(null);
+  });
+
+  it('passes undefined through', () => {
+    scheduleDashboardPrefetch(undefined);
+    expect(scheduleDashboardChannelPrefetch).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/lib/app/hub-prefetch.test.ts
+++ b/src/lib/app/hub-prefetch.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scheduleHubParentPrefetch } from './dashboard-parent-prefetch';
+import { scheduleHubPrefetch } from './hub-prefetch';
+
+vi.mock('./dashboard-parent-prefetch', () => ({
+  scheduleHubParentPrefetch: vi.fn(),
+}));
+
+describe('scheduleHubPrefetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to scheduleHubParentPrefetch', () => {
+    const parent = { id: 'parent-1', name: 'Test' } as unknown as Parameters<
+      typeof scheduleHubPrefetch
+    >[0];
+    scheduleHubPrefetch(parent);
+    expect(scheduleHubParentPrefetch).toHaveBeenCalledWith(parent);
+  });
+
+  it('passes null through', () => {
+    scheduleHubPrefetch(null);
+    expect(scheduleHubParentPrefetch).toHaveBeenCalledWith(null);
+  });
+
+  it('passes undefined through', () => {
+    scheduleHubPrefetch(undefined);
+    expect(scheduleHubParentPrefetch).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/lib/app/post-login-sync.test.ts
+++ b/src/lib/app/post-login-sync.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runPostLoginNetworkSync } from './post-login-sync';
+
+const scheduleCommonsStartupPrefetch = vi.fn();
+const apiConnect = vi.fn();
+const fetchMessages = vi.fn();
+const refreshProfileNow = vi.fn();
+const syncMlsGroupsNow = vi.fn();
+const dmSyncStatusSet = vi.fn();
+const dmLog = vi.fn();
+const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+vi.mock('../api/auth', () => ({
+  connect: (...args: unknown[]) => apiConnect(...args),
+}));
+
+vi.mock('../api/nostr', () => ({
+  fetchMessages: (...args: unknown[]) => fetchMessages(...args),
+  refreshProfileNow: (...args: unknown[]) => refreshProfileNow(...args),
+  syncMlsGroupsNow: (...args: unknown[]) => syncMlsGroupsNow(...args),
+}));
+
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: (...args: unknown[]) => dmLog(...args),
+}));
+
+vi.mock('../../stores/dm', () => ({
+  dmSyncStatus: { set: (...args: unknown[]) => dmSyncStatusSet(...args) },
+}));
+
+vi.mock('../commons/commons-prefetch', () => ({
+  scheduleCommonsStartupPrefetch: (...args: unknown[]) =>
+    scheduleCommonsStartupPrefetch(...args),
+}));
+
+describe('runPostLoginNetworkSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    consoleError.mockClear();
+  });
+
+  async function flushAsync(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+  }
+
+  it('starts commons prefetch and sets sync status', async () => {
+    const connectDeferred = Promise.withResolvers<void>();
+    apiConnect.mockReturnValue(connectDeferred.promise);
+    fetchMessages.mockResolvedValue(undefined);
+    refreshProfileNow.mockResolvedValue(undefined);
+    syncMlsGroupsNow.mockResolvedValue(undefined);
+
+    runPostLoginNetworkSync('npub1test');
+    expect(scheduleCommonsStartupPrefetch).toHaveBeenCalled();
+    expect(dmLog).toHaveBeenCalledWith('post-login: connect()');
+
+    connectDeferred.resolve();
+    await flushAsync();
+
+    expect(dmLog).toHaveBeenCalledWith('post-login: connect() done');
+    expect(dmLog).toHaveBeenCalledWith('post-login: fetchMessages(true)');
+    expect(dmSyncStatusSet).toHaveBeenCalledWith('syncing');
+    expect(fetchMessages).toHaveBeenCalledWith(true);
+    expect(refreshProfileNow).toHaveBeenCalledWith('npub1test');
+    expect(syncMlsGroupsNow).toHaveBeenCalledWith(null);
+    expect(dmLog).toHaveBeenCalledWith('post-login: network sync done');
+  });
+
+  it('logs connect errors and continues', async () => {
+    const connectDeferred = Promise.withResolvers<void>();
+    apiConnect.mockReturnValue(connectDeferred.promise);
+    fetchMessages.mockResolvedValue(undefined);
+    refreshProfileNow.mockResolvedValue(undefined);
+    syncMlsGroupsNow.mockResolvedValue(undefined);
+
+    runPostLoginNetworkSync('npub1test');
+    const err = new Error('connect failed');
+    connectDeferred.reject(err);
+
+    await flushAsync();
+
+    expect(console.error).toHaveBeenCalledWith('connect after login failed:', err);
+    expect(dmSyncStatusSet).toHaveBeenCalledWith('syncing');
+    expect(refreshProfileNow).toHaveBeenCalledWith('npub1test');
+  });
+
+  it('logs fetchMessages rejection', async () => {
+    apiConnect.mockResolvedValue(undefined);
+    const fetchDeferred = Promise.withResolvers<undefined>();
+    fetchMessages.mockReturnValue(fetchDeferred.promise);
+    refreshProfileNow.mockResolvedValue(undefined);
+    syncMlsGroupsNow.mockResolvedValue(undefined);
+
+    runPostLoginNetworkSync('npub1test');
+    const err = new Error('fetch failed');
+    fetchDeferred.reject(err);
+
+    await flushAsync();
+
+    expect(console.error).toHaveBeenCalledWith('fetch_messages failed:', err);
+  });
+
+  it('logs refreshProfileNow rejection', async () => {
+    apiConnect.mockResolvedValue(undefined);
+    fetchMessages.mockResolvedValue(undefined);
+    const refreshDeferred = Promise.withResolvers<void>();
+    refreshProfileNow.mockReturnValue(refreshDeferred.promise);
+    syncMlsGroupsNow.mockResolvedValue(undefined);
+
+    runPostLoginNetworkSync('npub1test');
+    const err = new Error('refresh failed');
+    refreshDeferred.reject(err);
+
+    await flushAsync();
+
+    expect(console.error).toHaveBeenCalledWith('Auto profile refresh failed:', err);
+  });
+
+  it('logs syncMlsGroupsNow rejection', async () => {
+    apiConnect.mockResolvedValue(undefined);
+    fetchMessages.mockResolvedValue(undefined);
+    refreshProfileNow.mockResolvedValue(undefined);
+    const mlsDeferred = Promise.withResolvers<undefined>();
+    syncMlsGroupsNow.mockReturnValue(mlsDeferred.promise);
+
+    runPostLoginNetworkSync('npub1test');
+    const err = new Error('mls failed');
+    mlsDeferred.reject(err);
+
+    await flushAsync();
+
+    expect(console.error).toHaveBeenCalledWith('syncMlsGroupsNow after login failed:', err);
+  });
+});

--- a/src/lib/app/tauri-subscriptions.test.ts
+++ b/src/lib/app/tauri-subscriptions.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribeAppEvents, type AppEventHandlers } from './tauri-subscriptions';
+import type { DmMessage } from '../../stores/dm';
+
+const mocks = vi.hoisted(() => {
+  function createMockStore<T>(initial: T) {
+    let value = initial;
+    const subscribers = new Set<(v: T) => void>();
+    return {
+      set: (v: T) => {
+        value = v;
+        subscribers.forEach((s) => s(v));
+      },
+      update: (fn: (v: T) => T) => {
+        value = fn(value);
+        subscribers.forEach((s) => s(value));
+      },
+      subscribe: (fn: (v: T) => void) => {
+        subscribers.add(fn);
+        fn(value);
+        return () => {
+          subscribers.delete(fn);
+        };
+      },
+      get: () => value,
+    };
+  }
+
+  const registered: Record<string, Array<(event: unknown) => void>> = {};
+  const listen = vi.fn((event: string, handler: (event: unknown) => void) => {
+    registered[event] = registered[event] ?? [];
+    registered[event].push(handler);
+    return Promise.resolve(() => {});
+  });
+
+  const mockStores = {
+    backendDmMessages: createMockStore<Record<string, DmMessage[]>>({}),
+    backendGroupMessages: createMockStore<Record<string, DmMessage[]>>({}),
+    dmChatsByNpub: createMockStore<Record<string, unknown>>({}),
+    dmSyncStatus: createMockStore<string>('idle'),
+    typingByChat: createMockStore<Record<string, string[]>>({}),
+    pendingMlsWelcomes: createMockStore<unknown[]>([]),
+    dashboardPollReplicaNonceByParentId: createMockStore<Record<string, number>>({}),
+    activeDmId: createMockStore<string | null>(null),
+  };
+
+  const mockFunctions = {
+    appendPactoAppInboxMessage: vi.fn(),
+    reconcilePeerThreadInvites: vi.fn(),
+    bumpMembershipVersion: vi.fn(),
+    handleMlsWelcomeAccepted: vi.fn(),
+    handleChannelAddedToSquad: vi.fn(),
+    updateChannelNameIfPlaceholder: vi.fn(),
+    listPendingMlsWelcomes: vi.fn(),
+    fetchMessages: vi.fn(),
+    parseAnnouncement: vi.fn(),
+    parseWalletTxAnnouncement: vi.fn(),
+    isPactoAppRoutableInviteContent: vi.fn(),
+    resolveInviteInviterNpub: vi.fn(),
+    incrementDmUnread: vi.fn(),
+    dmLog: vi.fn(),
+    dmError: vi.fn(),
+  };
+
+  const dmThreadScrolledToBottom = createMockStore<boolean>(false);
+
+  return {
+    createMockStore,
+    registered,
+    listen,
+    mockStores,
+    mockFunctions,
+    dmThreadScrolledToBottom,
+  };
+});
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock('../api/nostr', () => ({
+  listPendingMlsWelcomes: (...args: unknown[]) => mocks.mockFunctions.listPendingMlsWelcomes(...args),
+  fetchMessages: (...args: unknown[]) => mocks.mockFunctions.fetchMessages(...args),
+}));
+
+vi.mock('../announcements', () => ({
+  parseAnnouncement: (...args: unknown[]) => mocks.mockFunctions.parseAnnouncement(...args),
+  ANNOUNCE_TYPE_GOVERNANCE_UPDATED: 'governance_updated',
+}));
+
+vi.mock('../wallet/dm-messages', () => ({
+  parseWalletTxAnnouncement: (...args: unknown[]) =>
+    mocks.mockFunctions.parseWalletTxAnnouncement(...args),
+}));
+
+vi.mock('../pacto-app-inbox', () => ({
+  isPactoAppRoutableInviteContent: (...args: unknown[]) =>
+    mocks.mockFunctions.isPactoAppRoutableInviteContent(...args),
+  resolveInviteInviterNpub: (...args: unknown[]) =>
+    mocks.mockFunctions.resolveInviteInviterNpub(...args),
+}));
+
+vi.mock('../invites/accept-invite', () => ({
+  handleChannelAddedToSquad: (...args: unknown[]) =>
+    mocks.mockFunctions.handleChannelAddedToSquad(...args),
+  handleMlsWelcomeAccepted: (...args: unknown[]) =>
+    mocks.mockFunctions.handleMlsWelcomeAccepted(...args),
+}));
+
+vi.mock('../squad/squad-catalog', () => ({
+  updateChannelNameIfPlaceholder: (...args: unknown[]) =>
+    mocks.mockFunctions.updateChannelNameIfPlaceholder(...args),
+}));
+
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: (...args: unknown[]) => mocks.mockFunctions.dmLog(...args),
+  dmError: (...args: unknown[]) => mocks.mockFunctions.dmError(...args),
+}));
+
+vi.mock('../../stores/app', () => ({
+  backendDmMessages: mocks.mockStores.backendDmMessages,
+  backendGroupMessages: mocks.mockStores.backendGroupMessages,
+  dmChatsByNpub: mocks.mockStores.dmChatsByNpub,
+  appendPactoAppInboxMessage: (...args: unknown[]) =>
+    mocks.mockFunctions.appendPactoAppInboxMessage(...args),
+  reconcilePeerThreadInvites: (...args: unknown[]) =>
+    mocks.mockFunctions.reconcilePeerThreadInvites(...args),
+  dmSyncStatus: mocks.mockStores.dmSyncStatus,
+  typingByChat: mocks.mockStores.typingByChat,
+  pendingMlsWelcomes: mocks.mockStores.pendingMlsWelcomes,
+  bumpMembershipVersion: (...args: unknown[]) => mocks.mockFunctions.bumpMembershipVersion(...args),
+  dashboardPollReplicaNonceByParentId: mocks.mockStores.dashboardPollReplicaNonceByParentId,
+  activeDmId: mocks.mockStores.activeDmId,
+}));
+
+vi.mock('../../stores/dm-unread', () => ({
+  incrementDmUnread: (...args: unknown[]) => mocks.mockFunctions.incrementDmUnread(...args),
+  dmThreadScrolledToBottom: mocks.dmThreadScrolledToBottom,
+}));
+
+function emit(event: string, payload: unknown): void {
+  const handlers = mocks.registered[event] ?? [];
+  for (const h of handlers) {
+    h({ payload } as unknown);
+  }
+}
+
+function dmMessage(overrides: Partial<DmMessage> = {}) {
+  return {
+    id: 'msg1',
+    content: 'hello',
+    at: 1000,
+    mine: false,
+    npub: 'npub1sender',
+    pending: false,
+    failed: false,
+    ...overrides,
+  };
+}
+
+const handlers: AppEventHandlers = {
+  mergeTreasurySafesForParent: vi.fn(),
+  mergeSquadInfraForParent: vi.fn(),
+};
+
+describe('subscribeAppEvents', () => {
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(mocks.registered).forEach((k) => delete mocks.registered[k]);
+    mocks.mockStores.backendDmMessages.set({});
+    mocks.mockStores.backendGroupMessages.set({});
+    mocks.mockStores.dmChatsByNpub.set({});
+    mocks.mockStores.dmSyncStatus.set('idle');
+    mocks.mockStores.typingByChat.set({});
+    mocks.mockStores.pendingMlsWelcomes.set([]);
+    mocks.mockStores.dashboardPollReplicaNonceByParentId.set({});
+    mocks.mockStores.activeDmId.set(null);
+    mocks.dmThreadScrolledToBottom.set(false);
+    mocks.mockFunctions.isPactoAppRoutableInviteContent.mockReturnValue(false);
+    mocks.mockFunctions.parseWalletTxAnnouncement.mockReturnValue(null);
+    mocks.mockFunctions.parseAnnouncement.mockReturnValue(null);
+    mocks.mockFunctions.listPendingMlsWelcomes.mockResolvedValue([]);
+    mocks.mockFunctions.fetchMessages.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    vi.useRealTimers();
+  });
+
+  it('registers expected event listeners', async () => {
+    subscribeAppEvents(handlers);
+    await Promise.resolve();
+    const expected = [
+      'message_new',
+      'message_update',
+      'sync_slice_finished',
+      'sync_progress',
+      'sync_finished',
+      'typing-update',
+      'mls_message_new',
+      'mls_invite_received',
+      'mls_welcome_accepted',
+      'channel_added_to_squad',
+      'mls_group_updated',
+      'mls_group_initial_sync',
+      'mls_group_left',
+      'dashboard_poll_replica_updated',
+    ];
+    for (const e of expected) {
+      expect(mocks.registered[e], `missing listener for ${e}`).toBeDefined();
+      expect(mocks.registered[e].length).toBe(1);
+    }
+  });
+
+  it('unsubscribes clears timeouts and unlisten promises', () => {
+    unsubscribe = subscribeAppEvents(handlers);
+    unsubscribe();
+  });
+
+  describe('message_new', () => {
+    it('ignores non-npub1 chat ids', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_new', { chat_id: 'group1', message: dmMessage() });
+      expect(mocks.mockStores.backendDmMessages.get()).toEqual({});
+      expect(mocks.mockFunctions.incrementDmUnread).not.toHaveBeenCalled();
+    });
+
+    it('appends pacto inbox message for routable invite content from others', () => {
+      mocks.mockFunctions.isPactoAppRoutableInviteContent.mockReturnValue(true);
+      mocks.mockFunctions.resolveInviteInviterNpub.mockReturnValue('npub1inviter');
+      unsubscribe = subscribeAppEvents(handlers);
+      const message = dmMessage({ mine: false });
+      emit('message_new', { chat_id: 'npub1chat', message });
+      expect(mocks.mockFunctions.appendPactoAppInboxMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'msg1' }),
+        'npub1inviter'
+      );
+      expect(mocks.mockStores.backendDmMessages.get()).toEqual({});
+    });
+
+    it('does not append inbox message for own routable invite', () => {
+      mocks.mockFunctions.isPactoAppRoutableInviteContent.mockReturnValue(true);
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ mine: true }) });
+      expect(mocks.mockFunctions.appendPactoAppInboxMessage).not.toHaveBeenCalled();
+    });
+
+    it('adds message to backendDmMessages for normal DM content', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ id: 'm1' }) });
+      expect(mocks.mockStores.backendDmMessages.get()).toHaveProperty('npub1chat');
+      const chatMessages = mocks.mockStores.backendDmMessages.get()['npub1chat'];
+      expect(chatMessages).toHaveLength(1);
+      expect(chatMessages![0].id).toBe('m1');
+    });
+
+    it('increments unread for inbound message when not active thread', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      mocks.mockStores.activeDmId.set('npub1other');
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ mine: false }) });
+      expect(mocks.mockFunctions.incrementDmUnread).toHaveBeenCalledWith('npub1chat');
+    });
+
+    it('does not increment unread for own message', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      mocks.mockStores.activeDmId.set('npub1chat');
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ mine: true }) });
+      expect(mocks.mockFunctions.incrementDmUnread).not.toHaveBeenCalled();
+    });
+
+    it('does not increment unread when thread is active and scrolled to bottom', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      mocks.mockStores.activeDmId.set('npub1chat');
+      mocks.dmThreadScrolledToBottom.set(true);
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ mine: false }) });
+      expect(mocks.mockFunctions.incrementDmUnread).not.toHaveBeenCalled();
+    });
+
+    it('updates dmChatsByNpub metadata', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ at: 5000, mine: false }) });
+      const chat = mocks.mockStores.dmChatsByNpub.get()['npub1chat'] as Record<string, unknown>;
+      expect(chat).toBeDefined();
+      expect(chat.hasFromThem).toBe(true);
+      expect(chat.lastAt).toBe(5000);
+    });
+
+    it('clears typing indicator for the chat', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      mocks.mockStores.typingByChat.set({ npub1chat: ['typer'] });
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage() });
+      expect(mocks.mockStores.typingByChat.get()).toEqual({ npub1chat: [] });
+    });
+
+    it('normalizes wallet tx announcement to pending false', () => {
+      mocks.mockFunctions.parseWalletTxAnnouncement.mockReturnValue({ block_number: 1 });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_new', { chat_id: 'npub1chat', message: dmMessage({ pending: true }) });
+      const stored = mocks.mockStores.backendDmMessages.get()['npub1chat']![0];
+      expect(stored.pending).toBe(false);
+    });
+  });
+
+  describe('message_update', () => {
+    it('replaces message in DM backend for npub1 chat', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_update', {
+        chat_id: 'npub1chat',
+        old_id: 'old1',
+        message: dmMessage({ id: 'new1', at: 2000 }),
+      });
+      const list = mocks.mockStores.backendDmMessages.get()['npub1chat']!;
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe('new1');
+    });
+
+    it('handles routable invite update in DM chat', () => {
+      mocks.mockFunctions.isPactoAppRoutableInviteContent.mockReturnValue(true);
+      mocks.mockFunctions.resolveInviteInviterNpub.mockReturnValue('npub1inviter');
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_update', {
+        chat_id: 'npub1chat',
+        old_id: 'old1',
+        message: dmMessage({ mine: false }),
+      });
+      expect(mocks.mockFunctions.appendPactoAppInboxMessage).toHaveBeenCalled();
+      expect(mocks.mockStores.backendDmMessages.get()).toEqual({});
+    });
+
+    it('updates group messages for non-npub1 chat', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_update', {
+        chat_id: 'group1',
+        old_id: 'old1',
+        message: dmMessage({ id: 'new1', at: 2000 }),
+      });
+      expect(mocks.mockStores.backendGroupMessages.get()).toHaveProperty('group1');
+    });
+
+    it('merges treasury safes on squad_safe_updated announcement', () => {
+      mocks.mockFunctions.parseAnnouncement.mockReturnValue({
+        type: 'squad_safe_updated',
+        payload: { squad_id: 's1' },
+      });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_update', { chat_id: 'group1', old_id: 'old1', message: dmMessage() });
+      expect(handlers.mergeTreasurySafesForParent).toHaveBeenCalledWith('s1');
+    });
+
+    it('merges squad infra on governance_updated announcement', () => {
+      mocks.mockFunctions.parseAnnouncement.mockReturnValue({
+        type: 'governance_updated',
+        payload: { parent_id: 'p1' },
+      });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('message_update', { chat_id: 'group1', old_id: 'old1', message: dmMessage() });
+      expect(handlers.mergeSquadInfraForParent).toHaveBeenCalledWith('p1');
+    });
+  });
+
+  describe('sync events', () => {
+    it('sync_slice_finished triggers fetchMessages(false)', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('sync_slice_finished', {});
+      expect(mocks.mockFunctions.fetchMessages).toHaveBeenCalledWith(false);
+      expect(mocks.mockStores.dmSyncStatus.get()).toBe('syncing');
+    });
+
+    it('sync_progress transitions idle to syncing', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('sync_progress', {});
+      expect(mocks.mockStores.dmSyncStatus.get()).toBe('syncing');
+    });
+
+    it('sync_progress keeps non-idle state unchanged', () => {
+      mocks.mockStores.dmSyncStatus.set('finished');
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('sync_progress', {});
+      expect(mocks.mockStores.dmSyncStatus.get()).toBe('finished');
+    });
+
+    it('sync_finished reconciles invites and returns to idle after timeout', () => {
+      vi.useFakeTimers();
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('sync_finished', {});
+      expect(mocks.mockFunctions.reconcilePeerThreadInvites).toHaveBeenCalled();
+      expect(mocks.mockStores.dmSyncStatus.get()).toBe('finished');
+      vi.advanceTimersByTime(2500);
+      expect(mocks.mockStores.dmSyncStatus.get()).toBe('idle');
+    });
+  });
+
+  describe('typing-update', () => {
+    it('ignores non-npub1 conversations', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('typing-update', { conversation_id: 'group1', typers: ['t1'] });
+      expect(mocks.mockStores.typingByChat.get()).toEqual({});
+    });
+
+    it('sets typers for npub1 conversation', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('typing-update', { conversation_id: 'npub1chat', typers: ['t1'] });
+      expect(mocks.mockStores.typingByChat.get()['npub1chat']).toEqual(['t1']);
+    });
+
+    it('clears typers after expiry', () => {
+      vi.useFakeTimers();
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('typing-update', { conversation_id: 'npub1chat', typers: ['t1'] });
+      vi.advanceTimersByTime(15_000);
+      expect(mocks.mockStores.typingByChat.get()['npub1chat']).toEqual([]);
+    });
+  });
+
+  describe('mls_message_new', () => {
+    it('adds message to backendGroupMessages', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_message_new', { group_id: 'g1', message: dmMessage({ id: 'm1' }) });
+      const list = mocks.mockStores.backendGroupMessages.get()['g1'] as Array<{ id: string }>;
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe('m1');
+    });
+
+    it('merges treasury safes on squad_safe_updated', () => {
+      mocks.mockFunctions.parseAnnouncement.mockReturnValue({
+        type: 'squad_safe_updated',
+        payload: { squad_id: 's1' },
+      });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_message_new', { group_id: 'g1', message: dmMessage() });
+      expect(handlers.mergeTreasurySafesForParent).toHaveBeenCalledWith('s1');
+    });
+
+    it('merges squad infra on governance_updated', () => {
+      mocks.mockFunctions.parseAnnouncement.mockReturnValue({
+        type: 'governance_updated',
+        payload: { parent_id: 'p1' },
+      });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_message_new', { group_id: 'g1', message: dmMessage() });
+      expect(handlers.mergeSquadInfraForParent).toHaveBeenCalledWith('p1');
+    });
+
+    it('updates channel name when group_name provided', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_message_new', { group_id: 'g1', message: dmMessage(), group_name: 'General' });
+      expect(mocks.mockFunctions.updateChannelNameIfPlaceholder).toHaveBeenCalledWith('g1', 'General');
+    });
+  });
+
+  describe('mls invite and membership events', () => {
+    it('mls_invite_received refreshes pending welcomes', async () => {
+      mocks.mockFunctions.listPendingMlsWelcomes.mockResolvedValue([{ group_id: 'g1' }]);
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_invite_received', {});
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mocks.mockFunctions.listPendingMlsWelcomes).toHaveBeenCalled();
+      expect(mocks.mockStores.pendingMlsWelcomes.get()).toEqual([{ group_id: 'g1' }]);
+    });
+
+    it('mls_welcome_accepted refreshes welcomes and handles acceptance', async () => {
+      mocks.mockFunctions.listPendingMlsWelcomes.mockResolvedValue([]);
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_welcome_accepted', { group_id: 'g1' });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mocks.mockFunctions.listPendingMlsWelcomes).toHaveBeenCalled();
+      expect(mocks.mockFunctions.handleMlsWelcomeAccepted).toHaveBeenCalledWith('g1');
+    });
+
+    it('channel_added_to_squad refreshes welcomes and handles channel', async () => {
+      mocks.mockFunctions.listPendingMlsWelcomes.mockResolvedValue([]);
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('channel_added_to_squad', {
+        announcements_group_id: 'a1',
+        channel_group_id: 'c1',
+        channel_name: 'General',
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mocks.mockFunctions.listPendingMlsWelcomes).toHaveBeenCalled();
+      expect(mocks.mockFunctions.handleChannelAddedToSquad).toHaveBeenCalledWith('a1', 'c1', 'General');
+    });
+
+    it.each([
+      'mls_group_updated',
+      'mls_group_initial_sync',
+      'mls_group_left',
+    ])('%s bumps membership version', (event) => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit(event, { group_id: 'g1' });
+      expect(mocks.mockFunctions.bumpMembershipVersion).toHaveBeenCalledWith('g1');
+    });
+  });
+
+  describe('dashboard_poll_replica_updated', () => {
+    it('increments nonce for parent id', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('dashboard_poll_replica_updated', { parent_id: 'p1' });
+      expect(mocks.mockStores.dashboardPollReplicaNonceByParentId.get()['p1']).toBe(1);
+      emit('dashboard_poll_replica_updated', { parentId: 'p1' });
+      expect(mocks.mockStores.dashboardPollReplicaNonceByParentId.get()['p1']).toBe(2);
+    });
+
+    it('ignores missing parent id', () => {
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('dashboard_poll_replica_updated', {});
+      expect(mocks.mockStores.dashboardPollReplicaNonceByParentId.get()).toEqual({});
+    });
+  });
+});

--- a/src/lib/commons/commons-prefetch.test.ts
+++ b/src/lib/commons/commons-prefetch.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { fetchCommonsBroadcasts, fetchCommonsBroadcastsCached } from '../api/commons';
+import {
+  commonsBroadcasts,
+  commonsFeedError,
+  commonsFeedSyncing,
+  refreshCommonsBroadcasts,
+  resetCommonsPrefetchSession,
+  scheduleCommonsStartupPrefetch,
+} from './commons-prefetch';
+import type { CommonsBroadcastDto } from './types';
+
+vi.mock('../api/commons', () => ({
+  fetchCommonsBroadcasts: vi.fn(),
+  fetchCommonsBroadcastsCached: vi.fn(),
+}));
+
+vi.mock('../utils/tauri-errors', () => ({
+  getInvokeErrorMessage: vi.fn((e: unknown, fallback: string) =>
+    typeof e === 'string' && e ? e : fallback
+  ),
+}));
+
+describe('commons-prefetch', () => {
+  const ImageMock = vi.fn(function () {
+    return { src: '' };
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('Image', ImageMock);
+    resetCommonsPrefetchSession();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetCommonsPrefetchSession();
+  });
+
+  function makeDto(): CommonsBroadcastDto {
+    return {
+      eventId: 'evt1',
+      authorNpub: 'npub1author',
+      subject: 'user',
+      subjectId: 'npub1author',
+      message: 'Hello',
+      durationHours: 24,
+      expiresAt: 1_000_000,
+      tags: ['neo'],
+      createdAt: 1,
+    };
+  }
+
+  it('resetCommonsPrefetchSession clears stores and allows another prefetch', async () => {
+    vi.mocked(fetchCommonsBroadcastsCached).mockResolvedValue([]);
+
+    scheduleCommonsStartupPrefetch();
+    await vi.waitFor(() => expect(fetchCommonsBroadcastsCached).toHaveBeenCalledTimes(1));
+
+    resetCommonsPrefetchSession();
+    expect(get(commonsBroadcasts)).toEqual([]);
+    expect(get(commonsFeedError)).toBeNull();
+    expect(get(commonsFeedSyncing)).toBe(false);
+
+    scheduleCommonsStartupPrefetch();
+    await vi.waitFor(() => expect(fetchCommonsBroadcastsCached).toHaveBeenCalledTimes(2));
+  });
+
+  it('scheduleCommonsStartupPrefetch ignores cached prefetch errors', async () => {
+    vi.mocked(fetchCommonsBroadcastsCached).mockRejectedValueOnce(new Error('db locked'));
+
+    scheduleCommonsStartupPrefetch();
+
+    await vi.waitFor(() => expect(fetchCommonsBroadcastsCached).toHaveBeenCalledTimes(1));
+    expect(get(commonsBroadcasts)).toEqual([]);
+  });
+  it('scheduleCommonsStartupPrefetch loads cached broadcasts into the store', async () => {
+    const rows = [makeDto()];
+    vi.mocked(fetchCommonsBroadcastsCached).mockResolvedValue(rows);
+
+    scheduleCommonsStartupPrefetch();
+
+    await vi.waitFor(() => expect(fetchCommonsBroadcastsCached).toHaveBeenCalledTimes(1));
+    expect(get(commonsBroadcasts)).toEqual(rows);
+  });
+
+  it('scheduleCommonsStartupPrefetch is idempotent', async () => {
+    vi.mocked(fetchCommonsBroadcastsCached).mockResolvedValue([]);
+
+    scheduleCommonsStartupPrefetch();
+    scheduleCommonsStartupPrefetch();
+
+    await vi.waitFor(() => expect(fetchCommonsBroadcastsCached).toHaveBeenCalledTimes(1));
+    expect(ImageMock).toHaveBeenCalled();
+  });
+
+  it('refreshCommonsBroadcasts loads rows into the store', async () => {
+    const rows = [makeDto()];
+    vi.mocked(fetchCommonsBroadcasts).mockResolvedValue(rows);
+
+    const result = await refreshCommonsBroadcasts();
+
+    expect(fetchCommonsBroadcasts).toHaveBeenCalledWith(100);
+    expect(result).toEqual(rows);
+    expect(get(commonsBroadcasts)).toEqual(rows);
+    expect(get(commonsFeedSyncing)).toBe(false);
+    expect(get(commonsFeedError)).toBeNull();
+  });
+
+  it('refreshCommonsBroadcasts handles errors and clears the store', async () => {
+    vi.mocked(fetchCommonsBroadcasts).mockRejectedValue('network error');
+
+    const result = await refreshCommonsBroadcasts();
+
+    expect(result).toEqual([]);
+    expect(get(commonsBroadcasts)).toEqual([]);
+    expect(get(commonsFeedError)).toBe('network error');
+    expect(get(commonsFeedSyncing)).toBe(false);
+  });
+
+  it('refreshCommonsBroadcasts in silent mode does not toggle syncing', async () => {
+    const rows = [makeDto()];
+    vi.mocked(fetchCommonsBroadcasts).mockResolvedValue(rows);
+
+    await refreshCommonsBroadcasts({ silent: true });
+
+    expect(get(commonsBroadcasts)).toEqual(rows);
+    expect(get(commonsFeedSyncing)).toBe(false);
+  });
+});

--- a/src/lib/commons/first-broadcast.test.ts
+++ b/src/lib/commons/first-broadcast.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { hasEverBroadcast, markHasEverBroadcast, PACTO_COMMONS_BROADCASTED_PREFIX } from './first-broadcast';
+
+const localStorageStore = new Map<string, string>();
+
+function stubLocalStorage(): void {
+  localStorageStore.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      localStorageStore.set(k, v);
+    },
+    removeItem: (k: string) => {
+      localStorageStore.delete(k);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+  });
+}
+
+describe('first-broadcast localStorage tracking', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false when no marker has been stored', () => {
+    expect(hasEverBroadcast('npub1test')).toBe(false);
+  });
+
+  it('returns true after markHasEverBroadcast', () => {
+    markHasEverBroadcast('npub1test');
+    expect(localStorage.getItem(`${PACTO_COMMONS_BROADCASTED_PREFIX}_npub1test`)).toBe('1');
+    expect(hasEverBroadcast('npub1test')).toBe(true);
+  });
+
+  it('returns false for an empty npub', () => {
+    markHasEverBroadcast('npub1test');
+    expect(hasEverBroadcast('')).toBe(false);
+  });
+
+  it('does not throw when marking an empty npub', () => {
+    expect(() => markHasEverBroadcast('')).not.toThrow();
+  });
+
+  it('is idempotent', () => {
+    markHasEverBroadcast('npub1test');
+    markHasEverBroadcast('npub1test');
+    expect(hasEverBroadcast('npub1test')).toBe(true);
+  });
+
+  it('returns false when localStorage is undefined', () => {
+    vi.unstubAllGlobals();
+    expect(hasEverBroadcast('npub1test')).toBe(false);
+  });
+
+  it('does not throw when localStorage is undefined', () => {
+    vi.unstubAllGlobals();
+    expect(() => markHasEverBroadcast('npub1test')).not.toThrow();
+  });
+
+  it('returns false when localStorage.getItem throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+    });
+    expect(hasEverBroadcast('npub1test')).toBe(false);
+  });
+
+  it('does not throw when localStorage.setItem throws', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota');
+      },
+      removeItem: () => {},
+      clear: () => {},
+    });
+    expect(() => markHasEverBroadcast('npub1test')).not.toThrow();
+  });
+});

--- a/src/lib/commons/local-broadcast-state.test.ts
+++ b/src/lib/commons/local-broadcast-state.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { persistenceKey } from '../../stores/persistence-context';
+import {
+  clearCommonsBroadcastLocalState,
+  getActiveCommonsBroadcastLocalState,
+  localStateFromDto,
+  PACTO_COMMONS_BROADCASTS_PREFIX,
+  recordCommonsBroadcastLocalState,
+} from './local-broadcast-state';
+import type { CommonsBroadcastDto } from './types';
+
+vi.mock('../../stores/persistence-context', () => ({
+  persistenceKey: vi.fn((prefix: string) => `${prefix}_testkey`),
+}));
+
+const localStorageStore = new Map<string, string>();
+
+function stubLocalStorage(): void {
+  localStorageStore.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      localStorageStore.set(k, v);
+    },
+    removeItem: (k: string) => {
+      localStorageStore.delete(k);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+  });
+}
+
+function makeDto(overrides: Partial<CommonsBroadcastDto> = {}): CommonsBroadcastDto {
+  return {
+    eventId: 'evt1',
+    authorNpub: 'npub1author',
+    subject: 'user',
+    subjectId: 'npub1author',
+    message: 'Hello',
+    durationHours: 24,
+    expiresAt: 1_000_000,
+    tags: ['neo'],
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+function storedKey(): string {
+  return `${PACTO_COMMONS_BROADCASTS_PREFIX}_testkey`;
+}
+
+describe('local-broadcast-state', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('localStateFromDto mirrors the DTO fields', () => {
+    const dto = makeDto({ audience: 'active_user' });
+    expect(localStateFromDto(dto)).toEqual({
+      subject: 'user',
+      subjectId: 'npub1author',
+      eventId: 'evt1',
+      expiresAt: 1_000_000,
+      durationHours: 24,
+      tags: ['neo'],
+      message: 'Hello',
+      audience: 'active_user',
+    });
+  });
+
+  it('recordCommonsBroadcastLocalState writes a keyed map to localStorage', () => {
+    const dto = makeDto();
+    recordCommonsBroadcastLocalState(dto);
+
+    const raw = localStorage.getItem(storedKey());
+    expect(raw).toBeTruthy();
+    const map = JSON.parse(raw!);
+    expect(map['user:npub1author']).toEqual(localStateFromDto(dto));
+  });
+
+  it('clearCommonsBroadcastLocalState removes the keyed entry', () => {
+    const dto = makeDto();
+    recordCommonsBroadcastLocalState(dto);
+    clearCommonsBroadcastLocalState('user', 'npub1author');
+
+    const map = JSON.parse(localStorage.getItem(storedKey()) ?? '{}');
+    expect('user:npub1author' in map).toBe(false);
+  });
+
+  it('getActiveCommonsBroadcastLocalState returns the state when not expired', () => {
+    const dto = makeDto({ expiresAt: 2_000_000 });
+    recordCommonsBroadcastLocalState(dto);
+
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1author', 1_000_000)).toEqual(
+      localStateFromDto(dto)
+    );
+  });
+
+  it('getActiveCommonsBroadcastLocalState returns null when expired', () => {
+    const dto = makeDto({ expiresAt: 500_000 });
+    recordCommonsBroadcastLocalState(dto);
+
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1author', 1_000_000)).toBeNull();
+  });
+
+  it('getActiveCommonsBroadcastLocalState returns null when missing', () => {
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1missing', 1)).toBeNull();
+  });
+
+  it('returns null and does not throw when localStorage is undefined', () => {
+    vi.unstubAllGlobals();
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1test', 1)).toBeNull();
+    expect(() => recordCommonsBroadcastLocalState(makeDto())).not.toThrow();
+    expect(() => clearCommonsBroadcastLocalState('user', 'npub1test')).not.toThrow();
+  });
+
+  it('returns null when the persistence key is empty', () => {
+    vi.mocked(persistenceKey).mockReturnValueOnce(null);
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1test', 1)).toBeNull();
+  });
+
+  it('ignores malformed stored JSON', () => {
+    localStorage.setItem(storedKey(), 'not-json');
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1test', 1)).toBeNull();
+  });
+
+  it('ignores non-object stored JSON', () => {
+    localStorage.setItem(storedKey(), JSON.stringify(['array']));
+    expect(getActiveCommonsBroadcastLocalState('user', 'npub1test', 1)).toBeNull();
+  });
+
+  it('does not throw when localStorage setItem fails', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota');
+      },
+      removeItem: () => {},
+      clear: () => {},
+    });
+    expect(() => recordCommonsBroadcastLocalState(makeDto())).not.toThrow();
+  });
+});

--- a/src/lib/commons/squad-broadcast.test.ts
+++ b/src/lib/commons/squad-broadcast.test.ts
@@ -1,13 +1,225 @@
-import { describe, expect, it } from 'vitest';
-import { formatBroadcastCooldownRemaining } from './squad-broadcast';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { getLocalActiveCommonsBroadcast, publishCommonsBroadcast } from '../api/commons';
+import { setCurrentNpubForPersistence } from '../../stores/persistence-context';
+import {
+  fetchActiveSquadCommonsBroadcast,
+  formatBroadcastCooldownRemaining,
+  publishSquadCommonsBroadcast,
+} from './squad-broadcast';
+import { getActiveCommonsBroadcastLocalState, recordCommonsBroadcastLocalState } from './local-broadcast-state';
+import type { CommonsBroadcastDto } from './types';
+
+vi.mock('../api/commons');
+vi.mock('../utils/tauri-errors', () => ({
+  getInvokeErrorMessage: vi.fn((e: unknown, fallback: string) =>
+    typeof e === 'string' && e ? e : fallback
+  ),
+}));
+
+const squadId = 'squad1';
+const nowSecs = Math.floor(Date.now() / 1000);
+
+const localStorageStore = new Map<string, string>();
+
+function stubLocalStorage(): void {
+  localStorageStore.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      localStorageStore.set(k, v);
+    },
+    removeItem: (k: string) => {
+      localStorageStore.delete(k);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+  });
+}
+
+function makeSquad(overrides: { visibility?: 'public' | 'private'; commonsTags?: string[]; kind?: 'squad' | 'squad-pair' } = {}) {
+  return {
+    id: squadId,
+    name: 'Neo Builders',
+    kind: 'squad' as const,
+    visibility: 'public' as const,
+    commonsTags: ['neo'],
+    ...overrides,
+  };
+}
+
+function makeDto(overrides: Partial<CommonsBroadcastDto> = {}): CommonsBroadcastDto {
+  return {
+    eventId: 'evt1',
+    authorNpub: 'npub1author',
+    subject: 'squad',
+    subjectId: squadId,
+    message: 'Hello Commons',
+    durationHours: 24,
+    expiresAt: nowSecs + 3600,
+    tags: ['neo'],
+    createdAt: 1,
+    ...overrides,
+  };
+}
 
 describe('formatBroadcastCooldownRemaining', () => {
   it('formats hours and minutes', () => {
-    expect(formatBroadcastCooldownRemaining(1000, 0)).toBe('16m');
     expect(formatBroadcastCooldownRemaining(7200, 0)).toBe('2h 0m');
+  });
+
+  it('formats minutes only when less than an hour remains', () => {
+    expect(formatBroadcastCooldownRemaining(1000, 0)).toBe('16m');
+  });
+
+  it('returns "under 1m" when less than a minute remains', () => {
+    expect(formatBroadcastCooldownRemaining(59, 0)).toBe('under 1m');
   });
 
   it('returns empty when expired', () => {
     expect(formatBroadcastCooldownRemaining(100, 200)).toBe('');
+  });
+});
+
+describe('fetchActiveSquadCommonsBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence('npub1test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('returns local cache hit without calling the backend', async () => {
+    recordCommonsBroadcastLocalState(makeDto());
+
+    const result = await fetchActiveSquadCommonsBroadcast(squadId);
+
+    expect(result?.message).toBe('Hello Commons');
+    expect(getLocalActiveCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('records and returns a DTO from the backend', async () => {
+    const dto = makeDto();
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(dto);
+
+    const result = await fetchActiveSquadCommonsBroadcast(squadId);
+
+    expect(getLocalActiveCommonsBroadcast).toHaveBeenCalledWith('squad', squadId);
+    expect(result?.eventId).toBe('evt1');
+    expect(getActiveCommonsBroadcastLocalState('squad', squadId, nowSecs)).toEqual(
+      expect.objectContaining({ subjectId: squadId, eventId: 'evt1' })
+    );
+  });
+
+  it('returns null on backend error', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockRejectedValueOnce(new Error('db locked'));
+
+    const result = await fetchActiveSquadCommonsBroadcast(squadId);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('publishSquadCommonsBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence('npub1test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('rejects non-public squads', async () => {
+    const result = await publishSquadCommonsBroadcast(makeSquad({ visibility: 'private' }), {
+      message: 'hello',
+      durationHours: 24,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Only public squads with tags can broadcast.' });
+  });
+
+  it('rejects an empty message', async () => {
+    const result = await publishSquadCommonsBroadcast(makeSquad(), {
+      message: '   ',
+      durationHours: 24,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Message is required.' });
+  });
+
+  it('rejects while an active broadcast is still cached', async () => {
+    recordCommonsBroadcastLocalState(makeDto());
+
+    const result = await publishSquadCommonsBroadcast(makeSquad(), {
+      message: 'hello',
+      durationHours: 24,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'A broadcast is still active for this squad.' });
+  });
+
+  it('skips publishing when skipIfActive is set', async () => {
+    recordCommonsBroadcastLocalState(makeDto());
+
+    const result = await publishSquadCommonsBroadcast(makeSquad(), {
+      message: 'hello',
+      durationHours: 24,
+      skipIfActive: true,
+    });
+
+    expect(result).toEqual({ ok: true, skipped: true });
+    expect(publishCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('publishes a public squad broadcast with tags and squad metadata', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(null);
+    const dto = makeDto({ tags: ['neo', 'new'] });
+    vi.mocked(publishCommonsBroadcast).mockResolvedValueOnce(dto);
+
+    const result = await publishSquadCommonsBroadcast(
+      makeSquad({ commonsTags: ['neo'] }),
+      {
+        message: 'hello',
+        durationHours: 72,
+        extraTags: ['new'],
+      }
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCommonsBroadcast).toHaveBeenCalledWith({
+      subject: 'squad',
+      message: 'hello',
+      durationHours: 72,
+      tags: ['neo', 'new'],
+      squad: {
+        id: squadId,
+        name: 'Neo Builders',
+        kind: 'squad',
+        iconUrl: undefined,
+      },
+    });
+    expect(getActiveCommonsBroadcastLocalState('squad', squadId, nowSecs)).toEqual(
+      expect.objectContaining({ tags: ['neo', 'new'] })
+    );
+  });
+
+  it('returns an error when publishing fails', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(null);
+    vi.mocked(publishCommonsBroadcast).mockRejectedValueOnce('pub failed');
+
+    const result = await publishSquadCommonsBroadcast(makeSquad(), {
+      message: 'hello',
+      durationHours: 24,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'pub failed' });
+    expect(getActiveCommonsBroadcastLocalState('squad', squadId, nowSecs)).toBeNull();
   });
 });

--- a/src/lib/commons/squad-create-broadcast.test.ts
+++ b/src/lib/commons/squad-create-broadcast.test.ts
@@ -1,8 +1,74 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { publishCommonsBroadcast } from '../api/commons';
+import { showToast } from '../../stores/toast';
+import { setCurrentNpubForPersistence } from '../../stores/persistence-context';
 import {
   defaultPublicSquadBroadcastMessage,
   isPublicSquadForCommonsBroadcast,
+  publishPublicSquadCreateBroadcast,
+  schedulePublicSquadCreateBroadcast,
 } from './squad-create-broadcast';
+import { COMMONS_NEW_TAG } from './tags';
+import { getActiveCommonsBroadcastLocalState } from './local-broadcast-state';
+import type { CommonsBroadcastDto } from './types';
+import type { PublicSquadBroadcastTarget } from './squad-create-broadcast';
+
+vi.mock('../api/commons');
+vi.mock('../utils/tauri-errors', () => ({
+  getInvokeErrorMessage: vi.fn((e: unknown, fallback: string) =>
+    typeof e === 'string' && e ? e : fallback
+  ),
+}));
+vi.mock('../../stores/toast', () => ({
+  showToast: vi.fn(),
+}));
+
+const squadId = 'squad1';
+const nowSecs = Math.floor(Date.now() / 1000);
+
+const localStorageStore = new Map<string, string>();
+
+function stubLocalStorage(): void {
+  localStorageStore.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      localStorageStore.set(k, v);
+    },
+    removeItem: (k: string) => {
+      localStorageStore.delete(k);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+  });
+}
+
+function makeSquad(overrides: Partial<PublicSquadBroadcastTarget> = {}): PublicSquadBroadcastTarget {
+  return {
+    id: squadId,
+    name: 'Neo Builders',
+    kind: 'squad',
+    visibility: 'public',
+    commonsTags: ['neo'],
+    ...overrides,
+  };
+}
+
+function makeDto(overrides: Partial<CommonsBroadcastDto> = {}): CommonsBroadcastDto {
+  return {
+    eventId: 'evt1',
+    authorNpub: 'npub1author',
+    subject: 'squad',
+    subjectId: squadId,
+    message: 'New squad: Neo Builders',
+    durationHours: 72,
+    expiresAt: nowSecs + 3600 * 72,
+    tags: ['neo', COMMONS_NEW_TAG],
+    createdAt: 1,
+    ...overrides,
+  };
+}
 
 describe('isPublicSquadForCommonsBroadcast', () => {
   it('requires public visibility and tags', () => {
@@ -38,5 +104,129 @@ describe('isPublicSquadForCommonsBroadcast', () => {
 describe('defaultPublicSquadBroadcastMessage', () => {
   it('uses squad name in default copy', () => {
     expect(defaultPublicSquadBroadcastMessage('Neo Builders')).toBe('New squad: Neo Builders');
+  });
+});
+
+describe('publishPublicSquadCreateBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence('npub1test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('returns ok for non-public squads without publishing', async () => {
+    const result = await publishPublicSquadCreateBroadcast(makeSquad({ visibility: 'private' }));
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('publishes a public squad broadcast with the default message and #new tag', async () => {
+    vi.mocked(publishCommonsBroadcast).mockResolvedValueOnce(makeDto());
+
+    const result = await publishPublicSquadCreateBroadcast(makeSquad());
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCommonsBroadcast).toHaveBeenCalledWith({
+      subject: 'squad',
+      message: 'New squad: Neo Builders',
+      durationHours: 72,
+      tags: ['neo', COMMONS_NEW_TAG],
+      squad: {
+        id: squadId,
+        name: 'Neo Builders',
+        kind: 'squad',
+        iconUrl: undefined,
+      },
+    });
+    expect(getActiveCommonsBroadcastLocalState('squad', squadId, nowSecs)).toEqual(
+      expect.objectContaining({ tags: ['neo', COMMONS_NEW_TAG] })
+    );
+  });
+
+  it('returns an error when the broadcast fails', async () => {
+    vi.mocked(publishCommonsBroadcast).mockRejectedValueOnce('pub failed');
+
+    const result = await publishPublicSquadCreateBroadcast(makeSquad());
+
+    expect(result).toEqual({ ok: false, error: 'pub failed' });
+    expect(getActiveCommonsBroadcastLocalState('squad', squadId, nowSecs)).toBeNull();
+  });
+});
+
+describe('schedulePublicSquadCreateBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence('npub1test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('does nothing when the resolved squad id does not match', async () => {
+    schedulePublicSquadCreateBroadcast('other', () => makeSquad());
+    await vi.waitFor(() => expect(publishCommonsBroadcast).not.toHaveBeenCalled());
+    await vi.waitFor(() => expect(showToast).not.toHaveBeenCalled());
+  });
+
+  it('does nothing for non-public squads', async () => {
+    schedulePublicSquadCreateBroadcast(squadId, () => makeSquad({ visibility: 'private' }));
+    await vi.waitFor(() => expect(publishCommonsBroadcast).not.toHaveBeenCalled());
+    await vi.waitFor(() => expect(showToast).not.toHaveBeenCalled());
+  });
+
+  it('publishes for a public squad', async () => {
+    vi.mocked(publishCommonsBroadcast).mockResolvedValueOnce(makeDto());
+
+    schedulePublicSquadCreateBroadcast(squadId, () => makeSquad());
+
+    await vi.waitFor(() =>
+      expect(publishCommonsBroadcast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: 'squad',
+          message: 'New squad: Neo Builders',
+          durationHours: 72,
+          tags: ['neo', COMMONS_NEW_TAG],
+        })
+      )
+    );
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('shows a retry toast when the broadcast fails', async () => {
+    vi.mocked(publishCommonsBroadcast).mockRejectedValueOnce('pub failed');
+
+    schedulePublicSquadCreateBroadcast(squadId, () => makeSquad());
+
+    await vi.waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining('Commons broadcast failed for Neo Builders'),
+        undefined,
+        expect.objectContaining({ label: 'Retry broadcast' })
+      )
+    );
+  });
+
+  it('retry action republishes the broadcast', async () => {
+    vi.mocked(publishCommonsBroadcast)
+      .mockRejectedValueOnce('pub failed')
+      .mockResolvedValueOnce(makeDto());
+
+    schedulePublicSquadCreateBroadcast(squadId, () => makeSquad());
+
+    await vi.waitFor(() => expect(showToast).toHaveBeenCalled());
+    const retry = vi.mocked(showToast).mock.calls[0][2];
+    expect(retry).toBeDefined();
+    retry!.action();
+
+    await vi.waitFor(() => expect(publishCommonsBroadcast).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/lib/commons/types.ts
+++ b/src/lib/commons/types.ts
@@ -3,6 +3,7 @@ import type { CommonsBroadcastDurationHours } from './broadcast-duration';
 export type CommonsBroadcastSubject = 'user' | 'squad';
 
 export type { CommonsBroadcastDurationHours } from './broadcast-duration';
+import type { CommonsBroadcastDurationHours } from './broadcast-duration';
 
 export type CommonsBroadcastAudience = 'new_user' | 'active_user';
 

--- a/src/lib/commons/user-broadcast.test.ts
+++ b/src/lib/commons/user-broadcast.test.ts
@@ -1,5 +1,68 @@
-import { describe, expect, it } from 'vitest';
-import { commonsAudienceForFirstBroadcast } from './user-broadcast';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  cancelCommonsBroadcast,
+  getLocalActiveCommonsBroadcast,
+  publishCommonsBroadcast,
+} from '../api/commons';
+import { getInvokeErrorMessage } from '../utils/tauri-errors';
+import { setCurrentNpubForPersistence } from '../../stores/persistence-context';
+import {
+  cancelUserCommonsBroadcast,
+  commonsAudienceForFirstBroadcast,
+  fetchActiveUserCommonsBroadcast,
+  publishUserCommonsBroadcast,
+} from './user-broadcast';
+import { COMMONS_NEW_TAG } from './tags';
+import { PACTO_COMMONS_BROADCASTED_PREFIX } from './first-broadcast';
+import {
+  getActiveCommonsBroadcastLocalState,
+  PACTO_COMMONS_BROADCASTS_PREFIX,
+  recordCommonsBroadcastLocalState,
+} from './local-broadcast-state';
+import type { CommonsBroadcastDto } from './types';
+
+const localStorageStore = new Map<string, string>();
+
+function stubLocalStorage(): void {
+  localStorageStore.clear();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => localStorageStore.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      localStorageStore.set(k, v);
+    },
+    removeItem: (k: string) => {
+      localStorageStore.delete(k);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+  });
+}
+
+vi.mock('../api/commons');
+vi.mock('../utils/tauri-errors', () => ({
+  getInvokeErrorMessage: vi.fn((e: unknown, fallback: string) =>
+    typeof e === 'string' && e ? e : fallback
+  ),
+}));
+
+const npub = 'npub1user';
+const nowSecs = Math.floor(Date.now() / 1000);
+
+function makeDto(overrides: Partial<CommonsBroadcastDto> = {}): CommonsBroadcastDto {
+  return {
+    eventId: 'evt1',
+    authorNpub: npub,
+    subject: 'user',
+    subjectId: npub,
+    message: 'Hello Commons',
+    durationHours: 24,
+    expiresAt: nowSecs + 3600,
+    tags: ['neo'],
+    createdAt: 1,
+    ...overrides,
+  };
+}
 
 describe('commonsAudienceForFirstBroadcast', () => {
   it('treats the first broadcast ever as a new user', () => {
@@ -8,5 +71,210 @@ describe('commonsAudienceForFirstBroadcast', () => {
 
   it('treats any later broadcast as an active user', () => {
     expect(commonsAudienceForFirstBroadcast(false)).toBe('active_user');
+  });
+});
+
+describe('fetchActiveUserCommonsBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence(npub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('returns local cache hit without calling the backend', async () => {
+    const dto = makeDto();
+    recordCommonsBroadcastLocalState(dto);
+
+    const result = await fetchActiveUserCommonsBroadcast(npub);
+
+    expect(result?.message).toBe('Hello Commons');
+    expect(getLocalActiveCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('records and returns a DTO from the backend', async () => {
+    const dto = makeDto();
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(dto);
+
+    const result = await fetchActiveUserCommonsBroadcast(npub);
+
+    expect(getLocalActiveCommonsBroadcast).toHaveBeenCalledWith('user', npub);
+    expect(result?.eventId).toBe('evt1');
+    expect(getActiveCommonsBroadcastLocalState('user', npub, nowSecs)).toEqual(
+      expect.objectContaining({ subjectId: npub, eventId: 'evt1' })
+    );
+  });
+
+  it('returns null on backend error', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockRejectedValueOnce(new Error('db locked'));
+
+    const result = await fetchActiveUserCommonsBroadcast(npub);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('cancelUserCommonsBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence(npub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('clears local state on success', async () => {
+    recordCommonsBroadcastLocalState(makeDto());
+    vi.mocked(cancelCommonsBroadcast).mockResolvedValueOnce(undefined);
+
+    const result = await cancelUserCommonsBroadcast(npub);
+
+    expect(result).toEqual({ ok: true });
+    expect(cancelCommonsBroadcast).toHaveBeenCalledWith('user', npub);
+    expect(getActiveCommonsBroadcastLocalState('user', npub, nowSecs)).toBeNull();
+  });
+
+  it('returns an error when the backend fails', async () => {
+    vi.mocked(cancelCommonsBroadcast).mockRejectedValueOnce('cancel failed');
+
+    const result = await cancelUserCommonsBroadcast(npub);
+
+    expect(result).toEqual({ ok: false, error: 'cancel failed' });
+    expect(getInvokeErrorMessage).toHaveBeenCalled();
+  });
+});
+
+describe('publishUserCommonsBroadcast', () => {
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence(npub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+  beforeEach(() => {
+    stubLocalStorage();
+    setCurrentNpubForPersistence(npub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    setCurrentNpubForPersistence(null);
+  });
+
+  it('rejects an empty message', async () => {
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: '   ',
+      durationHours: 24,
+      tags: ['neo'],
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Message is required.' });
+  });
+
+  it('rejects when no tags are provided', async () => {
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: 'hello',
+      durationHours: 24,
+      tags: [],
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Add at least one tag.' });
+  });
+
+  it('blocks while an active broadcast is still cached', async () => {
+    recordCommonsBroadcastLocalState(makeDto());
+
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: 'hello',
+      durationHours: 24,
+      tags: ['neo'],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'A broadcast is still active. Wait until it expires.',
+    });
+    expect(publishCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('publishes a first-ever broadcast as a new user with the #new tag', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(null);
+    const dto = makeDto({ tags: ['neo', COMMONS_NEW_TAG], audience: 'new_user' });
+    vi.mocked(publishCommonsBroadcast).mockResolvedValueOnce(dto);
+
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: 'hello',
+      durationHours: 24,
+      tags: ['neo'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCommonsBroadcast).toHaveBeenCalledWith({
+      subject: 'user',
+      message: 'hello',
+      durationHours: 24,
+      tags: ['neo', COMMONS_NEW_TAG],
+      audience: 'new_user',
+    });
+    expect(localStorage.getItem(`${PACTO_COMMONS_BROADCASTED_PREFIX}_${npub}`)).toBe('1');
+    expect(getActiveCommonsBroadcastLocalState('user', npub, nowSecs)).toEqual(
+      expect.objectContaining({ tags: ['neo', COMMONS_NEW_TAG], audience: 'new_user' })
+    );
+  });
+
+  it('publishes later broadcasts as active users without the #new tag', async () => {
+    localStorage.setItem(`${PACTO_COMMONS_BROADCASTED_PREFIX}_${npub}`, '1');
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(null);
+    const dto = makeDto({ audience: 'active_user' });
+    vi.mocked(publishCommonsBroadcast).mockResolvedValueOnce(dto);
+
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: 'hello again',
+      durationHours: 48,
+      tags: ['neo'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(publishCommonsBroadcast).toHaveBeenCalledWith({
+      subject: 'user',
+      message: 'hello again',
+      durationHours: 48,
+      tags: ['neo'],
+      audience: 'active_user',
+    });
+    expect(localStorage.getItem(`${PACTO_COMMONS_BROADCASTS_PREFIX}_${npub}`)).toBeTruthy();
+  });
+
+  it('returns an error when publishing fails', async () => {
+    vi.mocked(getLocalActiveCommonsBroadcast).mockResolvedValueOnce(null);
+    vi.mocked(publishCommonsBroadcast).mockRejectedValueOnce('pub failed');
+
+    const result = await publishUserCommonsBroadcast({
+      npub,
+      message: 'hello',
+      durationHours: 24,
+      tags: ['neo'],
+    });
+
+    expect(result).toEqual({ ok: false, error: 'pub failed' });
+    expect(localStorage.getItem(`${PACTO_COMMONS_BROADCASTS_PREFIX}_${npub}`)).toBeNull();
+    expect(localStorage.getItem(`${PACTO_COMMONS_BROADCASTED_PREFIX}_${npub}`)).toBeNull();
   });
 });

--- a/src/lib/dashboard/batch-safe-state-refresh.test.ts
+++ b/src/lib/dashboard/batch-safe-state-refresh.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TreasurySafeEntry } from '../treasury/treasury-safes';
+import { refreshSafeStateForTreasuryEntry } from '../../stores/safe';
+import { refreshAllSafeStates } from './batch-safe-state-refresh';
+
+vi.mock('../../stores/safe');
+
+const mockedRefresh = vi.mocked(refreshSafeStateForTreasuryEntry);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const entries: TreasurySafeEntry[] = [
+  {
+    id: 'entry-1',
+    parentId: 'parent-1',
+    safeAddress: '0xAAA',
+    chain: 'sepolia',
+    label: 'Vault A',
+    createdAtMs: 1,
+  },
+  {
+    id: 'entry-2',
+    parentId: 'parent-1',
+    safeAddress: '0xBBB',
+    chain: 'sepolia',
+    label: 'Vault B',
+    createdAtMs: 2,
+  },
+];
+
+describe('refreshAllSafeStates', () => {
+  it('returns early when entries is empty', async () => {
+    await refreshAllSafeStates([]);
+    expect(mockedRefresh).not.toHaveBeenCalled();
+  });
+
+  it('calls refreshSafeStateForTreasuryEntry for each entry', async () => {
+    await refreshAllSafeStates(entries);
+
+    expect(mockedRefresh).toHaveBeenCalledTimes(2);
+    expect(mockedRefresh).toHaveBeenNthCalledWith(1, entries[0], undefined);
+    expect(mockedRefresh).toHaveBeenNthCalledWith(2, entries[1], undefined);
+  });
+
+  it('forwards options to each refresh call', async () => {
+    await refreshAllSafeStates(entries, { force: true });
+
+    expect(mockedRefresh).toHaveBeenCalledTimes(2);
+    expect(mockedRefresh).toHaveBeenNthCalledWith(1, entries[0], { force: true });
+    expect(mockedRefresh).toHaveBeenNthCalledWith(2, entries[1], { force: true });
+  });
+});

--- a/src/lib/dashboard/dashboard-data-sync.test.ts
+++ b/src/lib/dashboard/dashboard-data-sync.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { currentUser } from '../../stores/auth';
+import {
+  squadMemberEvmByParentId,
+  treasurySafesByParentId,
+  squadInfraByParentId,
+  type TreasurySafeEntry,
+} from '../../stores/squads';
+import {
+  treasurySafesFetchMetaByParentId,
+  squadInfraFetchMetaByParentId,
+  clearDashboardFetchMetaStores,
+} from './dashboard-fetch-meta';
+import { listParentTreasurySafes } from '../api/nostr';
+import { listSquadInfra } from '../governance/api';
+import { fetchSquadMemberEvmByNpub } from './parent-dashboard-loaders';
+import {
+  syncTreasurySafesForParent,
+  syncSquadInfraForParent,
+  syncSquadMemberEvmForParent,
+  resetDashboardDataSyncInflight,
+} from './dashboard-data-sync';
+import { TREASURY_SAFES_CACHE_PREFIX } from './treasury-safes-cache';
+import { SQUAD_INFRA_CACHE_PREFIX } from './squad-infra-cache';
+import { SQUAD_MEMBER_EVM_CACHE_PREFIX } from './squad-member-evm-cache';
+import type { SquadInfraDto } from '../governance/api';
+
+vi.mock('../api/nostr');
+vi.mock('../governance/api');
+vi.mock('./parent-dashboard-loaders');
+
+const mockedListParentTreasurySafes = vi.mocked(listParentTreasurySafes);
+const mockedListSquadInfra = vi.mocked(listSquadInfra);
+const mockedFetchSquadMemberEvmByNpub = vi.mocked(fetchSquadMemberEvmByNpub);
+
+const npub = 'npub1testdashboardsyncxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+const parentId = 'parent-1';
+
+let storage: Map<string, string>;
+
+function mockStorage() {
+  storage = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      storage.set(k, v);
+    },
+    removeItem: (k: string) => {
+      storage.delete(k);
+    },
+    clear: () => storage.clear(),
+    key: (i: number) => [...storage.keys()][i] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage);
+}
+
+beforeEach(() => {
+  mockStorage();
+  vi.clearAllMocks();
+  currentUser.set({ npub, pubkey: '0000' });
+});
+
+afterEach(() => {
+  currentUser.set(null);
+  treasurySafesByParentId.set({});
+  squadInfraByParentId.set({});
+  squadMemberEvmByParentId.set({});
+  clearDashboardFetchMetaStores();
+  vi.unstubAllGlobals();
+});
+
+const treasuryRows: TreasurySafeEntry[] = [
+  {
+    id: 't1',
+    parentId,
+    safeAddress: '0xSafe1',
+    chain: 'sepolia',
+    label: 'Main',
+    createdAtMs: 1,
+  },
+];
+
+const infraRows: SquadInfraDto[] = [
+  {
+    id: 'infra-1',
+    parentId,
+    infraType: 'pacto_gov',
+    chain: 'sepolia',
+    canonicalRef: '0xRef',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  },
+];
+
+const evmMap: Record<string, string> = { npub1: '0xABC' };
+
+describe('syncTreasurySafesForParent', () => {
+  it('returns early when parentId is empty', async () => {
+    await syncTreasurySafesForParent('');
+    expect(mockedListParentTreasurySafes).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent calls', async () => {
+    let resolve!: (value: TreasurySafeEntry[]) => void;
+    const promise = new Promise<TreasurySafeEntry[]>((r) => {
+      resolve = r;
+    });
+    mockedListParentTreasurySafes.mockReturnValueOnce(promise);
+
+    const a = syncTreasurySafesForParent(parentId);
+    const b = syncTreasurySafesForParent(parentId);
+
+    expect(mockedListParentTreasurySafes).toHaveBeenCalledTimes(1);
+    resolve(treasuryRows);
+    await Promise.all([a, b]);
+
+    expect(get(treasurySafesByParentId)[parentId]).toEqual(treasuryRows);
+  });
+
+  it('updates the store and persists cache when the user is logged in', async () => {
+    mockedListParentTreasurySafes.mockResolvedValueOnce(treasuryRows);
+
+    await syncTreasurySafesForParent(parentId);
+
+    expect(get(treasurySafesByParentId)[parentId]).toEqual(treasuryRows);
+    const raw = storage.get(`${TREASURY_SAFES_CACHE_PREFIX}_${npub}`);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.byParentId[parentId]).toEqual(treasuryRows);
+  });
+
+  it('sets loading and final fetch meta', async () => {
+    mockedListParentTreasurySafes.mockResolvedValueOnce(treasuryRows);
+
+    const loadingPromise = syncTreasurySafesForParent(parentId);
+    expect(get(treasurySafesFetchMetaByParentId)[parentId]?.loading).toBe(true);
+    await loadingPromise;
+
+    const meta = get(treasurySafesFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBeNull();
+    expect(typeof meta.fetchedAtMs).toBe('number');
+  });
+
+  it('sets error meta when the fetch fails', async () => {
+    mockedListParentTreasurySafes.mockRejectedValueOnce(new Error('fetch failed'));
+
+    await syncTreasurySafesForParent(parentId);
+
+    const meta = get(treasurySafesFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBe('fetch failed');
+  });
+
+  it('sets error meta without cache timestamp when the user is not logged in', async () => {
+    currentUser.set(null);
+    mockedListParentTreasurySafes.mockRejectedValueOnce(new Error('auth failed'));
+
+    await syncTreasurySafesForParent(parentId);
+
+    const meta = get(treasurySafesFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBe('auth failed');
+    expect(meta.fetchedAtMs).toBeNull();
+  });
+
+  it('does not persist cache when the user is not logged in', async () => {
+    currentUser.set(null);
+    mockedListParentTreasurySafes.mockResolvedValueOnce(treasuryRows);
+
+    await syncTreasurySafesForParent(parentId);
+
+    expect(get(treasurySafesByParentId)[parentId]).toEqual(treasuryRows);
+    expect(storage.get(`${TREASURY_SAFES_CACHE_PREFIX}_${npub}`)).toBeUndefined();
+    const meta = get(treasurySafesFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(typeof meta.fetchedAtMs).toBe('number');
+  });
+});
+
+describe('syncSquadInfraForParent', () => {
+  it('returns early when parentId is empty', async () => {
+    await syncSquadInfraForParent('');
+    expect(mockedListSquadInfra).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent calls', async () => {
+    let resolve!: (value: SquadInfraDto[]) => void;
+    const promise = new Promise<SquadInfraDto[]>((r) => {
+      resolve = r;
+    });
+    mockedListSquadInfra.mockReturnValueOnce(promise);
+
+    const a = syncSquadInfraForParent(parentId);
+    const b = syncSquadInfraForParent(parentId);
+
+    expect(mockedListSquadInfra).toHaveBeenCalledTimes(1);
+    resolve(infraRows);
+    await Promise.all([a, b]);
+
+    expect(get(squadInfraByParentId)[parentId]).toEqual(infraRows);
+  });
+
+  it('updates the store and persists cache when the user is logged in', async () => {
+    mockedListSquadInfra.mockResolvedValueOnce(infraRows);
+
+    await syncSquadInfraForParent(parentId);
+
+    expect(get(squadInfraByParentId)[parentId]).toEqual(infraRows);
+    const raw = storage.get(`${SQUAD_INFRA_CACHE_PREFIX}_${npub}`);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.byParentId[parentId]).toEqual(infraRows);
+  });
+
+  it('sets loading and final fetch meta', async () => {
+    mockedListSquadInfra.mockResolvedValueOnce(infraRows);
+
+    const loadingPromise = syncSquadInfraForParent(parentId);
+    expect(get(squadInfraFetchMetaByParentId)[parentId]?.loading).toBe(true);
+    await loadingPromise;
+
+    const meta = get(squadInfraFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBeNull();
+    expect(typeof meta.fetchedAtMs).toBe('number');
+  });
+
+  it('does not persist cache when the user is not logged in', async () => {
+    currentUser.set(null);
+    mockedListSquadInfra.mockResolvedValueOnce(infraRows);
+
+    await syncSquadInfraForParent(parentId);
+
+    expect(get(squadInfraByParentId)[parentId]).toEqual(infraRows);
+    expect(storage.get(`${SQUAD_INFRA_CACHE_PREFIX}_${npub}`)).toBeUndefined();
+    const meta = get(squadInfraFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(typeof meta.fetchedAtMs).toBe('number');
+  });
+
+  it('sets error meta when the fetch fails', async () => {
+    mockedListSquadInfra.mockRejectedValueOnce(new Error('infra failed'));
+
+    await syncSquadInfraForParent(parentId);
+
+    const meta = get(squadInfraFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBe('infra failed');
+  });
+
+  it('sets error meta without cache timestamp when the user is not logged in', async () => {
+    currentUser.set(null);
+    mockedListSquadInfra.mockRejectedValueOnce(new Error('auth failed'));
+
+    await syncSquadInfraForParent(parentId);
+
+    const meta = get(squadInfraFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBe('auth failed');
+    expect(meta.fetchedAtMs).toBeNull();
+  });
+});
+
+describe('syncSquadMemberEvmForParent', () => {
+  it('returns early when parentId is empty', async () => {
+    await syncSquadMemberEvmForParent('', null);
+    expect(mockedFetchSquadMemberEvmByNpub).not.toHaveBeenCalled();
+  });
+
+  it('dedupes concurrent calls', async () => {
+    let resolve!: (value: Record<string, string>) => void;
+    const promise = new Promise<Record<string, string>>((r) => {
+      resolve = r;
+    });
+    mockedFetchSquadMemberEvmByNpub.mockReturnValueOnce(promise);
+
+    const a = syncSquadMemberEvmForParent(parentId, 'group-1');
+    const b = syncSquadMemberEvmForParent(parentId, 'group-1');
+
+    expect(mockedFetchSquadMemberEvmByNpub).toHaveBeenCalledTimes(1);
+    resolve(evmMap);
+    await Promise.all([a, b]);
+
+    expect(get(squadMemberEvmByParentId)[parentId]).toEqual(evmMap);
+  });
+
+  it('updates the store and persists cache', async () => {
+    mockedFetchSquadMemberEvmByNpub.mockResolvedValueOnce(evmMap);
+
+    await syncSquadMemberEvmForParent(parentId, 'group-1');
+
+    expect(mockedFetchSquadMemberEvmByNpub).toHaveBeenCalledWith(parentId, 'group-1');
+    expect(get(squadMemberEvmByParentId)[parentId]).toEqual(evmMap);
+    const raw = storage.get(`${SQUAD_MEMBER_EVM_CACHE_PREFIX}_${npub}`);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.byParentId[parentId]).toEqual([evmMap]);
+  });
+});
+
+describe('resetDashboardDataSyncInflight', () => {
+  it('clears in-flight maps so a new call fetches again', async () => {
+    let resolve!: (value: TreasurySafeEntry[]) => void;
+    const promise = new Promise<TreasurySafeEntry[]>((r) => {
+      resolve = r;
+    });
+    mockedListParentTreasurySafes.mockReturnValueOnce(promise);
+
+    const a = syncTreasurySafesForParent(parentId);
+    resetDashboardDataSyncInflight();
+    resolve([]);
+    await a;
+
+    mockedListParentTreasurySafes.mockResolvedValueOnce([]);
+    await syncTreasurySafesForParent(parentId);
+    expect(mockedListParentTreasurySafes).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/dashboard/governance-snapshot-cache.test.ts
+++ b/src/lib/dashboard/governance-snapshot-cache.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  GOVERNANCE_SNAPSHOT_CACHE_PREFIX,
+  clearGovernanceSnapshotCacheStore,
+  getCachedHatsTree,
+  getCachedTreasuryProposals,
+  governanceSnapshotHydrated,
+  hydrateGovernanceSnapshotCacheFromDisk,
+  persistHatsTreeSnapshot,
+  persistTreasuryProposalsSnapshot,
+} from './governance-snapshot-cache';
+import type { HatTreeNodeDto, TreasuryProposalDto } from '../governance/api';
+
+describe('governance-snapshot-cache', () => {
+  const npub = 'npub1testgovernancesnapshot';
+  const key = 'test-key';
+
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    governanceSnapshotHydrated.set(null);
+  });
+
+  function proposal(id: string): TreasuryProposalDto {
+    return {
+      proposalId: id,
+      proposer: '0xabc',
+      to: '0xdef',
+      valueWei: '0',
+      operation: '0',
+      dataHex: '0x',
+      deadline: 1,
+      snapshot: 1,
+      yeas: 0,
+      nays: 0,
+      captainApproved: false,
+      captainDefeated: false,
+      executed: false,
+      status: 'active',
+    };
+  }
+
+  function hatTree(): HatTreeNodeDto {
+    return {
+      hatId: '0x1',
+      details: 'Top',
+      maxSupply: 1,
+      supply: 1,
+      active: true,
+      children: [],
+    };
+  }
+
+  it('hydrates treasury proposals into the store', () => {
+    const proposals = [proposal('p1')];
+    persistTreasuryProposalsSnapshot(npub, key, proposals);
+    governanceSnapshotHydrated.set(null);
+
+    hydrateGovernanceSnapshotCacheFromDisk(npub);
+
+    const h = get(governanceSnapshotHydrated);
+    expect(h?.npub).toBe(npub);
+    expect(h?.treasuryProposalsByKey[key]?.proposals).toEqual(proposals);
+    expect(getCachedTreasuryProposals(npub, key)?.proposals).toEqual(proposals);
+  });
+
+  it('hydrates hats tree into the store', () => {
+    const tree = hatTree();
+    persistHatsTreeSnapshot(npub, key, tree);
+    governanceSnapshotHydrated.set(null);
+
+    hydrateGovernanceSnapshotCacheFromDisk(npub);
+
+    const h = get(governanceSnapshotHydrated);
+    expect(h?.hatsTreeByKey[key]?.tree).toEqual(tree);
+    expect(getCachedHatsTree(npub, key)?.tree).toEqual(tree);
+  });
+
+  it('persists a null hats tree and treats it as a valid snapshot', () => {
+    persistHatsTreeSnapshot(npub, key, null);
+    expect(getCachedHatsTree(npub, key)?.tree).toBeNull();
+  });
+
+  it('clearGovernanceSnapshotCacheStore resets the hydrated store', () => {
+    persistTreasuryProposalsSnapshot(npub, key, [proposal('p1')]);
+    expect(get(governanceSnapshotHydrated)).not.toBeNull();
+    clearGovernanceSnapshotCacheStore();
+    expect(get(governanceSnapshotHydrated)).toBeNull();
+  });
+
+  it('returns null for a mismatched treasury proposal key', () => {
+    persistTreasuryProposalsSnapshot(npub, key, [proposal('p1')]);
+    expect(getCachedTreasuryProposals(npub, 'wrong-key')).toBeNull();
+  });
+
+  it('returns null for a mismatched hats tree key', () => {
+    persistHatsTreeSnapshot(npub, key, hatTree());
+    expect(getCachedHatsTree(npub, 'wrong-key')).toBeNull();
+  });
+
+  it('validates treasury proposals and rejects malformed snapshots', () => {
+    const good = proposal('p1');
+    store.set(
+      `${GOVERNANCE_SNAPSHOT_CACHE_PREFIX}_${npub}`,
+      JSON.stringify({
+        version: 1,
+        treasuryProposalsByKey: {
+          [key]: {
+            proposals: [good, { ...good, status: 123 }],
+            fetchedAtMs: 1,
+          },
+        },
+        hatsTreeByKey: {},
+      }),
+    );
+
+    expect(getCachedTreasuryProposals(npub, key)).toBeNull();
+  });
+
+  it('validates hats tree snapshots and rejects malformed entries', () => {
+    store.set(
+      `${GOVERNANCE_SNAPSHOT_CACHE_PREFIX}_${npub}`,
+      JSON.stringify({
+        version: 1,
+        treasuryProposalsByKey: {},
+        hatsTreeByKey: {
+          [key]: {
+            tree: { hatId: 'ok', children: 'not-an-array' },
+            fetchedAtMs: 1,
+          },
+        },
+      }),
+    );
+
+    expect(getCachedHatsTree(npub, key)).toBeNull();
+  });
+});

--- a/src/lib/dashboard/parent-dashboard-loaders.test.ts
+++ b/src/lib/dashboard/parent-dashboard-loaders.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  fetchSquadMemberEvmByNpub,
+  fetchDashboardChannelMembers,
+  fetchTreasuryProposalVoteMap,
+  fetchTreasuryProposals,
+  fetchHatsTree,
+  fetchSettingsChainMemberMaps,
+} from './parent-dashboard-loaders';
+import { getMlsGroupMembers, type MlsGroupMembers } from '../api/nostr';
+import {
+  getHatsTree,
+  getMemberHatWearers,
+  getNavePirataDeployment,
+  getSquadAdminExecutorRoles,
+  listTreasuryProposals,
+  treasuryProposalHasVoted,
+} from '../governance/api';
+import { withReadPlaneLimit } from '../evm/read-plane-limiter';
+import type { TreasuryProposalDto } from '../governance/api';
+
+vi.mock('@tauri-apps/api/core');
+vi.mock('../api/nostr');
+vi.mock('../governance/api');
+vi.mock('../evm/read-plane-limiter', () => ({
+  withReadPlaneLimit: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedGetMlsGroupMembers = vi.mocked(getMlsGroupMembers);
+const mockedListTreasuryProposals = vi.mocked(listTreasuryProposals);
+const mockedTreasuryProposalHasVoted = vi.mocked(treasuryProposalHasVoted);
+const mockedGetHatsTree = vi.mocked(getHatsTree);
+const mockedGetNavePirataDeployment = vi.mocked(getNavePirataDeployment);
+const mockedGetMemberHatWearers = vi.mocked(getMemberHatWearers);
+const mockedGetSquadAdminExecutorRoles = vi.mocked(getSquadAdminExecutorRoles);
+const mockedWithReadPlaneLimit = vi.mocked(withReadPlaneLimit);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const baseProposal: TreasuryProposalDto = {
+  proposalId: '1',
+  proposer: '0x1',
+  to: '0x2',
+  valueWei: '0',
+  operation: '0',
+  dataHex: '0x',
+  deadline: 1,
+  snapshot: 1,
+  yeas: 1,
+  nays: 0,
+  captainApproved: false,
+  captainDefeated: false,
+  executed: false,
+  status: 'active',
+};
+
+describe('fetchSquadMemberEvmByNpub', () => {
+  it('returns empty map when both args are absent', async () => {
+    expect(await fetchSquadMemberEvmByNpub(undefined, null)).toEqual({});
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it('invokes list_squad_member_evm with the expected payload shape and keys by npub', async () => {
+    mockedInvoke.mockResolvedValueOnce([
+      { memberNpub: 'npub-a', evmAddress: '0xAAA', updatedAtMs: 1 },
+      { memberNpub: 'npub-b', evmAddress: '0xBBB', updatedAtMs: 2 },
+    ]);
+
+    const result = await fetchSquadMemberEvmByNpub('parent-1', 'group-1');
+
+    expect(mockedInvoke).toHaveBeenCalledWith('list_squad_member_evm', {
+      parentId: 'group-1',
+      altParentId: 'parent-1',
+    });
+    expect(result).toEqual({ 'npub-a': '0xAAA', 'npub-b': '0xBBB' });
+  });
+
+  it('returns empty map when invoke fails', async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error('network'));
+    expect(await fetchSquadMemberEvmByNpub('parent-1', null)).toEqual({});
+  });
+
+  it('returns empty map when the resolved parent id is empty', async () => {
+    expect(await fetchSquadMemberEvmByNpub('   ', null)).toEqual({});
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchDashboardChannelMembers', () => {
+  it('returns empty array when groupId is null', async () => {
+    expect(await fetchDashboardChannelMembers(null)).toEqual([]);
+    expect(mockedGetMlsGroupMembers).not.toHaveBeenCalled();
+  });
+
+  it('returns members from getMlsGroupMembers', async () => {
+    mockedGetMlsGroupMembers.mockResolvedValueOnce({
+      group_id: 'group-1',
+      members: ['npub-1', 'npub-2'],
+      admins: [],
+    });
+    expect(await fetchDashboardChannelMembers('group-1')).toEqual(['npub-1', 'npub-2']);
+    expect(mockedGetMlsGroupMembers).toHaveBeenCalledWith('group-1');
+  });
+
+  it('falls back to empty array when members is missing', async () => {
+    mockedGetMlsGroupMembers.mockResolvedValueOnce({
+      group_id: 'group-1',
+      members: undefined,
+      admins: [],
+    } as unknown as MlsGroupMembers);
+    expect(await fetchDashboardChannelMembers('group-1')).toEqual([]);
+  });
+
+  it('returns empty array on error', async () => {
+    mockedGetMlsGroupMembers.mockRejectedValueOnce(new Error('mls'));
+    expect(await fetchDashboardChannelMembers('group-1')).toEqual([]);
+  });
+});
+
+describe('fetchTreasuryProposalVoteMap', () => {
+  const baseProposals: TreasuryProposalDto[] = [
+    baseProposal,
+    { ...baseProposal, proposalId: '2', status: 'executed' },
+  ];
+
+  it('returns empty map when no proposals are active', async () => {
+    const inactive: TreasuryProposalDto = { ...baseProposal, status: 'expired' };
+    const result = await fetchTreasuryProposalVoteMap({
+      network: 'sepolia',
+      treasuryAuthority: '0xAuth',
+      proposals: [inactive],
+      voterAddress: '0xVoter',
+    });
+    expect(result).toEqual({});
+    expect(mockedWithReadPlaneLimit).not.toHaveBeenCalled();
+    expect(mockedTreasuryProposalHasVoted).not.toHaveBeenCalled();
+  });
+
+  it('queries each active proposal through the read plane limiter and returns a map', async () => {
+    mockedTreasuryProposalHasVoted.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await fetchTreasuryProposalVoteMap({
+      network: 'sepolia',
+      treasuryAuthority: '0xAuth',
+      proposals: baseProposals,
+      voterAddress: '0xVoter',
+    });
+
+    expect(mockedWithReadPlaneLimit).toHaveBeenCalledTimes(1);
+    expect(mockedTreasuryProposalHasVoted).toHaveBeenCalledWith({
+      network: 'sepolia',
+      treasuryAuthority: '0xAuth',
+      proposalId: '1',
+      voter: '0xVoter',
+    });
+    expect(result).toEqual({ '1': true });
+  });
+});
+
+describe('fetchTreasuryProposals', () => {
+  it('sorts proposals by proposalId descending', async () => {
+    const rows: TreasuryProposalDto[] = [
+      { ...baseProposal, proposalId: '5' },
+      { ...baseProposal, proposalId: '10' },
+      { ...baseProposal, proposalId: '7' },
+    ];
+    mockedListTreasuryProposals.mockResolvedValueOnce(rows);
+
+    const result = await fetchTreasuryProposals({ network: 'sepolia', treasuryAuthority: '0xAuth' });
+
+    expect(mockedListTreasuryProposals).toHaveBeenCalledWith({
+      network: 'sepolia',
+      treasuryAuthority: '0xAuth',
+    });
+    expect(result.proposals.map((p) => p.proposalId)).toEqual(['10', '7', '5']);
+    expect(result.error).toBe('');
+  });
+
+  it('returns an error message on failure', async () => {
+    mockedListTreasuryProposals.mockRejectedValueOnce(new Error('rpc down'));
+
+    const result = await fetchTreasuryProposals({ network: 'sepolia', treasuryAuthority: '0xAuth' });
+
+    expect(result.proposals).toEqual([]);
+    expect(result.error).toBe('rpc down');
+  });
+});
+
+describe('fetchHatsTree', () => {
+  it('returns the tree on success', async () => {
+    const tree = {
+      hatId: '0x1',
+      details: 'Top',
+      maxSupply: 1,
+      supply: 1,
+      active: true,
+      children: [],
+    };
+    mockedGetHatsTree.mockResolvedValueOnce(tree);
+
+    const result = await fetchHatsTree({ network: 'sepolia', topHatId: '0x1' });
+
+    expect(result.tree).toEqual(tree);
+    expect(result.error).toBe('');
+  });
+
+  it('returns an error message on failure', async () => {
+    mockedGetHatsTree.mockRejectedValueOnce(new Error('hats failed'));
+
+    const result = await fetchHatsTree({ network: 'sepolia', topHatId: '0x1' });
+
+    expect(result.tree).toBeNull();
+    expect(result.error).toBe('hats failed');
+  });
+});
+
+describe('fetchSettingsChainMemberMaps', () => {
+  const naveDeployment = {
+    chain: 'sepolia',
+    chainId: 11155111,
+    topHatId: '0xTop',
+    safe: '0xSafe',
+    quartermaster: '0xQm',
+    mutinyModule: '0xMutiny',
+    treasuryAuthority: '0xAuth',
+    squadAdminProxy: '0xAdmin',
+    captainHatId: '0xCaptainHat',
+    crewHatId: '0xCrewHat',
+    squadAdminHatId: '0xAdminHat',
+    mutinyRoleHatId: '0xMutinyRoleHat',
+    quartermasterRoleHatId: '0xQmRoleHat',
+    treasuryAuthorityRoleHatId: '0xTaRoleHat',
+    deployedAt: 1,
+    deployer: '0xDeployer',
+  };
+
+  it('returns empty maps when there are no EVM addresses', async () => {
+    const result = await fetchSettingsChainMemberMaps({
+      network: 'sepolia',
+      topHatId: '0xTop',
+      squadAdminProxy: '0xAdmin',
+      squadAdminChain: 'sepolia',
+      squadMemberEvmByNpub: {},
+    });
+
+    expect(result).toEqual({
+      memberHatByAddress: {},
+      memberRolesByAddress: {},
+      error: '',
+    });
+  });
+
+  it('loads hats when topHatId is provided', async () => {
+    mockedGetNavePirataDeployment.mockResolvedValueOnce(naveDeployment);
+    mockedGetMemberHatWearers.mockResolvedValueOnce([
+      {
+        address: '0xabc',
+        hats: [{ hatId: '0xCaptainHat', label: 'Captain' }],
+      },
+    ]);
+
+    const result = await fetchSettingsChainMemberMaps({
+      network: 'sepolia',
+      topHatId: '0xTop',
+      squadAdminProxy: null,
+      squadAdminChain: null,
+      squadMemberEvmByNpub: { npub1: '0xABC' },
+    });
+
+    expect(mockedGetNavePirataDeployment).toHaveBeenCalledWith({ network: 'sepolia', topHatId: '0xTop' });
+    expect(result.memberHatByAddress).toEqual({ '0xabc': 'Captain' });
+    expect(result.memberRolesByAddress).toEqual({});
+    expect(result.error).toBe('');
+  });
+
+  it('loads roles when squadAdminProxy is provided', async () => {
+    mockedGetSquadAdminExecutorRoles.mockResolvedValueOnce({
+      address: '0xabc',
+      fullPermission: true,
+      paused: false,
+      roles: [],
+    });
+
+    const result = await fetchSettingsChainMemberMaps({
+      network: 'sepolia',
+      topHatId: null,
+      squadAdminProxy: '0xAdmin',
+      squadAdminChain: 'optimism',
+      squadMemberEvmByNpub: { npub1: '0xABC' },
+    });
+
+    expect(mockedGetSquadAdminExecutorRoles).toHaveBeenCalledWith({
+      network: 'optimism',
+      squadAdminProxy: '0xAdmin',
+      executorAddress: '0xABC',
+    });
+    expect(result.memberHatByAddress).toEqual({});
+    expect(result.memberRolesByAddress).toEqual({ '0xabc': 'Full' });
+    expect(result.error).toBe('');
+  });
+
+  it('loads both hats and roles when both ids are provided', async () => {
+    mockedGetNavePirataDeployment.mockResolvedValueOnce(naveDeployment);
+    mockedGetMemberHatWearers.mockResolvedValueOnce([
+      { address: '0xabc', hats: [{ hatId: '0xCrewHat', label: 'Crew' }] },
+    ]);
+    mockedGetSquadAdminExecutorRoles.mockResolvedValueOnce({
+      address: '0xabc',
+      fullPermission: false,
+      paused: false,
+      roles: [{ role: 'Treasurer', enabled: true }],
+    });
+
+    const result = await fetchSettingsChainMemberMaps({
+      network: 'sepolia',
+      topHatId: '0xTop',
+      squadAdminProxy: '0xAdmin',
+      squadAdminChain: null,
+      squadMemberEvmByNpub: { npub1: '0xABC' },
+    });
+
+    expect(result.memberHatByAddress).toEqual({ '0xabc': 'Crew' });
+    expect(result.memberRolesByAddress).toEqual({ '0xabc': 'Treasurer' });
+  });
+
+  it('returns an error message when the on-chain calls fail', async () => {
+    mockedGetNavePirataDeployment.mockRejectedValueOnce(new Error('chain error'));
+
+    const result = await fetchSettingsChainMemberMaps({
+      network: 'sepolia',
+      topHatId: '0xTop',
+      squadAdminProxy: null,
+      squadAdminChain: null,
+      squadMemberEvmByNpub: { npub1: '0xABC' },
+    });
+
+    expect(result.memberHatByAddress).toEqual({});
+    expect(result.memberRolesByAddress).toEqual({});
+    expect(result.error).toBe('chain error');
+  });
+});

--- a/src/lib/dashboard/permissions-panel.test.ts
+++ b/src/lib/dashboard/permissions-panel.test.ts
@@ -11,6 +11,8 @@ describe('resolveDashboardPermissionsContext', () => {
     const ctx = resolveDashboardPermissionsContext(undefined);
     expect(ctx.phase).toBe('loading');
     expect(ctx.catalogRows).toEqual([]);
+    expect(ctx.leadNote).toBe('');
+    expect(ctx.showExecutorMappingPlaceholder).toBe(false);
   });
 
   it('mls_only when no row', () => {
@@ -18,6 +20,24 @@ describe('resolveDashboardPermissionsContext', () => {
     expect(ctx.phase).toBe('mls_only');
     expect(ctx.catalogRows).toEqual([]);
     expect(ctx.leadNote).toContain('Pacto Gov');
+    expect(ctx.showExecutorMappingPlaceholder).toBe(false);
+  });
+
+  it('pacto_gov without revision omits pactoGovRevision', () => {
+    const row: ParentGovernanceDto = {
+      id: 'pacto-gov-p1',
+      parentId: 'p1',
+      infraType: 'pacto_gov',
+      provider: 'pacto_gov',
+      chain: 'sepolia',
+      canonicalRef: '1',
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    const ctx = resolveDashboardPermissionsContext(row);
+    expect(ctx.phase).toBe('pacto_gov');
+    expect(ctx.pactoGovRevision).toBeUndefined();
+    expect(ctx.showExecutorMappingPlaceholder).toBe(false);
   });
 
   it('pacto_gov includes catalog and revision', () => {
@@ -39,7 +59,7 @@ describe('resolveDashboardPermissionsContext', () => {
     expect(ctx.showExecutorMappingPlaceholder).toBe(false);
   });
 
-  it('gnosis_safe uses treasury catalog', () => {
+  it('gnosis_safe uses treasury catalog and keeps executor placeholder off', () => {
     const row: ParentGovernanceDto = {
       id: 'standalone-safe-p1',
       parentId: 'p1',
@@ -69,5 +89,7 @@ describe('resolveDashboardPermissionsContext', () => {
     });
     expect(ctx.phase).toBe('other_provider');
     expect(ctx.catalogRows).toEqual([]);
+    expect(ctx.leadNote).toContain('not wired');
+    expect(ctx.showExecutorMappingPlaceholder).toBe(false);
   });
 });

--- a/src/lib/dashboard/proposal-cards.test.ts
+++ b/src/lib/dashboard/proposal-cards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildDashboardProposalCards } from './proposal-cards';
+import { buildDashboardProposalCards, dashboardProposalToolLabel } from './proposal-cards';
 
 describe('buildDashboardProposalCards', () => {
   it('returns empty when no treasury or pacto gov', () => {
@@ -30,6 +30,63 @@ describe('buildDashboardProposalCards', () => {
     ]);
   });
 
+  it('skips pacto_gov when canonical ref is empty or whitespace', () => {
+    expect(
+      buildDashboardProposalCards({
+        treasurySafes: [],
+        governanceConfig: {
+          id: 'infra-1',
+          parentId: 'p1',
+          provider: 'pacto_gov',
+          infraType: 'pacto_gov',
+          chain: 'sepolia',
+          canonicalRef: '',
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      buildDashboardProposalCards({
+        treasurySafes: [],
+        governanceConfig: {
+          id: 'infra-1',
+          parentId: 'p1',
+          provider: 'pacto_gov',
+          infraType: 'pacto_gov',
+          chain: 'sepolia',
+          canonicalRef: '   ',
+          createdAtMs: 1,
+          updatedAtMs: 1,
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('pacto_gov card tolerates a missing chain', () => {
+    const cards = buildDashboardProposalCards({
+      treasurySafes: [],
+      governanceConfig: {
+        id: 'infra-1',
+        parentId: 'p1',
+        provider: 'pacto_gov',
+        infraType: 'pacto_gov',
+        // @ts-expect-error exercise optional chain handling a missing chain
+        chain: undefined,
+        canonicalRef: '0xabc',
+        createdAtMs: 1,
+        updatedAtMs: 1,
+      },
+    });
+    expect(cards).toEqual([
+      expect.objectContaining({
+        tool: 'pacto_gov',
+        ref: '0xabc',
+        chain: undefined,
+      }),
+    ]);
+  });
+
   it('maps treasury safes to safe tool rows', () => {
     const cards = buildDashboardProposalCards({
       treasurySafes: [
@@ -53,6 +110,109 @@ describe('buildDashboardProposalCards', () => {
         title: 'Main',
       }),
     ]);
+  });
+
+  it('trims whitespace from safe chain and label and falls back title', () => {
+    const cards = buildDashboardProposalCards({
+      treasurySafes: [
+        {
+          id: 't2',
+          parentId: 'p1',
+          safeAddress: ' 0x2222 ',
+          chain: '  sepolia  ',
+          label: '',
+          createdAtMs: 1,
+        },
+        {
+          id: 't3',
+          parentId: 'p1',
+          safeAddress: '0x3333',
+          chain: 'mainnet',
+          label: '  ',
+          createdAtMs: 1,
+        },
+      ],
+      governanceConfig: null,
+    });
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toEqual(
+      expect.objectContaining({
+        tool: 'safe',
+        ref: '0x2222',
+        chain: 'sepolia',
+        treasuryEntryId: 't2',
+        title: 'Safe multisig',
+      }),
+    );
+    expect(cards[1]).toEqual(
+      expect.objectContaining({
+        tool: 'safe',
+        ref: '0x3333',
+        chain: 'mainnet',
+        treasuryEntryId: 't3',
+        title: 'Safe multisig',
+      }),
+    );
+  });
+
+  it('handles missing treasury safes list and optional safe fields', () => {
+    const cards = buildDashboardProposalCards({
+      // @ts-expect-error exercise nullish coalescing when the array is omitted
+      treasurySafes: undefined,
+      governanceConfig: null,
+    });
+    expect(cards).toEqual([]);
+
+    const withMissingFields = buildDashboardProposalCards({
+      treasurySafes: [
+        {
+          id: 't-missing',
+          parentId: 'p1',
+          safeAddress: '0x4444',
+          // @ts-expect-error exercise optional chain handling a missing chain
+          chain: undefined,
+          // @ts-expect-error exercise optional chain handling a missing label
+          label: undefined,
+          createdAtMs: 1,
+        },
+      ],
+      governanceConfig: null,
+    });
+    expect(withMissingFields).toEqual([
+      expect.objectContaining({
+        tool: 'safe',
+        ref: '0x4444',
+        chain: undefined,
+        treasuryEntryId: 't-missing',
+        title: 'Safe multisig',
+      }),
+    ]);
+  });
+
+  it('skips treasury safes with empty address', () => {
+    expect(
+      buildDashboardProposalCards({
+        treasurySafes: [
+          {
+            id: 't1',
+            parentId: 'p1',
+            safeAddress: '',
+            chain: 'sepolia',
+            label: 'Empty',
+            createdAtMs: 1,
+          },
+          {
+            id: 't2',
+            parentId: 'p1',
+            safeAddress: '   ',
+            chain: 'sepolia',
+            label: 'Whitespace',
+            createdAtMs: 1,
+          },
+        ],
+        governanceConfig: null,
+      }),
+    ).toEqual([]);
   });
 
   it('orders pacto_gov before treasury rows', () => {
@@ -79,5 +239,13 @@ describe('buildDashboardProposalCards', () => {
       },
     });
     expect(cards.map((c) => c.tool)).toEqual(['pacto_gov', 'safe']);
+  });
+});
+
+describe('dashboardProposalToolLabel', () => {
+  it('labels each proposal tool', () => {
+    expect(dashboardProposalToolLabel('pacto_gov')).toBe('Pacto Gov');
+    expect(dashboardProposalToolLabel('safe')).toBe('Safe');
+    expect(dashboardProposalToolLabel('nostr_poll')).toBe('Poll');
   });
 });

--- a/src/lib/dashboard/safe-state-disk-cache.test.ts
+++ b/src/lib/dashboard/safe-state-disk-cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  SAFE_STATE_DISK_CACHE_PREFIX,
+  SAFE_STATE_DISK_TTL_MS,
+  hydrateSafeStateCacheFromDisk,
+  persistSafeStateCacheEntry,
+} from './safe-state-disk-cache';
+import type { SafeStateEntry } from '../../stores/safe';
+import type { SupportedChainId } from '../wallet/chains';
+
+describe('safe-state-disk-cache', () => {
+  const npub = 'npub1testsafestate';
+
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+  });
+
+  function sampleEntry(opts: { treasuryEntryId?: string; lastFetchedAt?: number } = {}): SafeStateEntry {
+    return {
+      treasuryEntryId: opts.treasuryEntryId ?? 'entry-1',
+      safeAddress: '0xabc',
+      chainId: 'sepolia' as SupportedChainId,
+      state: {
+        address: '0xabc',
+        owners: ['0xdef'],
+        threshold: 1,
+        nonce: 0n,
+        balanceWei: 1000n,
+        balanceFormatted: '0.000000000000001',
+      },
+      error: null,
+      loading: false,
+      lastFetchedAt: opts.lastFetchedAt ?? Date.now(),
+    };
+  }
+
+  it('round-trips SafeState entries through wire format', () => {
+    const entry = sampleEntry();
+    persistSafeStateCacheEntry(npub, entry);
+    expect(localStorage.getItem(`${SAFE_STATE_DISK_CACHE_PREFIX}_${npub}`)).toBeTruthy();
+
+    const merged: Record<string, SafeStateEntry> = {};
+    hydrateSafeStateCacheFromDisk(npub, (rows) => Object.assign(merged, rows));
+
+    const hydrated = merged['entry-1'];
+    expect(hydrated).toBeDefined();
+    expect(hydrated.treasuryEntryId).toBe('entry-1');
+    expect(hydrated.safeAddress).toBe('0xabc');
+    expect(hydrated.chainId).toBe('sepolia');
+    expect(hydrated.error).toBeNull();
+    expect(hydrated.loading).toBe(false);
+
+    const state = hydrated.state;
+    expect(state).not.toBeNull();
+    expect(state?.address).toBe('0xabc');
+    expect(state?.owners).toEqual(['0xdef']);
+    expect(state?.threshold).toBe(1);
+    expect(state?.nonce).toBe(0n);
+    expect(state?.balanceWei).toBe(1000n);
+    expect(state?.balanceFormatted).toBe('0.000000000000001');
+  });
+
+  it('evicts stale entries by TTL', () => {
+    const stale = sampleEntry({ lastFetchedAt: Date.now() - SAFE_STATE_DISK_TTL_MS - 1000 });
+    persistSafeStateCacheEntry(npub, stale);
+
+    const merged: Record<string, SafeStateEntry> = {};
+    hydrateSafeStateCacheFromDisk(npub, (rows) => Object.assign(merged, rows));
+
+    expect(merged['entry-1']).toBeUndefined();
+  });
+
+  it('merges hydrated rows into existing state via the merge callback', () => {
+    const entry1 = sampleEntry({ treasuryEntryId: 'entry-1', lastFetchedAt: Date.now() });
+    const entry2 = sampleEntry({ treasuryEntryId: 'entry-2', lastFetchedAt: Date.now() });
+    persistSafeStateCacheEntry(npub, entry1);
+    persistSafeStateCacheEntry(npub, entry2);
+
+    const merged: Record<string, SafeStateEntry> = {};
+    hydrateSafeStateCacheFromDisk(npub, (rows) => Object.assign(merged, rows));
+
+    expect(Object.keys(merged)).toHaveLength(2);
+    expect(merged['entry-1']).toBeDefined();
+    expect(merged['entry-2']).toBeDefined();
+  });
+
+  it('ignores malformed persisted blobs', () => {
+    store.set(`${SAFE_STATE_DISK_CACHE_PREFIX}_${npub}`, JSON.stringify({ version: 2, byTreasuryEntryId: {} }));
+    const merged: Record<string, SafeStateEntry> = {};
+    hydrateSafeStateCacheFromDisk(npub, (rows) => Object.assign(merged, rows));
+    expect(Object.keys(merged)).toHaveLength(0);
+  });
+});

--- a/src/lib/dashboard/settings-chain-cache.test.ts
+++ b/src/lib/dashboard/settings-chain-cache.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
 import {
   SETTINGS_CHAIN_CACHE_PREFIX,
   getCachedSettingsChainSnapshot,
   hydrateSettingsChainCacheFromDisk,
   persistSettingsChainSnapshot,
   settingsChainCacheKey,
+  clearSettingsChainCacheStore,
+  removeSettingsChainCacheForParent,
+  settingsChainHydrated,
 } from './settings-chain-cache';
 
 describe('settings-chain-cache', () => {
@@ -33,6 +37,7 @@ describe('settings-chain-cache', () => {
 
   afterEach(() => {
     delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    clearSettingsChainCacheStore();
   });
 
   it('round-trips member hat/role maps when fingerprint matches', () => {
@@ -52,5 +57,57 @@ describe('settings-chain-cache', () => {
     expect(snap?.memberHatByAddress['0xabc']).toBe('Captain');
     expect(snap?.memberRolesByAddress['0xabc']).toBe('Executor');
     expect(localStorage.getItem(`${SETTINGS_CHAIN_CACHE_PREFIX}_${npub}`)).toBeTruthy();
+  });
+
+  it('returns null when the cache key does not match', () => {
+    const evm = { npub1: '0xabc', npub2: '0xdef' };
+    const cacheKey = settingsChainCacheKey({
+      network: 'sepolia',
+      topHatId: '0x1',
+      squadAdminProxy: '0x2',
+      squadMemberEvmByNpub: evm,
+    });
+    persistSettingsChainSnapshot(npub, parentId, cacheKey, {
+      memberHatByAddress: { '0xabc': 'Captain' },
+      memberRolesByAddress: { '0xabc': 'Executor' },
+    });
+    expect(getCachedSettingsChainSnapshot(npub, parentId, 'different-key')).toBeNull();
+  });
+
+  it('clearSettingsChainCacheStore resets the hydrated store', () => {
+    const evm = { npub1: '0xabc' };
+    const cacheKey = settingsChainCacheKey({
+      network: 'sepolia',
+      topHatId: '0x1',
+      squadAdminProxy: '0x2',
+      squadMemberEvmByNpub: evm,
+    });
+    persistSettingsChainSnapshot(npub, parentId, cacheKey, {
+      memberHatByAddress: {},
+      memberRolesByAddress: {},
+    });
+    expect(get(settingsChainHydrated)).not.toBeNull();
+    clearSettingsChainCacheStore();
+    expect(get(settingsChainHydrated)).toBeNull();
+  });
+
+  it('removeSettingsChainCacheForParent deletes the disk and store entry', () => {
+    const evm = { npub1: '0xabc' };
+    const cacheKey = settingsChainCacheKey({
+      network: 'sepolia',
+      topHatId: '0x1',
+      squadAdminProxy: '0x2',
+      squadMemberEvmByNpub: evm,
+    });
+    persistSettingsChainSnapshot(npub, parentId, cacheKey, {
+      memberHatByAddress: { '0xabc': 'Captain' },
+      memberRolesByAddress: { '0xabc': 'Executor' },
+    });
+    expect(getCachedSettingsChainSnapshot(npub, parentId, cacheKey)).not.toBeNull();
+
+    removeSettingsChainCacheForParent(npub, parentId);
+
+    expect(getCachedSettingsChainSnapshot(npub, parentId, cacheKey)).toBeNull();
+    expect(get(settingsChainHydrated)?.byParentId[parentId]).toBeUndefined();
   });
 });

--- a/src/lib/dashboard/squad-infra-cache.test.ts
+++ b/src/lib/dashboard/squad-infra-cache.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get, writable } from 'svelte/store';
+import { squadInfraByParentId } from '../../stores/squads';
+import { clearDashboardFetchMetaStores, squadInfraFetchMetaByParentId } from './dashboard-fetch-meta';
+import {
+  SQUAD_INFRA_CACHE_PREFIX,
+  hydrateSquadInfraCacheFromDisk,
+  hydrateSquadInfraCacheIntoStore,
+  persistSquadInfraForParent,
+  removeSquadInfraCacheForParent,
+  squadInfraFetchedAtMs,
+} from './squad-infra-cache';
+import type { SquadInfraDto } from '../governance/api';
+
+describe('squad-infra-cache', () => {
+  const npub = 'npub1testsquadinfra';
+  const parentId = 'squad-parent-1';
+
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    squadInfraByParentId.set({});
+    clearDashboardFetchMetaStores();
+  });
+
+  function sampleInfra(): SquadInfraDto[] {
+    return [
+      {
+        id: 'infra-1',
+        parentId,
+        infraType: 'pacto_gov',
+        chain: 'sepolia',
+        canonicalRef: '0x1',
+        createdAtMs: 1,
+        updatedAtMs: 2,
+      },
+    ];
+  }
+
+  it('hydrates squad infra rows into the Svelte store', () => {
+    const rows = sampleInfra();
+    persistSquadInfraForParent(npub, parentId, rows);
+    squadInfraByParentId.set({});
+    hydrateSquadInfraCacheFromDisk(npub);
+    expect(get(squadInfraByParentId)[parentId]).toEqual(rows);
+    expect(localStorage.getItem(`${SQUAD_INFRA_CACHE_PREFIX}_${npub}`)).toBeTruthy();
+
+    const meta = get(squadInfraFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBeNull();
+    expect(meta.fetchedAtMs).toBeGreaterThan(0);
+  });
+
+  it('persists squad infra rows and updates fetch meta', () => {
+    const rows = sampleInfra();
+    persistSquadInfraForParent(npub, parentId, rows);
+    expect(squadInfraFetchedAtMs(npub, parentId)).toBeGreaterThan(0);
+  });
+
+  it('removes squad infra cache for a parent from disk and store', () => {
+    const rows = sampleInfra();
+    persistSquadInfraForParent(npub, parentId, rows);
+    hydrateSquadInfraCacheFromDisk(npub);
+    expect(get(squadInfraByParentId)[parentId]).toEqual(rows);
+
+    removeSquadInfraCacheForParent(npub, parentId);
+
+    expect(get(squadInfraByParentId)[parentId]).toBeUndefined();
+    expect(squadInfraFetchedAtMs(npub, parentId)).toBeNull();
+    expect(get(squadInfraFetchMetaByParentId)[parentId]).toBeUndefined();
+
+    squadInfraByParentId.set({});
+    hydrateSquadInfraCacheFromDisk(npub);
+    expect(get(squadInfraByParentId)[parentId]).toBeUndefined();
+  });
+
+  it('can hydrate into a provided writable store', () => {
+    const rows = sampleInfra();
+    persistSquadInfraForParent(npub, parentId, rows);
+    const target = writable<Record<string, SquadInfraDto[]>>({});
+    hydrateSquadInfraCacheIntoStore(npub, target);
+    expect(get(target)[parentId]).toEqual(rows);
+  });
+
+  it('ignores invalid persisted rows during hydration', () => {
+    store.set(
+      `${SQUAD_INFRA_CACHE_PREFIX}_${npub}`,
+      JSON.stringify({
+        version: 1,
+        byParentId: { [parentId]: [{ notAnInfraRow: true }] },
+        fetchedAtMsByParentId: { [parentId]: 1 },
+      }),
+    );
+    const target = writable<Record<string, SquadInfraDto[]>>({});
+    hydrateSquadInfraCacheIntoStore(npub, target);
+    expect(get(target)[parentId]).toBeUndefined();
+  });
+});

--- a/src/lib/dashboard/squad-member-evm-cache.test.ts
+++ b/src/lib/dashboard/squad-member-evm-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get, writable } from 'svelte/store';
+import { squadMemberEvmByParentId } from '../../stores/squads';
+import {
+  SQUAD_MEMBER_EVM_CACHE_PREFIX,
+  hydrateSquadMemberEvmCacheFromDisk,
+  hydrateSquadMemberEvmCacheIntoStore,
+  persistSquadMemberEvmForParent,
+  getCachedSquadMemberEvmForParent,
+  removeSquadMemberEvmCacheForParent,
+} from './squad-member-evm-cache';
+
+describe('squad-member-evm-cache', () => {
+  const npub = 'npub1testsquadmemberevm';
+  const parentId = 'squad-parent-1';
+
+  const store = new Map<string, string>();
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    squadMemberEvmByParentId.set({});
+  });
+
+  function sampleMap(): Record<string, string> {
+    return { npub1: '0xabc', npub2: '0xdef' };
+  }
+
+  it('hydrates squad member evm mapping into the Svelte store', () => {
+    const map = sampleMap();
+    persistSquadMemberEvmForParent(npub, parentId, map);
+    squadMemberEvmByParentId.set({});
+    hydrateSquadMemberEvmCacheFromDisk(npub);
+    expect(get(squadMemberEvmByParentId)[parentId]).toEqual(map);
+    expect(localStorage.getItem(`${SQUAD_MEMBER_EVM_CACHE_PREFIX}_${npub}`)).toBeTruthy();
+  });
+
+  it('returns cached map for a parent or null when missing', () => {
+    const map = sampleMap();
+    persistSquadMemberEvmForParent(npub, parentId, map);
+    expect(getCachedSquadMemberEvmForParent(npub, parentId)).toEqual(map);
+    expect(getCachedSquadMemberEvmForParent(npub, 'other-parent')).toBeNull();
+  });
+
+  it('removes squad member evm cache for a parent from disk and store', () => {
+    const map = sampleMap();
+    persistSquadMemberEvmForParent(npub, parentId, map);
+    hydrateSquadMemberEvmCacheFromDisk(npub);
+    expect(get(squadMemberEvmByParentId)[parentId]).toEqual(map);
+
+    removeSquadMemberEvmCacheForParent(npub, parentId);
+
+    expect(get(squadMemberEvmByParentId)[parentId]).toBeUndefined();
+    expect(getCachedSquadMemberEvmForParent(npub, parentId)).toBeNull();
+
+    squadMemberEvmByParentId.set({});
+    hydrateSquadMemberEvmCacheFromDisk(npub);
+    expect(get(squadMemberEvmByParentId)[parentId]).toBeUndefined();
+  });
+
+  it('can hydrate into a provided writable store', () => {
+    const map = sampleMap();
+    persistSquadMemberEvmForParent(npub, parentId, map);
+    const target = writable<Record<string, Record<string, string>>>({});
+    hydrateSquadMemberEvmCacheIntoStore(npub, target);
+    expect(get(target)[parentId]).toEqual(map);
+  });
+
+  it('ignores invalid persisted maps during hydration', () => {
+    store.set(
+      `${SQUAD_MEMBER_EVM_CACHE_PREFIX}_${npub}`,
+      JSON.stringify({
+        version: 1,
+        byParentId: { [parentId]: [{ notAMap: true }] },
+        fetchedAtMsByParentId: { [parentId]: 1 },
+      }),
+    );
+    const target = writable<Record<string, Record<string, string>>>({});
+    hydrateSquadMemberEvmCacheIntoStore(npub, target);
+    expect(get(target)[parentId]).toBeUndefined();
+  });
+});

--- a/src/lib/dashboard/structure-summary.test.ts
+++ b/src/lib/dashboard/structure-summary.test.ts
@@ -22,8 +22,14 @@ describe('normalizeHatIdPathSegment', () => {
     expect(normalizeHatIdPathSegment(' 298 ')).toBe('298');
   });
 
-  it('converts hex hat ids to decimal', () => {
-    expect(normalizeHatIdPathSegment('0x12a')).toBe('298');
+  it('trims whitespace-only strings to null', () => {
+    expect(normalizeHatIdPathSegment('   ')).toBe(null);
+    expect(normalizeHatIdPathSegment('\t\n')).toBe(null);
+  });
+
+  it('accepts uppercase hex and decimal strings', () => {
+    expect(normalizeHatIdPathSegment('0x12A')).toBe('298');
+    expect(normalizeHatIdPathSegment('000298')).toBe('000298');
   });
 
   it('returns null for empty or invalid', () => {
@@ -41,8 +47,15 @@ describe('hatsTreeExplorerUrl', () => {
     );
   });
 
-  it('returns null when hat id is unusable', () => {
-    expect(hatsTreeExplorerUrl(1, 'nope')).toBe(null);
+  it('returns null for non-finite chain ids', () => {
+    expect(hatsTreeExplorerUrl(NaN, '298')).toBe(null);
+    expect(hatsTreeExplorerUrl(Infinity, '298')).toBe(null);
+    expect(hatsTreeExplorerUrl(-Infinity, '0x12a')).toBe(null);
+  });
+
+  it('trims whitespace from hat id before normalizing', () => {
+    expect(hatsTreeExplorerUrl(10, '  298  ')).toBe('https://app.hatsprotocol.xyz/trees/10/298');
+    expect(hatsTreeExplorerUrl(10, '  nope  ')).toBe(null);
   });
 });
 
@@ -81,5 +94,36 @@ describe('resolveDashboardStructureSummary', () => {
   it('treats the retired "anvil" alias as unknown (falls back to sepolia)', () => {
     const s = resolveDashboardStructureSummary({ ...pactoGovRow, chain: 'anvil' });
     expect(s?.chainKey).toBe('sepolia');
+  });
+
+  it('returns null when canonical ref is empty or whitespace', () => {
+    expect(resolveDashboardStructureSummary({ ...pactoGovRow, canonicalRef: '' })).toBe(null);
+    expect(resolveDashboardStructureSummary({ ...pactoGovRow, canonicalRef: '   ' })).toBe(null);
+  });
+
+  it('returns summary for each supported chain', () => {
+    const cases: Array<{ chain: string; name: string; id: number }> = [
+      { chain: 'mainnet', name: 'Ethereum', id: 1 },
+      { chain: 'arbitrum', name: 'Arbitrum', id: 42161 },
+      { chain: 'optimism', name: 'Optimism', id: 10 },
+      { chain: 'gnosis', name: 'Gnosis', id: 100 },
+      { chain: 'sepolia', name: 'Sepolia', id: 11155111 },
+      { chain: 'local', name: 'Local Anvil', id: 31337 },
+    ];
+    for (const { chain, name, id } of cases) {
+      const s = resolveDashboardStructureSummary({ ...pactoGovRow, chain });
+      expect(s?.chainKey).toBe(chain as SquadInfraDto['chain']);
+      expect(s?.chainDisplayName).toBe(name);
+      expect(s?.chainIdNumeric).toBe(id);
+      expect(s?.hatsExplorerUrl).toBe(`https://app.hatsprotocol.xyz/trees/${id}/298`);
+    }
+  });
+
+  it('falls back to sepolia for unknown chain strings', () => {
+    const s = resolveDashboardStructureSummary({ ...pactoGovRow, chain: 'unknown' });
+    expect(s?.chainKey).toBe('sepolia');
+    expect(s?.chainDisplayName).toBe('Sepolia');
+    expect(s?.chainIdNumeric).toBe(11155111);
+  });
   });
 });

--- a/src/lib/dashboard/treasury-safes-cache.test.ts
+++ b/src/lib/dashboard/treasury-safes-cache.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { get, writable } from 'svelte/store';
+import { treasurySafesByParentId } from '../../stores/squads';
+import { clearDashboardFetchMetaStores, treasurySafesFetchMetaByParentId } from './dashboard-fetch-meta';
 import {
   TREASURY_SAFES_CACHE_PREFIX,
+  hydrateTreasurySafesCacheFromDisk,
   hydrateTreasurySafesCacheIntoStore,
   persistTreasurySafesForParent,
+  removeTreasurySafesCacheForParent,
+  treasurySafesFetchedAtMs,
 } from './treasury-safes-cache';
 import type { TreasurySafeEntry } from '../treasury/treasury-safes';
 
@@ -33,6 +38,8 @@ describe('treasury-safes-cache', () => {
 
   afterEach(() => {
     delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    treasurySafesByParentId.set({});
+    clearDashboardFetchMetaStores();
   });
 
   it('round-trips treasury rows per parent id', () => {
@@ -52,5 +59,51 @@ describe('treasury-safes-cache', () => {
     hydrateTreasurySafesCacheIntoStore(npub, target);
     expect(get(target)[parentId]).toEqual(rows);
     expect(localStorage.getItem(`${TREASURY_SAFES_CACHE_PREFIX}_${npub}`)).toBeTruthy();
+  });
+
+  it('updates treasury safes fetch meta and exposes fetchedAtMs', () => {
+    const rows: TreasurySafeEntry[] = [
+      {
+        id: 'entry-1',
+        parentId,
+        safeAddress: '0xabc',
+        chain: 'sepolia',
+        label: 'Vault',
+        createdAtMs: 1,
+      },
+    ];
+    persistTreasurySafesForParent(npub, parentId, rows);
+
+    const meta = get(treasurySafesFetchMetaByParentId)[parentId];
+    expect(meta.loading).toBe(false);
+    expect(meta.error).toBeNull();
+    expect(meta.fetchedAtMs).toBeGreaterThan(0);
+    expect(treasurySafesFetchedAtMs(npub, parentId)).toBe(meta.fetchedAtMs);
+  });
+
+  it('removes treasury safes cache for a parent from disk and store', () => {
+    const rows: TreasurySafeEntry[] = [
+      {
+        id: 'entry-1',
+        parentId,
+        safeAddress: '0xabc',
+        chain: 'sepolia',
+        label: 'Vault',
+        createdAtMs: 1,
+      },
+    ];
+    persistTreasurySafesForParent(npub, parentId, rows);
+    hydrateTreasurySafesCacheFromDisk(npub);
+    expect(get(treasurySafesByParentId)[parentId]).toEqual(rows);
+
+    removeTreasurySafesCacheForParent(npub, parentId);
+
+    expect(get(treasurySafesByParentId)[parentId]).toBeUndefined();
+    expect(treasurySafesFetchedAtMs(npub, parentId)).toBeNull();
+    expect(get(treasurySafesFetchMetaByParentId)[parentId]).toBeUndefined();
+
+    treasurySafesByParentId.set({});
+    hydrateTreasurySafesCacheFromDisk(npub);
+    expect(get(treasurySafesByParentId)[parentId]).toBeUndefined();
   });
 });

--- a/src/lib/dev/index.test.ts
+++ b/src/lib/dev/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { applyLocalDevDefaults } from './index';
+import { applyLocalDevDefaults as originalApplyLocalDevDefaults } from './local-dev-setup';
+
+describe('dev index', () => {
+  it('re-exports applyLocalDevDefaults from local-dev-setup', () => {
+    expect(applyLocalDevDefaults).toBe(originalApplyLocalDevDefaults);
+  });
+});

--- a/src/lib/dm/dm-unread.test.ts
+++ b/src/lib/dm/dm-unread.test.ts
@@ -2,21 +2,57 @@ import { describe, expect, it } from 'vitest';
 import { countUnreadInThread, formatUnreadBadgeCount, isScrollAtBottom } from './dm-unread';
 
 describe('countUnreadInThread', () => {
-  const msgs = [
-    { id: 'a', mine: false },
-    { id: 'b', mine: false },
-    { id: 'c', mine: true },
-    { id: 'd', mine: false },
-  ];
-
-  it('counts inbound messages after last read, stopping at own message', () => {
-    expect(countUnreadInThread(msgs, 'd')).toBe(0);
-    expect(countUnreadInThread(msgs, 'b')).toBe(1);
-    expect(countUnreadInThread(msgs, '')).toBe(1);
+  it('returns zero for empty messages', () => {
+    expect(countUnreadInThread([], '')).toBe(0);
   });
 
-  it('returns zero when last read is the newest inbound', () => {
+  it('counts all inbound messages when no last-read and no own message', () => {
+    const msgs = [
+      { id: 'a', mine: false },
+      { id: 'b', mine: false },
+      { id: 'c', mine: false },
+    ];
+    expect(countUnreadInThread(msgs, '')).toBe(3);
+  });
+
+  it('counts only messages newer than last-read id', () => {
+    const msgs = [
+      { id: 'a', mine: false },
+      { id: 'b', mine: false },
+      { id: 'c', mine: false },
+    ];
+    expect(countUnreadInThread(msgs, 'b')).toBe(1);
+    expect(countUnreadInThread(msgs, 'a')).toBe(2);
+  });
+
+  it('stops at own message even if it appears before last-read id', () => {
+    const msgs = [
+      { id: 'a', mine: false },
+      { id: 'b', mine: true },
+      { id: 'c', mine: false },
+    ];
+    expect(countUnreadInThread(msgs, 'a')).toBe(1);
+  });
+
+  it('stops counting at the newest message when it is the last-read id', () => {
     expect(countUnreadInThread([{ id: 'x', mine: false }], 'x')).toBe(0);
+  });
+
+  it('returns zero when last-read id is not found and newest is own', () => {
+    const msgs = [
+      { id: 'a', mine: false },
+      { id: 'b', mine: true },
+    ];
+    expect(countUnreadInThread(msgs, 'z')).toBe(0);
+  });
+
+  it('stops before own message when last-read id is missing', () => {
+    const msgs = [
+      { id: 'a', mine: false },
+      { id: 'b', mine: false },
+      { id: 'c', mine: true },
+    ];
+    expect(countUnreadInThread(msgs, 'z')).toBe(0);
   });
 });
 
@@ -24,7 +60,9 @@ describe('formatUnreadBadgeCount', () => {
   it('formats counts for badges', () => {
     expect(formatUnreadBadgeCount(0)).toBe('');
     expect(formatUnreadBadgeCount(3)).toBe('3');
+    expect(formatUnreadBadgeCount(99)).toBe('99');
     expect(formatUnreadBadgeCount(100)).toBe('99+');
+    expect(formatUnreadBadgeCount(-1)).toBe('');
   });
 });
 
@@ -37,5 +75,20 @@ describe('isScrollAtBottom', () => {
     } as HTMLElement;
     expect(isScrollAtBottom(el)).toBe(true);
     expect(isScrollAtBottom({ ...el, scrollTop: 700 } as HTMLElement)).toBe(false);
+  });
+
+  it('uses the provided threshold', () => {
+    const el = {
+      scrollHeight: 1000,
+      scrollTop: 821,
+      clientHeight: 100,
+    } as HTMLElement;
+    expect(isScrollAtBottom(el, 80)).toBe(true);
+    expect(isScrollAtBottom(el, 79)).toBe(false);
+  });
+
+  it('treats an exact-gap value as not at bottom', () => {
+    const el = { scrollHeight: 500, scrollTop: 300, clientHeight: 100 } as HTMLElement;
+    expect(isScrollAtBottom(el, 100)).toBe(false);
   });
 });

--- a/src/lib/dm/resolve-dm-message-presentation.test.ts
+++ b/src/lib/dm/resolve-dm-message-presentation.test.ts
@@ -1,10 +1,93 @@
 import { describe, it, expect } from 'vitest';
-import { resolveDmMessagePresentation, isInvitePresentation } from './resolve-dm-message-presentation';
+import {
+  resolveDmMessagePresentation,
+  isInvitePresentation,
+  inviteInviterNpub,
+  getInviterDisplayFromNpub,
+  getInviterDisplay,
+  buildPlainMessageProps,
+} from './resolve-dm-message-presentation';
 import type { DmMessage } from '../../stores/dm';
+import type { PactoAppInboxEntry } from '../pacto-app-inbox';
+import type { NostrProfile } from '../api/nostr';
 
-const SAMPLE_REQUEST = `{"version":1,"type":"wallet_tx_request","request_id":"550e8400-e29b-41d4-a716-446655440000","network":"sepolia","asset":"ETH","amount":"0.05","from_evm_address":"0x1111111111111111111111111111111111111111","created_at_ms":1710000000000}`;
+const NPUB_A = 'npub1alice0000000';
+const NPUB_B = 'npub1bob00000000';
+const EVM_A = '0x1111111111111111111111111111111111111111';
+const TX_HASH = `0x${'a'.repeat(64)}`;
 
-function msg(overrides: Partial<DmMessage> = {}): DmMessage {
+const SAMPLE_REQUEST = `{"version":1,"type":"wallet_tx_request","request_id":"550e8400-e29b-41d4-a716-446655440000","network":"sepolia","asset":"ETH","amount":"0.05","from_evm_address":"${EVM_A}","created_at_ms":1710000000000}`;
+
+const CHANNEL_IN_SQUAD = JSON.stringify({
+  type: 'channel_in_squad',
+  squadName: 'Alpha',
+  announcementsGroupId: 'ag1',
+  channelGroupId: 'cg1',
+  channelName: 'general',
+});
+
+const SQUAD_INVITE = JSON.stringify({
+  type: 'squad_invite',
+  squadName: 'Alpha',
+  groupId: 'g1',
+  kind: 'squad',
+  invitedByNpub: NPUB_A,
+});
+
+const SQUAD_PAIR_INVITE = JSON.stringify({
+  type: 'squad_invite',
+  squadName: 'Pair',
+  groupId: 'g2',
+  kind: 'squad-pair',
+  pairedSquads: [
+    { id: 'a', name: 'A' },
+    { id: 'b', name: 'B' },
+  ],
+});
+
+const PEER_INFO_REQUEST = JSON.stringify({
+  version: 1,
+  type: 'wallet_peer_info_request',
+  request_id: 'r1',
+  requester_npub: NPUB_A,
+  requester_evm_address: EVM_A,
+});
+
+const PEER_INFO_GRANT = JSON.stringify({
+  version: 1,
+  type: 'wallet_peer_info_grant',
+  request_id: 'r1',
+  grantor_npub: NPUB_A,
+  evm_address: EVM_A,
+});
+
+const PEER_INFO_DECLINE = JSON.stringify({
+  version: 1,
+  type: 'wallet_peer_info_decline',
+  request_id: 'r1',
+});
+
+const WALLET_TX_ANNOUNCEMENT = JSON.stringify({
+  version: 1,
+  type: 'wallet_tx_announcement',
+  network: 'sepolia',
+  asset: 'ETH',
+  amount: '0.05',
+  tx_hash: TX_HASH,
+  from_npub: NPUB_A,
+  to_npub: NPUB_B,
+  from_evm_address: EVM_A,
+});
+
+const COMMONS_JOIN_REQUEST = JSON.stringify({
+  type: 'commons_join_request',
+  squadId: 's1',
+  squadName: 'Commons',
+  broadcastEventId: 'e1',
+  requesterNpub: NPUB_A,
+});
+
+function msg(overrides: Partial<PactoAppInboxEntry> = {}): DmMessage {
   return {
     id: 'm1',
     content: 'hello',
@@ -12,6 +95,17 @@ function msg(overrides: Partial<DmMessage> = {}): DmMessage {
     mine: false,
     ...overrides,
   };
+}
+
+function profile(overrides: Partial<NostrProfile> = {}): NostrProfile {
+  return {
+    id: NPUB_A,
+    name: 'Alice',
+    display_name: 'Alice Display',
+    nickname: 'Ally',
+    avatar: 'https://example.com/a.png',
+    ...overrides,
+  } as NostrProfile;
 }
 
 describe('resolveDmMessagePresentation', () => {
@@ -25,6 +119,54 @@ describe('resolveDmMessagePresentation', () => {
     expect(resolveDmMessagePresentation(msg({ content: 'hello' }))).toEqual({ kind: 'plain' });
   });
 
+  it('classifies channel-in-squad JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: CHANNEL_IN_SQUAD }));
+    expect(p.kind).toBe('channel-in-squad');
+    if (p.kind === 'channel-in-squad') {
+      expect(p.payload.channelGroupId).toBe('cg1');
+      expect(p.payload.channelName).toBe('general');
+    }
+  });
+
+  it('classifies squad invite JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: SQUAD_INVITE }));
+    expect(p.kind).toBe('squad-invite');
+    if (p.kind === 'squad-invite') {
+      expect(p.payload.groupId).toBe('g1');
+      expect(p.payload.squadName).toBe('Alpha');
+    }
+  });
+
+  it('classifies squad-pair invite JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: SQUAD_PAIR_INVITE }));
+    expect(p.kind).toBe('squad-pair-invite');
+    if (p.kind === 'squad-pair-invite') {
+      expect(p.payload.groupId).toBe('g2');
+      expect(p.payload.kind).toBe('squad-pair');
+    }
+  });
+
+  it('classifies wallet peer info request JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: PEER_INFO_REQUEST }));
+    expect(p.kind).toBe('wallet-peer-info-request');
+    if (p.kind === 'wallet-peer-info-request') {
+      expect(p.payload.request_id).toBe('r1');
+    }
+  });
+
+  it('classifies wallet peer info grant JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: PEER_INFO_GRANT }));
+    expect(p.kind).toBe('wallet-peer-info-grant');
+    if (p.kind === 'wallet-peer-info-grant') {
+      expect(p.payload.evm_address).toBe(EVM_A);
+    }
+  });
+
+  it('classifies wallet peer info decline JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: PEER_INFO_DECLINE }));
+    expect(p.kind).toBe('wallet-peer-info-decline');
+  });
+
   it('classifies wallet tx request JSON', () => {
     const p = resolveDmMessagePresentation(msg({ content: SAMPLE_REQUEST }));
     expect(p.kind).toBe('wallet-tx-request');
@@ -33,8 +175,208 @@ describe('resolveDmMessagePresentation', () => {
     }
   });
 
-  it('isInvitePresentation covers invite kinds only', () => {
+  it('classifies wallet tx announcement JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: WALLET_TX_ANNOUNCEMENT }));
+    expect(p.kind).toBe('wallet-tx-announcement');
+    if (p.kind === 'wallet-tx-announcement') {
+      expect(p.payload.tx_hash).toBe(TX_HASH);
+    }
+  });
+
+  it('classifies commons join request JSON', () => {
+    const p = resolveDmMessagePresentation(msg({ content: COMMONS_JOIN_REQUEST }));
+    expect(p.kind).toBe('commons-join-request');
+    if (p.kind === 'commons-join-request') {
+      expect(p.payload.squadId).toBe('s1');
+    }
+  });
+
+  it('falls back to plain for invalid or non-JSON content', () => {
+    expect(resolveDmMessagePresentation(msg({ content: 'not json' }))).toEqual({ kind: 'plain' });
+    expect(resolveDmMessagePresentation(msg({ content: '' }))).toEqual({ kind: 'plain' });
+    expect(resolveDmMessagePresentation(msg({ content: '{"type":"unknown"}' }))).toEqual({ kind: 'plain' });
+  });
+});
+
+describe('isInvitePresentation', () => {
+  it('covers invite kinds only', () => {
+    expect(isInvitePresentation({ kind: 'channel-in-squad', payload: {} as never })).toBe(true);
     expect(isInvitePresentation({ kind: 'squad-invite', payload: {} as never })).toBe(true);
+    expect(isInvitePresentation({ kind: 'squad-pair-invite', payload: {} as never })).toBe(true);
     expect(isInvitePresentation({ kind: 'plain' })).toBe(false);
+    expect(isInvitePresentation({ kind: 'wallet-tx-request', payload: {} as never })).toBe(false);
+  });
+});
+
+describe('inviteInviterNpub', () => {
+  it('reads inviterNpub from Pacto App inbox entries', () => {
+    const entry = msg({ inviterNpub: `  ${NPUB_A}  ` });
+    expect(inviteInviterNpub(entry, '__pacto_app__')).toBe(NPUB_A);
+  });
+
+  it('falls back to content inviter for Pacto App entries without inviterNpub', () => {
+    const entry = msg({ content: SQUAD_INVITE });
+    expect(inviteInviterNpub(entry, '__pacto_app__')).toBe(NPUB_A);
+  });
+
+  it('resolves peer npub for non-app threads', () => {
+    const message = msg({ npub: NPUB_B, content: 'hi' });
+    expect(inviteInviterNpub(message, NPUB_B)).toBe(NPUB_B);
+  });
+
+  it('returns null when resolved value is not an npub', () => {
+    const message = msg({ npub: 'not-an-npub', content: 'hi' });
+    expect(inviteInviterNpub(message, 'not-an-npub')).toBeNull();
+  });
+});
+
+describe('getInviterDisplayFromNpub', () => {
+  it('returns Someone when npub is missing', () => {
+    expect(getInviterDisplayFromNpub(null, {})).toEqual({
+      inviterName: 'Someone',
+      inviterAvatarSrc: null,
+    });
+    expect(getInviterDisplayFromNpub(undefined, {})).toEqual({
+      inviterName: 'Someone',
+      inviterAvatarSrc: null,
+    });
+  });
+
+  it('uses profile display name and avatar when available', () => {
+    const profiles = { [NPUB_A]: profile() };
+    const result = getInviterDisplayFromNpub(NPUB_A, profiles);
+    expect(result.inviterName).toBe('Ally');
+    expect(result.inviterAvatarSrc).toBe('https://example.com/a.png');
+  });
+
+  it('falls back to Unknown when profile is absent', () => {
+    const result = getInviterDisplayFromNpub(NPUB_A, {});
+    expect(result.inviterName).toBe('Unknown');
+    expect(result.inviterAvatarSrc).toBeNull();
+  });
+
+  it('prefers remote avatar over cached paths', () => {
+    const profiles = {
+      [NPUB_A]: profile({ avatar: 'https://example.com/remote.png', avatar_cached: '/tmp/local.png' }),
+    };
+    const result = getInviterDisplayFromNpub(NPUB_A, profiles);
+    expect(result.inviterAvatarSrc).toBe('https://example.com/remote.png');
+  });
+});
+
+describe('getInviterDisplay', () => {
+  it('uses activeDmId for messages sent by the current user', () => {
+    const message = msg({ mine: true });
+    const result = getInviterDisplay(message, NPUB_A, { [NPUB_A]: profile() });
+    expect(result.inviterName).toBe('Ally');
+  });
+
+  it('uses message npub for inbound messages', () => {
+    const message = msg({ mine: false, npub: NPUB_B });
+    const result = getInviterDisplay(message, NPUB_A, { [NPUB_B]: profile({ nickname: 'Bob' }) as NostrProfile });
+    expect(result.inviterName).toBe('Bob');
+  });
+
+  it('falls back to activeDmId when inbound message has no npub', () => {
+    const message = msg({ mine: false });
+    const result = getInviterDisplay(message, NPUB_A, { [NPUB_A]: profile() });
+    expect(result.inviterName).toBe('Ally');
+  });
+});
+
+describe('buildPlainMessageProps', () => {
+  it('builds props for an outbound message', () => {
+    const message = msg({ mine: true, content: 'hi' });
+    const props = buildPlainMessageProps(message, NPUB_B, { [NPUB_A]: profile() }, NPUB_A);
+    expect(props.authorName).toBe('You');
+    expect(props.content).toBe('hi');
+    expect(props.avatar).toBe('https://example.com/a.png');
+    expect(props.timestamp).toBe(new Date(1).toISOString());
+  });
+
+  it('builds props for an inbound message using sender profile', () => {
+    const message = msg({ mine: false, npub: NPUB_B, content: 'hello' });
+    const props = buildPlainMessageProps(
+      message,
+      NPUB_B,
+      { [NPUB_B]: profile({ nickname: 'Bob', avatar: 'https://example.com/b.png' }) as NostrProfile },
+      NPUB_A
+    );
+    expect(props.authorName).toBe('Bob');
+    expect(props.avatar).toBe('https://example.com/b.png');
+  });
+
+  it('uses the thread npub when inbound message has no sender npub', () => {
+    const message = msg({ mine: false, content: 'hello' });
+    const props = buildPlainMessageProps(message, NPUB_B, { [NPUB_B]: profile({ nickname: 'Bob' }) as NostrProfile }, NPUB_A);
+    expect(props.authorName).toBe('Bob');
+  });
+
+  it('renders reply author as You when reply is from current user', () => {
+    const message = msg({
+      mine: false,
+      replied_to: 'r1',
+      replied_to_npub: NPUB_A,
+      replied_to_content: 'original',
+    });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, NPUB_A);
+    expect(props.replyToId).toBe('r1');
+    expect(props.replyAuthorName).toBe('You');
+    expect(props.replyPreview).toBe('original');
+  });
+
+  it('renders reply author from profile when available', () => {
+    const message = msg({
+      mine: false,
+      replied_to: 'r1',
+      replied_to_npub: NPUB_B,
+      replied_to_content: 'original',
+    });
+    const props = buildPlainMessageProps(message, NPUB_B, { [NPUB_B]: profile({ nickname: 'Bob' }) as NostrProfile }, NPUB_A);
+    expect(props.replyAuthorName).toBe('Bob');
+  });
+
+  it('renders Unknown for anonymous replies', () => {
+    const message = msg({ mine: false, replied_to: 'r1' });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, NPUB_A);
+    expect(props.replyAuthorName).toBe('Unknown');
+  });
+
+  it('uses Attachment preview when reply had an attachment', () => {
+    const message = msg({
+      mine: false,
+      replied_to: 'r1',
+      replied_to_has_attachment: true,
+      replied_to_content: 'text',
+    });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, NPUB_A);
+    expect(props.replyPreview).toBe('Attachment');
+  });
+
+  it('truncates long reply content to 80 characters', () => {
+    const long = 'a'.repeat(120);
+    const message = msg({ mine: false, replied_to: 'r1', replied_to_content: long });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, NPUB_A);
+    expect(props.replyPreview).toBe(`${long.slice(0, 80)}…`);
+  });
+
+  it('renders outbound message with no current user profile', () => {
+    const message = msg({ mine: true, content: 'hi' });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, undefined);
+    expect(props.authorName).toBe('You');
+    expect(props.avatar).toBe('');
+  });
+
+  it('renders inbound message with no sender or thread npub', () => {
+    const message = msg({ mine: false, content: 'hi' });
+    const props = buildPlainMessageProps(message, undefined as unknown as string, {}, NPUB_A);
+    expect(props.authorName).toBe('Unknown');
+    expect(props.avatar).toBe('');
+  });
+
+  it('renders reply author as Unknown when reply npub has no profile', () => {
+    const message = msg({ mine: false, replied_to: 'r1', replied_to_npub: NPUB_B });
+    const props = buildPlainMessageProps(message, NPUB_B, {}, NPUB_A);
+    expect(props.replyAuthorName).toBe('Unknown');
   });
 });

--- a/src/lib/evm/abi-loader.test.ts
+++ b/src/lib/evm/abi-loader.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { listShippedAbiRefs, loadShippedAbi, parseAbiJson, resolveAbiRefFromInfraPayload } from './abi-loader';
+import {
+  listShippedAbiRefs,
+  loadShippedAbi,
+  parseAbiJson,
+  resolveAbiRefFromInfraPayload,
+} from './abi-loader';
 
 describe('abi-loader', () => {
   it('lists shipped abis', () => {
@@ -13,6 +18,14 @@ describe('abi-loader', () => {
     expect(abi?.some((e) => e.type === 'function' && e.name === 'balanceOf')).toBe(true);
   });
 
+  it('returns null for an unknown shipped abi ref', () => {
+    expect(loadShippedAbi('does-not-exist')).toBeNull();
+  });
+
+  it('trims whitespace from abi refs', () => {
+    expect(loadShippedAbi('  erc20-minimal  ')).toBeTruthy();
+  });
+
   it('parses array and foundry artifact', () => {
     const arr = parseAbiJson('[{"type":"function","name":"foo","inputs":[],"outputs":[]}]');
     expect(arr).toHaveLength(1);
@@ -20,10 +33,32 @@ describe('abi-loader', () => {
     expect(artifact).toHaveLength(1);
   });
 
+  it('throws on empty ABI input', () => {
+    expect(() => parseAbiJson('  ')).toThrow('Paste a JSON ABI array');
+  });
+
+  it('throws on non-array, non-artifact JSON', () => {
+    expect(() => parseAbiJson('{"name":"foo"}')).toThrow('ABI JSON must be an array');
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseAbiJson('{invalid')).toThrow();
+  });
+
   it('reads optional infra abiRef hook', () => {
     expect(resolveAbiRefFromInfraPayload({ custom_module: { abiRef: 'erc20-minimal' } })).toBe(
-      'erc20-minimal'
+      'erc20-minimal',
     );
     expect(resolveAbiRefFromInfraPayload({})).toBeNull();
   });
+
+  it('returns null for invalid infra payloads', () => {
+    expect(resolveAbiRefFromInfraPayload(null)).toBeNull();
+    expect(resolveAbiRefFromInfraPayload(undefined)).toBeNull();
+    expect(resolveAbiRefFromInfraPayload('string')).toBeNull();
+    expect(resolveAbiRefFromInfraPayload({ custom_module: null })).toBeNull();
+    expect(resolveAbiRefFromInfraPayload({ custom_module: { abiRef: 123 } })).toBeNull();
+    expect(resolveAbiRefFromInfraPayload({ custom_module: { abiRef: '   ' } })).toBeNull();
+  });
 });
+

--- a/src/lib/evm/calldata-builder.test.ts
+++ b/src/lib/evm/calldata-builder.test.ts
@@ -1,27 +1,65 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import {
   buildCalldataFromAbiForm,
   ethAmountToWeiString,
   isSquadInfraTargetAddress,
   normalizeCalldataHex,
   normalizeToAddress,
+  parseAbiArgsJson,
+  simulateAdvancedTransaction,
+  weiStringToEthDisplay,
 } from './calldata-builder';
 import { loadShippedAbi } from './abi-loader';
 
+vi.mock('./read-plane', () => ({
+  simulateContractCall: vi.fn(),
+}));
+
+import { simulateContractCall } from './read-plane';
+
 describe('calldata-builder', () => {
+  beforeEach(() => {
+    vi.mocked(simulateContractCall).mockReset();
+  });
+
   it('normalizes calldata hex', () => {
     expect(normalizeCalldataHex('')).toBe('0x');
+    expect(normalizeCalldataHex('0x')).toBe('0x');
     expect(normalizeCalldataHex('deadBEEF')).toBe('0xdeadbeef');
+  });
+
+  it('rejects calldata with odd length or non-hex characters', () => {
+    expect(() => normalizeCalldataHex('abc')).toThrow('even number of digits');
+    expect(() => normalizeCalldataHex('0xzz')).toThrow('non-hex characters');
   });
 
   it('validates to address', () => {
     expect(normalizeToAddress('0x1111111111111111111111111111111111111111')).toMatch(/^0x/i);
-    expect(() => normalizeToAddress('not-an-address')).toThrow();
+    expect(() => normalizeToAddress('not-an-address')).toThrow('Enter a valid 0x contract address');
   });
 
   it('converts eth to wei string', () => {
     expect(ethAmountToWeiString('0')).toBe('0');
     expect(ethAmountToWeiString('1')).toBe('1000000000000000000');
+    expect(ethAmountToWeiString('0.5')).toBe('500000000000000000');
+  });
+
+  it('converts wei to eth display', () => {
+    expect(weiStringToEthDisplay('0')).toBe('0');
+    expect(weiStringToEthDisplay('1000000000000000000')).toBe('1');
+  });
+
+  it('returns the raw input when wei cannot be parsed', () => {
+    expect(weiStringToEthDisplay('not-a-number')).toBe('not-a-number');
+  });
+
+  it('parses ABI args JSON', () => {
+    expect(parseAbiArgsJson('')).toEqual([]);
+    expect(parseAbiArgsJson('["a", 1]')).toEqual(['a', 1]);
+  });
+
+  it('throws when args JSON is not an array', () => {
+    expect(() => parseAbiArgsJson('{"a":1}')).toThrow('JSON array');
   });
 
   it('encodes erc20 balanceOf from shipped abi', () => {
@@ -40,5 +78,44 @@ describe('calldata-builder', () => {
     const target = '0xAbCdEf0123456789AbCdEf0123456789AbCdEf01';
     expect(isSquadInfraTargetAddress(target, [target.toLowerCase()])).toBe(true);
     expect(isSquadInfraTargetAddress('0x0000000000000000000000000000000000000001', [])).toBe(false);
+    expect(isSquadInfraTargetAddress('not-an-address', ['0xabc'])).toBe(false);
+  });
+
+  it('simulates an advanced transaction with normalized inputs', async () => {
+    vi.mocked(simulateContractCall).mockResolvedValue({ ok: true });
+    const result = await simulateAdvancedTransaction({
+      chainId: 'sepolia',
+      to: '0x1111111111111111111111111111111111111111',
+      valueWei: '1000',
+      dataHex: 'deadbeef',
+    });
+    expect(result).toEqual({ ok: true });
+    expect(simulateContractCall).toHaveBeenCalledWith({
+      chainId: 'sepolia',
+      to: '0x1111111111111111111111111111111111111111',
+      valueWei: 1000n,
+      data: '0xdeadbeef',
+    });
+  });
+
+  it('rejects an invalid wei value', async () => {
+    const result = await simulateAdvancedTransaction({
+      chainId: 'sepolia',
+      to: '0x1111111111111111111111111111111111111111',
+      valueWei: 'not-a-number',
+      dataHex: '0x',
+    });
+    expect(result).toEqual({ ok: false, message: 'Value must be a decimal wei string.' });
+  });
+
+  it('rejects malformed calldata', async () => {
+    await expect(
+      simulateAdvancedTransaction({
+        chainId: 'sepolia',
+        to: '0x1111111111111111111111111111111111111111',
+        valueWei: '0',
+        dataHex: 'zzzz',
+      }),
+    ).rejects.toThrow('non-hex characters');
   });
 });

--- a/src/lib/evm/pacto-protocol-addresses.test.ts
+++ b/src/lib/evm/pacto-protocol-addresses.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { pactoProtocolNetworkBook } from './pacto-protocol-addresses';
+import {
+  pactoProtocolNetworkBook,
+  pactoProtocolBookVersion,
+} from './pacto-protocol-addresses';
 
 describe('pacto-protocol-addresses', () => {
   it('loads Sepolia sponsor and gov factories from the book', () => {
@@ -7,5 +10,27 @@ describe('pacto-protocol-addresses', () => {
     expect(sepolia?.chainId).toBe(11155111);
     expect(sepolia?.squadSponsor?.factory).toBe('0x3994B38f9A0Cf542241FD9C959F94386e6733D6e');
     expect(sepolia?.pactoGov?.navePirataFactory).toBe('0x44E42cf7b2DadDe6D5fc27B57625EaF3e3D41316');
+  });
+
+  it('exposes the book version', () => {
+    expect(pactoProtocolBookVersion()).toBe(1);
+  });
+
+  it('returns undefined for an unknown network', () => {
+    expect(pactoProtocolNetworkBook('mainnet')).toBeUndefined();
+    expect(pactoProtocolNetworkBook('unknown' as never)).toBeUndefined();
+  });
+
+  it('exposes all Safe infrastructure addresses on Sepolia', () => {
+    const sepolia = pactoProtocolNetworkBook('sepolia');
+    expect(sepolia?.safe?.proxyFactory).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(sepolia?.safe?.singleton).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(sepolia?.safe?.fallbackHandler).toMatch(/^0x[a-fA-F0-9]{40}$/);
+  });
+
+  it('exposes PactoGov addresses on Sepolia', () => {
+    const sepolia = pactoProtocolNetworkBook('sepolia');
+    expect(sepolia?.pactoGov?.masterQuartermaster).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(sepolia?.pactoGov?.masterMutiny).toMatch(/^0x[a-fA-F0-9]{40}$/);
   });
 });

--- a/src/lib/evm/read-plane.test.ts
+++ b/src/lib/evm/read-plane.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Abi, Address } from 'viem';
+
+vi.mock('../wallet/chains', () => ({
+  createWalletPublicClient: vi.fn(),
+  DEFAULT_CHAIN_ID: 'sepolia',
+  SUPPORTED_CHAINS: {},
+}));
+
+vi.mock('./read-plane-limiter', () => ({
+  withReadPlaneLimit: (fn: () => Promise<unknown>) => fn(),
+}));
+
+import { createWalletPublicClient } from '../wallet/chains';
+import type { Mock } from 'vitest';
+import {
+  ReadPlaneError,
+  readContract,
+  multicall,
+  simulateContractCall,
+  getReadOnlyContract,
+} from './read-plane';
+
+describe('read-plane', () => {
+  let fakeClient: {
+    readContract: Mock;
+    multicall: Mock;
+    call: Mock;
+  };
+
+  beforeEach(() => {
+    fakeClient = {
+      readContract: vi.fn(),
+      multicall: vi.fn(),
+      call: vi.fn(),
+    };
+    vi.mocked(createWalletPublicClient).mockReset().mockReturnValue(fakeClient as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('ReadPlaneError', () => {
+    it('carries a code and message', () => {
+      const err = new ReadPlaneError('READ_CONTRACT_FAILED', 'boom');
+      expect(err.code).toBe('READ_CONTRACT_FAILED');
+      expect(err.message).toBe('boom');
+      expect(err.name).toBe('ReadPlaneError');
+    });
+  });
+
+  describe('readContract', () => {
+    it('returns the contract result', async () => {
+      fakeClient.readContract.mockResolvedValueOnce(42n);
+      const abi = [{ type: 'function', name: 'count', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi;
+      const result = await readContract({
+        chainId: 'sepolia',
+        address: '0x1111111111111111111111111111111111111111' as Address,
+        abi,
+        functionName: 'count',
+      });
+      expect(result).toBe(42n);
+      expect(fakeClient.readContract).toHaveBeenCalledWith({
+        address: '0x1111111111111111111111111111111111111111',
+        abi,
+        functionName: 'count',
+        args: undefined,
+      });
+    });
+
+    it('passes args when provided', async () => {
+      fakeClient.readContract.mockResolvedValueOnce(1n);
+      const abi = [{ type: 'function', name: 'balanceOf', inputs: [{ type: 'address', name: 'account' }], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi;
+      await readContract({
+        chainId: 'sepolia',
+        address: '0x1111111111111111111111111111111111111111' as Address,
+        abi,
+        functionName: 'balanceOf',
+        args: ['0x2222222222222222222222222222222222222222'],
+      });
+      expect(fakeClient.readContract).toHaveBeenCalledWith(expect.objectContaining({
+        functionName: 'balanceOf',
+        args: ['0x2222222222222222222222222222222222222222'],
+      }));
+    });
+
+    it('wraps errors in a ReadPlaneError', async () => {
+      fakeClient.readContract.mockRejectedValueOnce(new Error('revert'));
+      const abi = [{ type: 'function', name: 'count', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi;
+      await expect(readContract({
+        chainId: 'sepolia',
+        address: '0x1111111111111111111111111111111111111111' as Address,
+        abi,
+        functionName: 'count',
+      })).rejects.toBeInstanceOf(ReadPlaneError);
+    });
+  });
+
+  describe('multicall', () => {
+    it('returns an empty array when there are no contracts', async () => {
+      const result = await multicall({ chainId: 'sepolia', contracts: [] });
+      expect(result).toEqual([]);
+      expect(fakeClient.multicall).not.toHaveBeenCalled();
+    });
+
+    it('returns multicall results', async () => {
+      fakeClient.multicall.mockResolvedValueOnce([1n, 2n]);
+      const result = await multicall({
+        chainId: 'sepolia',
+        contracts: [
+          {
+            address: '0x1111111111111111111111111111111111111111' as Address,
+            abi: [{ type: 'function', name: 'a', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi,
+            functionName: 'a',
+          },
+          {
+            address: '0x2222222222222222222222222222222222222222' as Address,
+            abi: [{ type: 'function', name: 'b', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi,
+            functionName: 'b',
+          },
+        ],
+      });
+      expect(result).toEqual([1n, 2n]);
+      expect(fakeClient.multicall).toHaveBeenCalled();
+    });
+
+    it('wraps errors in a ReadPlaneError', async () => {
+      fakeClient.multicall.mockRejectedValueOnce(new Error('multicall revert'));
+      await expect(multicall({
+        chainId: 'sepolia',
+        contracts: [{
+          address: '0x1111111111111111111111111111111111111111' as Address,
+          abi: [{ type: 'function', name: 'a', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi,
+          functionName: 'a',
+        }],
+      })).rejects.toBeInstanceOf(ReadPlaneError);
+    });
+  });
+
+  describe('simulateContractCall', () => {
+    it('returns ok when the call succeeds', async () => {
+      fakeClient.call.mockResolvedValueOnce({ data: '0x' });
+      const result = await simulateContractCall({
+        chainId: 'sepolia',
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x',
+      });
+      expect(result).toEqual({ ok: true });
+      expect(fakeClient.call).toHaveBeenCalledWith(expect.objectContaining({
+        to: '0x1111111111111111111111111111111111111111',
+        value: 0n,
+        data: '0x',
+      }));
+    });
+
+    it('passes value and from when provided', async () => {
+      fakeClient.call.mockResolvedValueOnce({ data: '0x' });
+      await simulateContractCall({
+        chainId: 'sepolia',
+        from: '0x2222222222222222222222222222222222222222' as Address,
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        valueWei: 1000n,
+        data: '0xdeadbeef',
+      });
+      expect(fakeClient.call).toHaveBeenCalledWith({
+        account: '0x2222222222222222222222222222222222222222',
+        to: '0x1111111111111111111111111111111111111111',
+        value: 1000n,
+        data: '0xdeadbeef',
+      });
+    });
+
+    it('returns ok:false with the revert message', async () => {
+      fakeClient.call.mockRejectedValueOnce(new Error('execution reverted'));
+      const result = await simulateContractCall({
+        chainId: 'sepolia',
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x',
+      });
+      expect(result).toEqual({ ok: false, message: 'execution reverted' });
+    });
+  });
+
+  describe('getReadOnlyContract', () => {
+    it('returns a contract bound to the requested address and chain', () => {
+      const abi = [{ type: 'function', name: 'count', inputs: [], outputs: [{ type: 'uint256' }], stateMutability: 'view' }] as Abi;
+      const contract = getReadOnlyContract({
+        chainId: 'sepolia',
+        address: '0x1111111111111111111111111111111111111111' as Address,
+        abi,
+      });
+      expect(contract).toBeDefined();
+      expect(createWalletPublicClient).toHaveBeenCalledWith('sepolia');
+    });
+  });
+});

--- a/src/lib/governance/api.test.ts
+++ b/src/lib/governance/api.test.ts
@@ -1,0 +1,513 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  buildPactoGovGovernanceAnnouncePayload,
+  buildSquadAdminGovernanceAnnouncePayload,
+  buildSponsorGovernanceAnnouncePayload,
+  buildStandaloneSafeGovernanceAnnouncePayload,
+  deployNavePirataForParent,
+  deploySquadAdminForParent,
+  deploySquadSponsorForParent,
+  depositSquadSponsor,
+  getHatsTree,
+  getMemberHatWearers,
+  getNavePirataDeployment,
+  getSquadAdminExecutorRoles,
+  getSquadSponsorSummary,
+  hasSponsorInfra,
+  infraTypeFromLegacyProvider,
+  listSquadInfra,
+  listTreasuryProposals,
+  pactoGovInfraId,
+  pactoGovInfraRow,
+  pactoGovTreasuryEntryId,
+  primaryGovernanceView,
+  squadAdminCreateRole,
+  squadAdminEnableExecutor,
+  squadAdminEnableFullPermission,
+  squadAdminInfraId,
+  squadAdminInfraRow,
+  squadInfraLegacyProvider,
+  squadSponsorInfraId,
+  sponsorInfraRow,
+  treasuryProposalHasVoted,
+  upsertSquadInfra,
+  withLegacyProvider,
+} from './api';
+import type { SquadInfraDto } from './api';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+const PARENT = 'test-parent';
+const NETWORK = 'sepolia';
+
+function makeSquadInfra(overrides: Partial<SquadInfraDto> = {}): SquadInfraDto {
+  return {
+    id: 'id-1',
+    parentId: PARENT,
+    infraType: 'pacto_gov',
+    chain: 'sepolia',
+    canonicalRef: '0x1234567890123456789012345678901234567890',
+    createdAtMs: 1,
+    updatedAtMs: 2,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('squad infra helpers', () => {
+  it('squadInfraLegacyProvider maps standalone_safe to gnosis_safe and leaves others unchanged', () => {
+    expect(squadInfraLegacyProvider('standalone_safe')).toBe('gnosis_safe');
+    expect(squadInfraLegacyProvider('pacto_gov')).toBe('pacto_gov');
+    expect(squadInfraLegacyProvider('sponsor')).toBe('sponsor');
+  });
+
+  it('withLegacyProvider adds provider field', () => {
+    const row = makeSquadInfra({ infraType: 'standalone_safe' });
+    expect(withLegacyProvider(row)).toEqual({ ...row, provider: 'gnosis_safe' });
+  });
+
+  it('primaryGovernanceView returns undefined for undefined rows', () => {
+    expect(primaryGovernanceView(undefined)).toBeUndefined();
+  });
+
+  it('primaryGovernanceView returns null for empty rows', () => {
+    expect(primaryGovernanceView([])).toBeNull();
+  });
+
+  it('primaryGovernanceView prefers pacto_gov, then standalone_safe, then first row', () => {
+    const sponsor = makeSquadInfra({ infraType: 'sponsor' });
+    const standalone = makeSquadInfra({ infraType: 'standalone_safe' });
+    const pacto = makeSquadInfra({ infraType: 'pacto_gov' });
+    expect(primaryGovernanceView([sponsor, standalone, pacto])?.infraType).toBe('pacto_gov');
+    expect(primaryGovernanceView([sponsor, standalone])?.infraType).toBe('standalone_safe');
+    expect(primaryGovernanceView([sponsor])?.infraType).toBe('sponsor');
+  });
+
+  it('infraTypeFromLegacyProvider normalizes aliases', () => {
+    expect(infraTypeFromLegacyProvider('gnosis_safe')).toBe('standalone_safe');
+    expect(infraTypeFromLegacyProvider('gnosis-safe')).toBe('standalone_safe');
+    expect(infraTypeFromLegacyProvider('safe')).toBe('standalone_safe');
+    expect(infraTypeFromLegacyProvider('pacto-gov')).toBe('pacto_gov');
+    expect(infraTypeFromLegacyProvider('squad_sponsor')).toBe('sponsor');
+    expect(infraTypeFromLegacyProvider('squad_admin')).toBe('squad_admin');
+    expect(infraTypeFromLegacyProvider('squad-admin')).toBe('squad_admin');
+    expect(infraTypeFromLegacyProvider('pacto_gov')).toBe('pacto_gov');
+  });
+
+  it('id builders return stable parent-scoped ids', () => {
+    expect(pactoGovInfraId(PARENT)).toBe(`pacto-gov-${PARENT}`);
+    expect(pactoGovTreasuryEntryId(PARENT)).toBe(`pacto-gov-treasury-${PARENT}`);
+    expect(squadSponsorInfraId(PARENT)).toBe(`sponsor-${PARENT}`);
+    expect(squadAdminInfraId(PARENT)).toBe(`squad-admin-${PARENT}`);
+  });
+
+  it('row finders return the matching row or null', () => {
+    const pacto = makeSquadInfra({ infraType: 'pacto_gov' });
+    const sponsor = makeSquadInfra({ infraType: 'sponsor' });
+    const admin = makeSquadInfra({ infraType: 'squad_admin' });
+    expect(pactoGovInfraRow([pacto, sponsor, admin])).toEqual(pacto);
+    expect(sponsorInfraRow([pacto, sponsor, admin])).toEqual(sponsor);
+    expect(squadAdminInfraRow([pacto, sponsor, admin])).toEqual(admin);
+    expect(hasSponsorInfra([pacto, sponsor])).toBe(true);
+    expect(hasSponsorInfra([pacto])).toBe(false);
+    expect(pactoGovInfraRow([])).toBeNull();
+    expect(pactoGovInfraRow(undefined)).toBeNull();
+  });
+});
+
+describe('api command wrappers', () => {
+  it('listSquadInfra sends list_squad_infra with parentId', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await listSquadInfra(PARENT);
+    expect(mockedInvoke).toHaveBeenCalledWith('list_squad_infra', { parentId: PARENT });
+  });
+
+  it('listSquadInfra coerces null/undefined to empty array', async () => {
+    mockedInvoke.mockResolvedValueOnce(null);
+    await expect(listSquadInfra(PARENT)).resolves.toEqual([]);
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await expect(listSquadInfra(PARENT)).resolves.toEqual([]);
+  });
+
+  it('upsertSquadInfra sends upsert_squad_infra with normalized nulls', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await upsertSquadInfra({
+      id: 'id-1',
+      parentId: PARENT,
+      infraType: 'pacto_gov',
+      canonicalRef: '0x1234',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('upsert_squad_infra', {
+      id: 'id-1',
+      parentId: PARENT,
+      infraType: 'pacto_gov',
+      chain: null,
+      canonicalRef: '0x1234',
+      pactoGovRevision: null,
+      providerPayload: null,
+    });
+  });
+
+  it('depositSquadSponsor sends deposit_squad_sponsor with trimmed sponsor address', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await depositSquadSponsor({
+      network: NETWORK,
+      parentId: PARENT,
+      amountWei: '1000',
+      sponsorAddress: ' 0xabc ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('deposit_squad_sponsor', {
+      network: NETWORK,
+      parentId: PARENT,
+      amountWei: '1000',
+      sponsorAddress: '0xabc',
+    });
+  });
+
+  it('depositSquadSponsor normalizes empty sponsor address to null', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await depositSquadSponsor({ network: NETWORK, parentId: PARENT, amountWei: '1000' });
+    expect(mockedInvoke).toHaveBeenCalledWith('deposit_squad_sponsor', {
+      network: NETWORK,
+      parentId: PARENT,
+      amountWei: '1000',
+      sponsorAddress: null,
+    });
+  });
+
+  it('deploySquadSponsorForParent sends deploy_squad_sponsor_for_parent with defaults', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await deploySquadSponsorForParent({ network: NETWORK, parentId: PARENT });
+    expect(mockedInvoke).toHaveBeenCalledWith('deploy_squad_sponsor_for_parent', {
+      network: NETWORK,
+      parentId: PARENT,
+      initialDepositWei: null,
+      signerWallet: 'squad',
+    });
+  });
+
+  it('deploySquadSponsorForParent passes optional params when provided', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await deploySquadSponsorForParent({
+      network: NETWORK,
+      parentId: PARENT,
+      initialDepositWei: '1000',
+      signerWallet: 'default',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('deploy_squad_sponsor_for_parent', {
+      network: NETWORK,
+      parentId: PARENT,
+      initialDepositWei: '1000',
+      signerWallet: 'default',
+    });
+  });
+
+  it('getSquadSponsorSummary sends get_squad_sponsor_summary', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await getSquadSponsorSummary({ network: NETWORK, parentId: PARENT });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_squad_sponsor_summary', {
+      network: NETWORK,
+      parentId: PARENT,
+      sponsorAddress: null,
+    });
+  });
+
+  it('deployNavePirataForParent sends deploy_nave_pirata_for_parent', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await deployNavePirataForParent({
+      network: NETWORK,
+      parentId: PARENT,
+      captain: '0xabc',
+      metadataUri: ' https://example.com ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('deploy_nave_pirata_for_parent', {
+      network: NETWORK,
+      parentId: PARENT,
+      captain: '0xabc',
+      metadataUri: 'https://example.com',
+      saltNonce: null,
+    });
+  });
+
+  it('getNavePirataDeployment sends get_nave_pirata_deployment with trimmed topHatId', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await getNavePirataDeployment({ network: NETWORK, topHatId: ' 42 ' });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_nave_pirata_deployment', {
+      network: NETWORK,
+      topHatId: '42',
+    });
+  });
+
+  it('listTreasuryProposals sends list_treasury_proposals', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await listTreasuryProposals({ network: NETWORK, treasuryAuthority: '0xabc' });
+    expect(mockedInvoke).toHaveBeenCalledWith('list_treasury_proposals', {
+      network: NETWORK,
+      treasuryAuthority: '0xabc',
+      maxScan: null,
+    });
+  });
+
+  it('listTreasuryProposals passes maxScan when provided', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await listTreasuryProposals({ network: NETWORK, treasuryAuthority: '0xabc', maxScan: 50 });
+    expect(mockedInvoke).toHaveBeenCalledWith('list_treasury_proposals', {
+      network: NETWORK,
+      treasuryAuthority: '0xabc',
+      maxScan: 50,
+    });
+  });
+
+  it('treasuryProposalHasVoted sends treasury_proposal_has_voted with trimmed inputs', async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+    await treasuryProposalHasVoted({
+      network: NETWORK,
+      treasuryAuthority: ' 0xabc ',
+      proposalId: ' 1 ',
+      voter: ' 0xdef ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('treasury_proposal_has_voted', {
+      network: NETWORK,
+      treasuryAuthority: '0xabc',
+      proposalId: '1',
+      voter: '0xdef',
+    });
+  });
+
+  it('getHatsTree sends get_hats_tree with defaults', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await getHatsTree({ network: NETWORK, topHatId: '42' });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_hats_tree', {
+      network: NETWORK,
+      topHatId: '42',
+      maxDepth: null,
+      maxNodes: null,
+    });
+  });
+
+  it('getHatsTree passes optional depth and node limits', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await getHatsTree({ network: NETWORK, topHatId: '42', maxDepth: 3, maxNodes: 100 });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_hats_tree', {
+      network: NETWORK,
+      topHatId: '42',
+      maxDepth: 3,
+      maxNodes: 100,
+    });
+  });
+
+  it('getMemberHatWearers sends get_member_hat_wearers', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    const hatChecks = [{ hatId: '1', label: 'Captain' }];
+    await getMemberHatWearers({
+      network: NETWORK,
+      memberAddresses: ['0xabc'],
+      hatChecks,
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_member_hat_wearers', {
+      network: NETWORK,
+      hatsContract: null,
+      memberAddresses: ['0xabc'],
+      hatChecks,
+    });
+  });
+
+  it('getMemberHatWearers passes hatsContract when provided', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    await getMemberHatWearers({
+      network: NETWORK,
+      hatsContract: ' 0xcontract ',
+      memberAddresses: ['0xabc'],
+      hatChecks: [{ hatId: '1', label: 'Captain' }],
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_member_hat_wearers', {
+      network: NETWORK,
+      hatsContract: '0xcontract',
+      memberAddresses: ['0xabc'],
+      hatChecks: [{ hatId: '1', label: 'Captain' }],
+    });
+  });
+
+  it('getSquadAdminExecutorRoles sends get_squad_admin_executor_roles', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await getSquadAdminExecutorRoles({
+      network: NETWORK,
+      squadAdminProxy: ' 0xadmin ',
+      executorAddress: ' 0xexec ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('get_squad_admin_executor_roles', {
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      executorAddress: '0xexec',
+    });
+  });
+
+  it('deploySquadAdminForParent sends deploy_squad_admin_for_parent with optional owner and captainHatId', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await deploySquadAdminForParent({
+      network: NETWORK,
+      parentId: PARENT,
+      variant: 'captain_hat',
+      owner: ' 0xowner ',
+      captainHatId: ' 42 ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('deploy_squad_admin_for_parent', {
+      network: NETWORK,
+      parentId: PARENT,
+      variant: 'captain_hat',
+      owner: '0xowner',
+      captainHatId: '42',
+    });
+  });
+
+  it('deploySquadAdminForParent sends deploy_squad_admin_for_parent with null optional fields', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await deploySquadAdminForParent({
+      network: NETWORK,
+      parentId: PARENT,
+      variant: 'ext_standalone',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('deploy_squad_admin_for_parent', {
+      network: NETWORK,
+      parentId: PARENT,
+      variant: 'ext_standalone',
+      owner: null,
+      captainHatId: null,
+    });
+  });
+
+  it('squadAdminCreateRole sends squad_admin_create_role with trimmed label', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await squadAdminCreateRole({
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      roleLabel: ' Treasurer ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('squad_admin_create_role', {
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      roleLabel: 'Treasurer',
+    });
+  });
+
+  it('squadAdminEnableExecutor sends squad_admin_enable_executor', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await squadAdminEnableExecutor({
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      executorAddress: '0xexec',
+      roleLabel: ' Treasurer ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('squad_admin_enable_executor', {
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      executorAddress: '0xexec',
+      roleLabel: 'Treasurer',
+    });
+  });
+
+  it('squadAdminEnableFullPermission sends squad_admin_enable_full_permission', async () => {
+    mockedInvoke.mockResolvedValueOnce({});
+    await squadAdminEnableFullPermission({
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      executorAddress: '0xexec',
+      enable: true,
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('squad_admin_enable_full_permission', {
+      network: NETWORK,
+      squadAdminProxy: '0xadmin',
+      executorAddress: '0xexec',
+      enable: true,
+    });
+  });
+});
+
+describe('governance announce payload builders', () => {
+  it('buildSponsorGovernanceAnnouncePayload returns sponsor-shaped payload', () => {
+    const payload = buildSponsorGovernanceAnnouncePayload({
+      parentId: PARENT,
+      sponsorAddress: '0x1111111111111111111111111111111111111111',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId: squadSponsorInfraId(PARENT),
+    });
+    expect(payload).toEqual({
+      parent_id: PARENT,
+      provider: 'sponsor',
+      canonical_ref: '0x1111111111111111111111111111111111111111',
+      chain: 'sepolia',
+      entry_id: squadSponsorInfraId(PARENT),
+      provider_payload: '{"v":1}',
+    });
+  });
+
+  it('buildPactoGovGovernanceAnnouncePayload omits revision when missing', () => {
+    const payload = buildPactoGovGovernanceAnnouncePayload({
+      parentId: PARENT,
+      topHatId: '42',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId: pactoGovInfraId(PARENT),
+    });
+    expect(payload.pacto_gov_revision).toBeUndefined();
+    expect(payload.provider).toBe('pacto_gov');
+  });
+
+  it('buildPactoGovGovernanceAnnouncePayload includes revision when provided', () => {
+    const payload = buildPactoGovGovernanceAnnouncePayload({
+      parentId: PARENT,
+      topHatId: '42',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId: pactoGovInfraId(PARENT),
+      pactoGovRevision: 'rev-1',
+    });
+    expect(payload.pacto_gov_revision).toBe('rev-1');
+  });
+
+  it('buildSquadAdminGovernanceAnnouncePayload returns squad_admin-shaped payload', () => {
+    const payload = buildSquadAdminGovernanceAnnouncePayload({
+      parentId: PARENT,
+      squadAdminProxy: '0x2222222222222222222222222222222222222222',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId: squadAdminInfraId(PARENT),
+    });
+    expect(payload).toEqual({
+      parent_id: PARENT,
+      provider: 'squad_admin',
+      canonical_ref: '0x2222222222222222222222222222222222222222',
+      chain: 'sepolia',
+      entry_id: squadAdminInfraId(PARENT),
+      provider_payload: '{"v":1}',
+    });
+  });
+
+  it('buildStandaloneSafeGovernanceAnnouncePayload returns gnosis_safe-shaped payload', () => {
+    const payload = buildStandaloneSafeGovernanceAnnouncePayload({
+      parentId: PARENT,
+      safeAddress: '0x3333333333333333333333333333333333333333',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId: 'vault-1',
+    });
+    expect(payload).toEqual({
+      parent_id: PARENT,
+      provider: 'gnosis_safe',
+      canonical_ref: '0x3333333333333333333333333333333333333333',
+      chain: 'sepolia',
+      entry_id: 'vault-1',
+      provider_payload: '{"v":1}',
+    });
+  });
+});

--- a/src/lib/governance/governance-announce-payload.test.ts
+++ b/src/lib/governance/governance-announce-payload.test.ts
@@ -43,6 +43,45 @@ describe('governance_updated announce payloads (A4 wire shape)', () => {
     expect(payload.entry_id).toBe(entryId);
   });
 
+  it('pacto_gov payload includes pacto_gov_revision when provided', () => {
+    const entryId = pactoGovInfraId(PARENT);
+    const payload = buildPactoGovGovernanceAnnouncePayload({
+      parentId: PARENT,
+      topHatId: '42',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId,
+      pactoGovRevision: 'rev-1',
+    });
+    expect(payload.pacto_gov_revision).toBe('rev-1');
+  });
+
+  it('pacto_gov payload omits pacto_gov_revision when missing', () => {
+    const entryId = pactoGovInfraId(PARENT);
+    const payload = buildPactoGovGovernanceAnnouncePayload({
+      parentId: PARENT,
+      topHatId: '42',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId,
+    });
+    expect(payload.pacto_gov_revision).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(payload, 'pacto_gov_revision')).toBe(false);
+  });
+
+  it('pacto_gov payload omits pacto_gov_revision when only whitespace', () => {
+    const entryId = pactoGovInfraId(PARENT);
+    const payload = buildPactoGovGovernanceAnnouncePayload({
+      parentId: PARENT,
+      topHatId: '42',
+      chain: 'sepolia',
+      providerPayload: '{"v":1}',
+      entryId,
+      pactoGovRevision: '  ',
+    });
+    expect(payload.pacto_gov_revision).toBeUndefined();
+  });
+
   it('squad_admin payload maps provider for ingest', () => {
     const entryId = squadAdminInfraId(PARENT);
     const proxy = '0x2222222222222222222222222222222222222222';

--- a/src/lib/governance/squad-allowlist.test.ts
+++ b/src/lib/governance/squad-allowlist.test.ts
@@ -1,11 +1,32 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { sendDmMessage } from '../api/nostr';
 import {
   buildAllowlistAnnouncePayload,
+  evmSendSquadAllowlistedContractCall,
   findAllowlistLabel,
   formatAllowlistAnnounceMessage,
+  listSquadContractAllowlist,
+  publishSquadAllowlistAnnounce,
+  removeSquadContractAllowlist,
   squadAllowlistEntryId,
   type SquadContractAllowlistRow,
+  type SquadAllowlistedSendOutcome,
+  upsertSquadContractAllowlist,
 } from './squad-allowlist';
+
+vi.mock('@tauri-apps/api/core');
+vi.mock('../api/nostr', () => ({
+  sendDmMessage: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedSendDmMessage = vi.mocked(sendDmMessage);
+
+function failureMessage(outcome: SquadAllowlistedSendOutcome): string {
+  if (outcome.ok) throw new Error('expected failure outcome');
+  return outcome.message;
+}
 
 const PARENT = 'test-parent-mls-id';
 const ROW: SquadContractAllowlistRow = {
@@ -18,6 +39,17 @@ const ROW: SquadContractAllowlistRow = {
   createdAtMs: 1,
   updatedAtMs: 1,
 };
+
+beforeEach(() => {
+  vi.stubGlobal('window', { __TAURI__: {} });
+  mockedInvoke.mockReset();
+  mockedSendDmMessage.mockReset().mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
 
 describe('squad allowlist helpers', () => {
   it('builds stable entry ids', () => {
@@ -36,5 +68,208 @@ describe('squad allowlist helpers', () => {
   it('finds label for matching target', () => {
     expect(findAllowlistLabel([ROW], 'sepolia', ROW.contractAddress)).toBe('Test protocol');
     expect(findAllowlistLabel([ROW], 'mainnet', ROW.contractAddress)).toBeNull();
+  });
+
+  it('findAllowlistLabel is case-insensitive for chain and address', () => {
+    expect(findAllowlistLabel([ROW], 'SEPOLIA', '0x1111111111111111111111111111111111111111')).toBe(
+      'Test protocol',
+    );
+  });
+
+  it('findAllowlistLabel returns null when rows are empty', () => {
+    expect(findAllowlistLabel([], 'sepolia', ROW.contractAddress)).toBeNull();
+  });
+
+  it('findAllowlistLabel returns null when label is missing or whitespace', () => {
+    const row = { ...ROW, label: '  ' };
+    expect(findAllowlistLabel([row], 'sepolia', ROW.contractAddress)).toBeNull();
+  });
+
+  it('buildAllowlistAnnouncePayload returns minimal payload for remove action', () => {
+    const payload = buildAllowlistAnnouncePayload({ parentId: PARENT, action: 'remove', row: ROW });
+    expect(payload).toEqual({
+      parent_id: PARENT,
+      entry_id: ROW.id,
+      action: 'remove',
+    });
+    expect(payload.chain).toBeUndefined();
+  });
+});
+
+describe('squad allowlist command wrappers', () => {
+  it('listSquadContractAllowlist sends list_squad_contract_allowlist', async () => {
+    mockedInvoke.mockResolvedValueOnce([ROW]);
+    await listSquadContractAllowlist(PARENT);
+    expect(mockedInvoke).toHaveBeenCalledWith('list_squad_contract_allowlist', { parentId: PARENT });
+  });
+
+  it('listSquadContractAllowlist returns empty array when not in Tauri', async () => {
+    vi.unstubAllGlobals();
+    await expect(listSquadContractAllowlist(PARENT)).resolves.toEqual([]);
+  });
+
+  it('listSquadContractAllowlist returns empty array when parentId is empty', async () => {
+    mockedInvoke.mockResolvedValueOnce([ROW]);
+    await expect(listSquadContractAllowlist('  ')).resolves.toEqual([]);
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it('upsertSquadContractAllowlist sends upsert_squad_contract_allowlist with trimmed fields', async () => {
+    mockedInvoke.mockResolvedValueOnce(ROW);
+    await upsertSquadContractAllowlist({
+      parentId: ` ${PARENT} `,
+      chain: ' sepolia ',
+      contractAddress: ' 0x2222222222222222222222222222222222222222 ',
+      label: 'Protocol',
+      abiRef: '  abi-1  ',
+      notes: '  note  ',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('upsert_squad_contract_allowlist', {
+      parentId: PARENT,
+      chain: 'sepolia',
+      contractAddress: '0x2222222222222222222222222222222222222222',
+      label: 'Protocol',
+      abiRef: 'abi-1',
+      notes: 'note',
+    });
+  });
+
+  it('upsertSquadContractAllowlist normalizes empty abiRef and notes to null', async () => {
+    mockedInvoke.mockResolvedValueOnce(ROW);
+    await upsertSquadContractAllowlist({
+      parentId: PARENT,
+      chain: 'sepolia',
+      contractAddress: '0x2222222222222222222222222222222222222222',
+      label: 'Protocol',
+      abiRef: '  ',
+      notes: '',
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'upsert_squad_contract_allowlist',
+      expect.objectContaining({ abiRef: null, notes: null }),
+    );
+  });
+
+  it('removeSquadContractAllowlist sends remove_squad_contract_allowlist with trimmed inputs', async () => {
+    await removeSquadContractAllowlist(` ${PARENT} `, ` ${ROW.id} `);
+    expect(mockedInvoke).toHaveBeenCalledWith('remove_squad_contract_allowlist', {
+      parentId: PARENT,
+      id: ROW.id,
+    });
+  });
+
+  it('evmSendSquadAllowlistedContractCall sends allowlisted send with defaults', async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      txHash: '0xabc',
+      network: 'sepolia',
+      chainId: 11155111,
+    });
+    const result = await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '1000',
+      dataHex: '0x1234',
+    });
+    expect(result.ok).toBe(true);
+    expect(mockedInvoke).toHaveBeenCalledWith('evm_send_squad_allowlisted_contract_call', {
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '1000',
+      dataHex: '0x1234',
+      waitForConfirmation: false,
+    });
+  });
+
+  it('evmSendSquadAllowlistedContractCall normalizes empty value and data', async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      txHash: '0xabc',
+      network: 'sepolia',
+      chainId: 11155111,
+    });
+    await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '  ',
+      dataHex: '  ',
+      waitForConfirmation: true,
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'evm_send_squad_allowlisted_contract_call',
+      expect.objectContaining({ valueWei: '0', dataHex: '0x', waitForConfirmation: true }),
+    );
+  });
+
+  it('evmSendSquadAllowlistedContractCall returns desktop-only message outside Tauri', async () => {
+    vi.unstubAllGlobals();
+    const result = await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '0',
+      dataHex: '0x',
+    });
+    expect(result.ok).toBe(false);
+    expect(failureMessage(result)).toContain('desktop app');
+  });
+
+  it('evmSendSquadAllowlistedContractCall parses wallet errors on failure', async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error('User rejected'));
+    const result = await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '0',
+      dataHex: '0x',
+    });
+    expect(result.ok).toBe(false);
+    expect(failureMessage(result)).toBeTruthy();
+  });
+
+  it('evmSendSquadAllowlistedContractCall handles string rejection', async () => {
+    mockedInvoke.mockRejectedValueOnce('User rejected');
+    const result = await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '0',
+      dataHex: '0x',
+    });
+    expect(result.ok).toBe(false);
+    expect(failureMessage(result)).toBe('User rejected');
+  });
+
+  it('evmSendSquadAllowlistedContractCall handles non-Error object rejection', async () => {
+    mockedInvoke.mockRejectedValueOnce({ code: 1 });
+    const result = await evmSendSquadAllowlistedContractCall({
+      parentId: PARENT,
+      network: 'sepolia',
+      to: '0x2222222222222222222222222222222222222222',
+      valueWei: '0',
+      dataHex: '0x',
+    });
+    expect(result.ok).toBe(false);
+    expect(failureMessage(result)).toBe('Squad allowlisted send failed.');
+  });
+});
+
+describe('publishSquadAllowlistAnnounce', () => {
+  it('sends a DM when announcements group id is present', async () => {
+    const payload = buildAllowlistAnnouncePayload({ parentId: PARENT, action: 'upsert', row: ROW });
+    await publishSquadAllowlistAnnounce('announcements-group', payload);
+    expect(mockedSendDmMessage).toHaveBeenCalledWith(
+      'announcements-group',
+      formatAllowlistAnnounceMessage(payload),
+      '',
+      { virtualBucket: 'inbox' },
+    );
+  });
+
+  it('is a no-op when announcements group id is empty', async () => {
+    const payload = buildAllowlistAnnouncePayload({ parentId: PARENT, action: 'upsert', row: ROW });
+    await publishSquadAllowlistAnnounce('  ', payload);
+    expect(mockedSendDmMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/governance/standalone-safe-payload.test.ts
+++ b/src/lib/governance/standalone-safe-payload.test.ts
@@ -2,8 +2,26 @@ import { describe, expect, it } from 'vitest';
 import {
   buildStandaloneSafeProviderPayload,
   isPactoGovTreasurySafe,
+  pactoGovPayloadFromInfra,
   parseStandaloneSafeProviderPayload,
+  standaloneSafeInfraRows,
 } from './standalone-safe-payload';
+import type { SquadInfraDto } from './api';
+
+const PARENT = 'test-parent';
+
+function makeSquadInfra(overrides: Partial<SquadInfraDto> = {}): SquadInfraDto {
+  return {
+    id: 'id-1',
+    parentId: PARENT,
+    infraType: 'pacto_gov',
+    chain: 'sepolia',
+    canonicalRef: '0x1234567890123456789012345678901234567890',
+    createdAtMs: 1,
+    updatedAtMs: 2,
+    ...overrides,
+  };
+}
 
 describe('isPactoGovTreasurySafe', () => {
   it('matches pacto-gov treasury safe case-insensitively', () => {
@@ -16,6 +34,82 @@ describe('isPactoGovTreasurySafe', () => {
 
   it('returns false when pacto payload has no safe', () => {
     expect(isPactoGovTreasurySafe('0x1234567890123456789012345678901234567890', {})).toBe(false);
+  });
+
+  it('returns false when pacto payload is null', () => {
+    expect(isPactoGovTreasurySafe('0x1234567890123456789012345678901234567890', null)).toBe(false);
+  });
+
+  it('returns false when safe addresses do not match', () => {
+    expect(
+      isPactoGovTreasurySafe('0x1111111111111111111111111111111111111111', {
+        safe: '0x2222222222222222222222222222222222222222',
+      }),
+    ).toBe(false);
+  });
+
+  it('trims whitespace from both addresses before comparing', () => {
+    expect(
+      isPactoGovTreasurySafe('  0xabcdef0123456789012345678901234567890abcd  ', {
+        safe: '  0xAbCdEf0123456789012345678901234567890AbCd  ',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when safe is whitespace-only', () => {
+    expect(
+      isPactoGovTreasurySafe('0x1234567890123456789012345678901234567890', {
+        safe: '  ',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('standaloneSafeInfraRows', () => {
+  it('returns only standalone_safe rows', () => {
+    const rows = [
+      makeSquadInfra({ infraType: 'standalone_safe', id: 's1' }),
+      makeSquadInfra({ infraType: 'pacto_gov', id: 'p1' }),
+      makeSquadInfra({ infraType: 'standalone_safe', id: 's2' }),
+    ];
+    const result = standaloneSafeInfraRows(rows);
+    expect(result.map((r) => r.id)).toEqual(['s1', 's2']);
+  });
+
+  it('returns empty array for undefined rows', () => {
+    expect(standaloneSafeInfraRows(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when no standalone rows exist', () => {
+    expect(standaloneSafeInfraRows([makeSquadInfra({ infraType: 'pacto_gov' })])).toEqual([]);
+  });
+});
+
+describe('pactoGovPayloadFromInfra', () => {
+  it('parses provider payload from pacto_gov row', () => {
+    const payload = { safe: '0x1234', v: 1 };
+    const rows = [
+      makeSquadInfra({ infraType: 'pacto_gov', providerPayload: JSON.stringify(payload) }),
+    ];
+    expect(pactoGovPayloadFromInfra(rows)).toEqual(payload);
+  });
+
+  it('returns null when no pacto_gov row exists', () => {
+    expect(pactoGovPayloadFromInfra([makeSquadInfra({ infraType: 'sponsor' })])).toBeNull();
+  });
+
+  it('returns null when payload is invalid JSON', () => {
+    const rows = [
+      makeSquadInfra({ infraType: 'pacto_gov', providerPayload: 'not-json' }),
+    ];
+    expect(pactoGovPayloadFromInfra(rows)).toBeNull();
+  });
+
+  it('returns null when payload is empty', () => {
+    const rows = [
+      makeSquadInfra({ infraType: 'pacto_gov', providerPayload: '  ' }),
+    ];
+    expect(pactoGovPayloadFromInfra(rows)).toBeNull();
   });
 });
 
@@ -31,5 +125,23 @@ describe('standalone safe provider payload', () => {
     expect(parsed?.treasuryEntryId).toBe('vault-1');
     expect(parsed?.label).toBe('Ops');
     expect(parsed?.tx_hash).toBe('0xabc');
+  });
+
+  it('omits optional label and txHash when blank', () => {
+    const raw = buildStandaloneSafeProviderPayload({
+      treasuryEntryId: 'vault-1',
+      safeAddress: '0x1234567890123456789012345678901234567890',
+      label: '  ',
+      txHash: '',
+    });
+    const parsed = parseStandaloneSafeProviderPayload(raw);
+    expect(parsed).toEqual({ v: 1, treasuryEntryId: 'vault-1', safe_address: '0x1234567890123456789012345678901234567890' });
+  });
+
+  it('parseStandaloneSafeProviderPayload returns null for empty or malformed input', () => {
+    expect(parseStandaloneSafeProviderPayload(null)).toBeNull();
+    expect(parseStandaloneSafeProviderPayload('')).toBeNull();
+    expect(parseStandaloneSafeProviderPayload('  ')).toBeNull();
+    expect(parseStandaloneSafeProviderPayload('not-json')).toBeNull();
   });
 });

--- a/src/lib/governance/treasury-proposal-ui.test.ts
+++ b/src/lib/governance/treasury-proposal-ui.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isTreasuryProposalActive,
+  isTreasuryProposalPast,
+  resolveProposalVoteUiState,
+  treasuryProposalOutcomeLabel,
+} from './treasury-proposal-ui';
+import { treasuryProposalStatusLabel } from './pacto-gov-payload';
+import type { TreasuryProposalDto } from './api';
+
+const BASE_PROPOSAL: TreasuryProposalDto = {
+  proposalId: '1',
+  proposer: '0xabc',
+  to: '0xdef',
+  valueWei: '1000',
+  operation: 'call',
+  dataHex: '0x',
+  deadline: 1000,
+  snapshot: 1,
+  yeas: 0,
+  nays: 0,
+  captainApproved: false,
+  captainDefeated: false,
+  executed: false,
+  status: 'active',
+};
+
+describe('treasury proposal status helpers', () => {
+  it('isTreasuryProposalActive returns true for active statuses', () => {
+    expect(isTreasuryProposalActive('active')).toBe(true);
+    expect(isTreasuryProposalActive('active_passed_crew')).toBe(true);
+  });
+
+  it('isTreasuryProposalActive returns false for non-active statuses', () => {
+    expect(isTreasuryProposalActive('executed')).toBe(false);
+    expect(isTreasuryProposalActive('captain_vetoed')).toBe(false);
+    expect(isTreasuryProposalActive('expired')).toBe(false);
+  });
+
+  it('isTreasuryProposalPast is the inverse of active', () => {
+    expect(isTreasuryProposalPast('active')).toBe(false);
+    expect(isTreasuryProposalPast('executed')).toBe(true);
+  });
+
+  it('treasuryProposalOutcomeLabel returns labels for terminal statuses', () => {
+    expect(treasuryProposalOutcomeLabel('executed')).toBe('Passed — executed');
+    expect(treasuryProposalOutcomeLabel('captain_vetoed')).toBe('Failed — captain veto');
+    expect(treasuryProposalOutcomeLabel('expired')).toBe('Failed — expired');
+    expect(treasuryProposalOutcomeLabel('active_passed_crew')).toBe(
+      'Crew passed — awaiting captain / execute',
+    );
+    expect(treasuryProposalOutcomeLabel('active')).toBeNull();
+    expect(treasuryProposalOutcomeLabel('unknown')).toBeNull();
+  });
+
+  it('treasuryProposalStatusLabel returns status labels', () => {
+    expect(treasuryProposalStatusLabel('executed')).toBe('Executed');
+    expect(treasuryProposalStatusLabel('captain_vetoed')).toBe('Captain vetoed');
+    expect(treasuryProposalStatusLabel('expired')).toBe('Expired');
+    expect(treasuryProposalStatusLabel('active_passed_crew')).toBe(
+      'Crew passed — awaiting captain / execute',
+    );
+    expect(treasuryProposalStatusLabel('active')).toBe('Active');
+    expect(treasuryProposalStatusLabel('unknown')).toBe('unknown');
+  });
+});
+
+describe('resolveProposalVoteUiState', () => {
+  it('returns not_voted for past proposals regardless of other params', () => {
+    expect(
+      resolveProposalVoteUiState({
+        proposal: { ...BASE_PROPOSAL, status: 'executed' },
+        hasVoted: undefined,
+        voterAddress: '',
+      }),
+    ).toBe('not_voted');
+  });
+
+  it('returns no_evm for active proposals without voter address', () => {
+    expect(
+      resolveProposalVoteUiState({
+        proposal: BASE_PROPOSAL,
+        hasVoted: undefined,
+        voterAddress: ' ',
+      }),
+    ).toBe('no_evm');
+  });
+
+  it('returns loading when hasVoted is undefined', () => {
+    expect(
+      resolveProposalVoteUiState({
+        proposal: BASE_PROPOSAL,
+        hasVoted: undefined,
+        voterAddress: '0xabc',
+      }),
+    ).toBe('loading');
+  });
+
+  it('returns voted when hasVoted is true', () => {
+    expect(
+      resolveProposalVoteUiState({
+        proposal: BASE_PROPOSAL,
+        hasVoted: true,
+        voterAddress: '0xabc',
+      }),
+    ).toBe('voted');
+  });
+
+  it('returns not_voted when hasVoted is false', () => {
+    expect(
+      resolveProposalVoteUiState({
+        proposal: BASE_PROPOSAL,
+        hasVoted: false,
+        voterAddress: '0xabc',
+      }),
+    ).toBe('not_voted');
+  });
+});

--- a/src/lib/invites/accept-invite.test.ts
+++ b/src/lib/invites/accept-invite.test.ts
@@ -1,17 +1,95 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
+import type { DmMessage } from '../../stores/dm';
+import type { PendingMlsWelcome } from '../api/nostr';
+import type { Squad } from '../../stores/app';
 
-const persistSquadPatchMock = vi.fn();
-
-vi.mock('../squad/squad-catalog', () => ({
-  persistSquadPatch: (...args: unknown[]) => persistSquadPatchMock(...args),
-  persistSquad: vi.fn(),
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
 }));
 
-import { handleChannelAddedToSquad, reconcileStaleInviteDecisions, squadInviteResolvedByMembership } from './accept-invite';
-import { squads, type Squad } from '../../stores/squads';
-import { acceptedSquadInviteIds } from '../../stores/invite-decisions';
-import { pactoAppInboxMessages } from '../../stores/dm';
+vi.mock('../squad/squad-catalog', () => ({
+  persistSquad: vi.fn(),
+  persistSquadPatch: vi.fn(),
+}));
+
+vi.mock('../utils/dm-debug', () => ({
+  dmLog: vi.fn(),
+  dmWarn: vi.fn(),
+  dmError: vi.fn(),
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import { persistSquad, persistSquadPatch } from '../squad/squad-catalog';
+import { dmError } from '../utils/dm-debug';
+import {
+  acceptAnnouncementsInvite,
+  acceptChannelInSquadInvite,
+  acceptSquadOrPairInvite,
+  acceptingChannelInSquadId,
+  acceptingSquadInviteId,
+  handleChannelAddedToSquad,
+  handleMlsWelcomeAccepted,
+  resetInviteAcceptState,
+} from './accept-invite';
+import {
+  acceptedChannelInviteMessageIds,
+  acceptedSquadInviteIds,
+  activeChannelId,
+  activeHubChannelName,
+  activeSquadId,
+  activeTopNavTab,
+  activeView,
+  membershipVersionByGroupId,
+  squads,
+  ANNOUNCEMENTS_CHANNEL_NAME,
+} from '../../stores/app';
+import { pendingReadyToast } from '../../stores/toast';
+
+let pendingWelcomes: PendingMlsWelcome[] = [];
+
+const SQUAD_INVITE = JSON.stringify({
+  type: 'squad_invite',
+  squadName: 'Alpha',
+  groupId: 'g1',
+  kind: 'squad',
+  invitedByNpub: 'npub1alice0000000',
+});
+
+const SQUAD_PAIR_INVITE = JSON.stringify({
+  type: 'squad_invite',
+  squadName: 'Pair',
+  groupId: 'g2',
+  kind: 'squad-pair',
+  pairedSquads: [
+    { id: 'anchor-a', name: 'A' },
+    { id: 'anchor-b', name: 'B' },
+  ],
+});
+
+function welcome(groupId: string): PendingMlsWelcome {
+  return {
+    id: `welcome-${groupId}`,
+    wrapper_event_id: `wrapper-${groupId}`,
+    nostr_group_id: groupId,
+    group_name: 'Test',
+    group_description: null,
+    group_admin_pubkeys: [],
+    group_relays: [],
+    welcomer: 'npub1welcomer',
+    member_count: 2,
+  };
+}
+
+function dmMessage(overrides: Partial<DmMessage> = {}): DmMessage {
+  return {
+    id: 'msg-1',
+    content: 'hello',
+    at: 1,
+    mine: false,
+    ...overrides,
+  };
+}
 
 const parent: Squad = {
   id: 'parent-1',
@@ -22,16 +100,371 @@ const parent: Squad = {
   updatedAt: 1,
 };
 
+describe('accept-invite state reset', () => {
+  it('clears accepting store state', () => {
+    acceptingSquadInviteId.set('busy');
+    acceptingChannelInSquadId.set('busy');
+    resetInviteAcceptState();
+    expect(get(acceptingSquadInviteId)).toBeNull();
+    expect(get(acceptingChannelInSquadId)).toBeNull();
+  });
+});
+
+describe('acceptAnnouncementsInvite', () => {
+  beforeEach(() => {
+    pendingWelcomes = [welcome('g1')];
+    vi.mocked(invoke).mockReset().mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve(pendingWelcomes);
+      if (command === 'accept_mls_welcome') return Promise.resolve(true);
+      if (command === 'sync_mls_groups_now') return Promise.resolve({ synced: 1, total: 1 });
+      if (command === 'get_mls_group_members') return Promise.resolve({ group_id: 'g1', members: ['npub1a'], admins: [] });
+      if (command === 'backfill_squad_member_evm_missing_from_profiles') return Promise.resolve(1);
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(persistSquad).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(persistSquadPatch).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(dmError).mockReset();
+    squads.set([]);
+    activeSquadId.set(null);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
+    activeTopNavTab.set('commons');
+    activeView.set('hub');
+    acceptedSquadInviteIds.set([]);
+    acceptedChannelInviteMessageIds.set([]);
+    membershipVersionByGroupId.set({});
+    pendingReadyToast.set(null);
+  });
+
+  afterEach(() => {
+    resetInviteAcceptState();
+  });
+
+  it('accepts a regular squad invite and updates navigation', async () => {
+    await acceptAnnouncementsInvite({ groupId: 'g1', name: 'Alpha' }, 'msg-1');
+
+    expect(invoke).toHaveBeenCalledWith('accept_mls_welcome', { welcomeEventIdHex: 'welcome-g1' });
+    expect(invoke).toHaveBeenCalledWith('sync_mls_groups_now', { group_id: 'g1' });
+    expect(invoke).toHaveBeenCalledWith('get_mls_group_members', { groupId: 'g1' });
+    expect(invoke).toHaveBeenCalledWith('backfill_squad_member_evm_missing_from_profiles', {
+      parentId: 'g1',
+      memberNpubs: ['npub1a'],
+    });
+
+    expect(persistSquad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'g1',
+        name: 'Alpha',
+        kind: 'squad',
+      })
+    );
+
+    expect(get(squads).some((s) => s.id === 'g1')).toBe(true);
+    expect(get(activeSquadId)).toBe('g1');
+    expect(get(activeChannelId)).toBe('g1');
+    expect(get(activeHubChannelName)).toBe(ANNOUNCEMENTS_CHANNEL_NAME);
+    expect(get(activeTopNavTab)).toBe('squads');
+    expect(get(activeView)).toBe('hub');
+    expect(get(acceptedSquadInviteIds)).toContain('msg-1');
+    expect(get(membershipVersionByGroupId).g1).toBe(1);
+
+    const toast = get(pendingReadyToast);
+    expect(toast?.text).toBe('Alpha is ready!');
+    expect(toast?.goTo).toEqual(
+      expect.objectContaining({
+        type: 'squad',
+        name: 'Alpha',
+        id: 'g1',
+        channelId: 'g1',
+      })
+    );
+  });
+
+  it('accepts a squad-pair invite and preserves paired squads', async () => {
+    pendingWelcomes = [welcome('g2')];
+    await acceptAnnouncementsInvite(
+      {
+        groupId: 'g2',
+        name: 'Pair',
+        memberSquads: [
+          { id: 'anchor-a', name: 'A' },
+          { id: 'anchor-b', name: 'B' },
+        ],
+      },
+      'msg-2'
+    );
+
+    const stored = get(squads).find((s) => s.id === 'g2');
+    expect(stored).toBeDefined();
+    expect(stored?.kind).toBe('squad-pair');
+    expect(stored?.pairedSquads).toEqual([
+      { id: 'anchor-a', name: 'A' },
+      { id: 'anchor-b', name: 'B' },
+    ]);
+  });
+
+  it('throws a no-welcome error when there is no pending welcome', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+    await expect(acceptAnnouncementsInvite({ groupId: 'g1', name: 'Alpha' }, 'msg-1')).rejects.toMatchObject(
+      { noWelcome: true }
+    );
+  });
+
+  it('reverts the local squad when persistence fails', async () => {
+    vi.mocked(persistSquad).mockRejectedValueOnce(new Error('db write failed'));
+
+    await expect(acceptAnnouncementsInvite({ groupId: 'g1', name: 'Alpha' }, 'msg-1')).rejects.toThrow('db write failed');
+    expect(get(squads).some((s) => s.id === 'g1')).toBe(false);
+    expect(get(pendingReadyToast)).toBeNull();
+  });
+});
+
+describe('acceptSquadOrPairInvite', () => {
+  beforeEach(() => {
+    pendingWelcomes = [welcome('g1')];
+    vi.mocked(invoke).mockReset().mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve(pendingWelcomes);
+      if (command === 'accept_mls_welcome') return Promise.resolve(true);
+      if (command === 'sync_mls_groups_now') return Promise.resolve({ synced: 1, total: 1 });
+      if (command === 'get_mls_group_members') return Promise.resolve({ group_id: 'g1', members: [], admins: [] });
+      if (command === 'backfill_squad_member_evm_missing_from_profiles') return Promise.resolve(0);
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(persistSquad).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(persistSquadPatch).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(dmError).mockReset();
+    squads.set([]);
+    activeSquadId.set(null);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
+    activeTopNavTab.set('commons');
+    activeView.set('hub');
+    acceptedSquadInviteIds.set([]);
+    acceptedChannelInviteMessageIds.set([]);
+    membershipVersionByGroupId.set({});
+    pendingReadyToast.set(null);
+    acceptingSquadInviteId.set(null);
+    acceptingChannelInSquadId.set(null);
+  });
+
+  afterEach(() => {
+    resetInviteAcceptState();
+  });
+
+  it('accepts a regular squad invite from a DM message', async () => {
+    await acceptSquadOrPairInvite(dmMessage({ id: 'msg-1', content: SQUAD_INVITE }));
+    expect(get(acceptingSquadInviteId)).toBeNull();
+    expect(get(squads).some((s) => s.id === 'g1')).toBe(true);
+  });
+
+  it('accepts a squad-pair invite from a DM message', async () => {
+    pendingWelcomes = [welcome('g2')];
+    await acceptSquadOrPairInvite(dmMessage({ id: 'msg-2', content: SQUAD_PAIR_INVITE }));
+    const stored = get(squads).find((s) => s.id === 'g2');
+    expect(stored?.kind).toBe('squad-pair');
+  });
+
+  it('does nothing when content is not a squad invite', async () => {
+    await acceptSquadOrPairInvite(dmMessage({ content: 'plain text' }));
+    expect(get(squads)).toHaveLength(0);
+    expect(get(acceptingSquadInviteId)).toBeNull();
+  });
+
+  it('does nothing when another squad invite is already being accepted', async () => {
+    acceptingSquadInviteId.set('other');
+    await acceptSquadOrPairInvite(dmMessage({ id: 'msg-1', content: SQUAD_INVITE }));
+    expect(get(acceptingSquadInviteId)).toBe('other');
+    expect(get(squads)).toHaveLength(0);
+  });
+
+  it('resets the accepting id even when acceptance fails', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+    await acceptSquadOrPairInvite(dmMessage({ id: 'msg-1', content: SQUAD_INVITE }));
+    expect(get(acceptingSquadInviteId)).toBeNull();
+    expect(dmError).toHaveBeenCalled();
+  });
+});
+
+describe('acceptChannelInSquadInvite', () => {
+  beforeEach(() => {
+    pendingWelcomes = [welcome('chan-1')];
+    vi.mocked(invoke).mockReset().mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve(pendingWelcomes);
+      if (command === 'accept_mls_welcome') return Promise.resolve(true);
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(persistSquad).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(persistSquadPatch).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(dmError).mockReset();
+    squads.set([parent]);
+    acceptedChannelInviteMessageIds.set([]);
+    acceptingChannelInSquadId.set(null);
+  });
+
+  afterEach(() => {
+    resetInviteAcceptState();
+  });
+
+  it('accepts a channel-in-squad invite and records the message id', async () => {
+    await acceptChannelInSquadInvite(dmMessage({ id: 'msg-chan' }), {
+      channelGroupId: 'chan-1',
+      announcementsGroupId: 'parent-1',
+      channelName: 'general',
+    });
+
+    expect(invoke).toHaveBeenCalledWith('accept_mls_welcome', { welcomeEventIdHex: 'welcome-chan-1' });
+    expect(get(acceptedChannelInviteMessageIds)).toContain('msg-chan');
+    expect(get(acceptingChannelInSquadId)).toBeNull();
+  });
+
+  it('adds the channel to the parent after the welcome is accepted', async () => {
+    await acceptChannelInSquadInvite(dmMessage({ id: 'msg-chan' }), {
+      channelGroupId: 'chan-1',
+      announcementsGroupId: 'parent-1',
+      channelName: 'general',
+    });
+
+    handleMlsWelcomeAccepted('chan-1');
+
+    expect(persistSquadPatch).toHaveBeenCalledWith('parent-1', expect.any(Function));
+    const patch = vi.mocked(persistSquadPatch).mock.calls[0]![1] as (s: Squad) => Squad;
+    const patched = patch(parent);
+    expect(patched.channels).toHaveLength(2);
+    expect(patched.channels[1]).toEqual({ name: 'general', groupId: 'chan-1', order: 1 });
+  });
+
+  it('logs and returns when there is no matching welcome', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
+    await acceptChannelInSquadInvite(dmMessage({ id: 'msg-chan' }), {
+      channelGroupId: 'chan-1',
+      announcementsGroupId: 'parent-1',
+      channelName: 'general',
+    });
+
+    expect(invoke).not.toHaveBeenCalledWith('accept_mls_welcome', expect.any(Object));
+    expect(dmError).toHaveBeenCalled();
+    expect(get(acceptedChannelInviteMessageIds)).not.toContain('msg-chan');
+  });
+
+  it('clears pending state when accepting a channel invite fails', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve([welcome('chan-1')]);
+      if (command === 'accept_mls_welcome') return Promise.reject(new Error('network'));
+      return Promise.resolve(undefined);
+    });
+
+    await acceptChannelInSquadInvite(dmMessage({ id: 'msg-chan' }), {
+      channelGroupId: 'chan-1',
+      announcementsGroupId: 'parent-1',
+      channelName: 'general',
+    });
+
+    expect(get(acceptingChannelInSquadId)).toBeNull();
+    expect(dmError).toHaveBeenCalled();
+    expect(get(acceptedChannelInviteMessageIds)).not.toContain('msg-chan');
+    squads.set([]);
+    handleMlsWelcomeAccepted('chan-1');
+    expect(persistSquadPatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleMlsWelcomeAccepted', () => {
+  beforeEach(() => {
+    pendingWelcomes = [welcome('g1'), welcome('chan-1')];
+    vi.mocked(invoke).mockReset().mockImplementation((command: string) => {
+      if (command === 'list_pending_mls_welcomes') return Promise.resolve(pendingWelcomes);
+      if (command === 'accept_mls_welcome') return Promise.resolve(true);
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(persistSquad).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(persistSquadPatch).mockReset().mockResolvedValue(undefined as unknown as Squad);
+    vi.mocked(dmError).mockReset();
+    squads.set([]);
+    acceptedChannelInviteMessageIds.set([]);
+    acceptingChannelInSquadId.set(null);
+    resetInviteAcceptState();
+  });
+
+  afterEach(() => {
+    resetInviteAcceptState();
+  });
+
+  it('ignores unattributed squad welcomes from a regular invite accept', async () => {
+    await acceptAnnouncementsInvite({ groupId: 'g1', name: 'Alpha' }, 'msg-1');
+    const callsBefore = vi.mocked(persistSquadPatch).mock.calls.length;
+
+    handleMlsWelcomeAccepted('g1');
+
+    expect(vi.mocked(persistSquadPatch).mock.calls.length).toBe(callsBefore);
+  });
+
+  it('adds a placeholder channel when exactly one single-channel squad exists', () => {
+    squads.set([
+      {
+        id: 'single-1',
+        name: 'Single',
+        channels: [{ name: 'announcements', groupId: 'single-1', order: 0 }],
+        kind: 'squad',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    handleMlsWelcomeAccepted('new-group-1');
+
+    expect(persistSquadPatch).toHaveBeenCalledWith('single-1', expect.any(Function));
+    const patch = vi.mocked(persistSquadPatch).mock.calls[0]![1] as (s: Squad) => Squad;
+    const patched = patch(get(squads)[0]!);
+    expect(patched.channels).toHaveLength(2);
+    expect(patched.channels[1].groupId).toBe('new-group-1');
+  });
+
+  it('does nothing when multiple single-channel squads exist', () => {
+    squads.set([
+      {
+        id: 'single-1',
+        name: 'Single',
+        channels: [{ name: 'announcements', groupId: 'single-1', order: 0 }],
+        kind: 'squad',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        id: 'single-2',
+        name: 'Other',
+        channels: [{ name: 'announcements', groupId: 'single-2', order: 0 }],
+        kind: 'squad',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    handleMlsWelcomeAccepted('new-group-1');
+
+    expect(persistSquadPatch).not.toHaveBeenCalled();
+  });
+});
+
 describe('accept-invite channel persistence', () => {
   beforeEach(() => {
-    persistSquadPatchMock.mockReset().mockResolvedValue(parent);
+    vi.mocked(persistSquadPatch).mockReset().mockResolvedValue(undefined as unknown as Squad);
     squads.set([parent]);
   });
 
   it('handleChannelAddedToSquad persists merged channels', () => {
     handleChannelAddedToSquad('parent-1', 'chan-new', 'general');
-    expect(persistSquadPatchMock).toHaveBeenCalledWith('parent-1', expect.any(Function));
-    const patch = persistSquadPatchMock.mock.calls[0]![1] as (s: Squad) => Squad;
+    expect(persistSquadPatch).toHaveBeenCalledWith('parent-1', expect.any(Function));
+    const patch = vi.mocked(persistSquadPatch).mock.calls[0]![1] as (s: Squad) => Squad;
     const patched = patch(parent);
     expect(patched.channels).toHaveLength(2);
     expect(patched.channels[1]).toEqual({
@@ -45,14 +478,11 @@ describe('accept-invite channel persistence', () => {
     squads.set([
       {
         ...parent,
-        channels: [
-          ...parent.channels,
-          { name: 'general', groupId: 'chan-new', order: 1 },
-        ],
+        channels: [...parent.channels, { name: 'general', groupId: 'chan-new', order: 1 }],
       },
     ]);
     handleChannelAddedToSquad('parent-1', 'chan-new', 'general');
-    const patch = persistSquadPatchMock.mock.calls[0]![1] as (s: Squad) => Squad;
+    const patch = vi.mocked(persistSquadPatch).mock.calls[0]![1] as (s: Squad) => Squad;
     const patched = patch(get(squads)[0]!);
     expect(patched.channels).toHaveLength(2);
   });

--- a/src/lib/navigation/open-squad-dashboard.test.ts
+++ b/src/lib/navigation/open-squad-dashboard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  activeTopNavTab,
+  activeSquadId,
+  activeChannelId,
+  activeView,
+  DASHBOARD_CHANNEL_ID,
+} from '../../stores/app';
+import { openSquadDashboard } from './open-squad-dashboard';
+
+vi.mock('../../stores/app', () => ({
+  activeTopNavTab: { set: vi.fn() },
+  activeSquadId: { set: vi.fn() },
+  activeChannelId: { set: vi.fn() },
+  activeView: { set: vi.fn() },
+  DASHBOARD_CHANNEL_ID: '#dashboard',
+}));
+
+describe('openSquadDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets active tab, squad, dashboard channel, and view', () => {
+    openSquadDashboard('squad-123');
+    expect(activeTopNavTab.set).toHaveBeenCalledWith('squads');
+    expect(activeSquadId.set).toHaveBeenCalledWith('squad-123');
+    expect(activeChannelId.set).toHaveBeenCalledWith(DASHBOARD_CHANNEL_ID);
+    expect(activeView.set).toHaveBeenCalledWith('hub');
+  });
+
+  it('trims whitespace from parent id', () => {
+    openSquadDashboard('  squad-456  ');
+    expect(activeSquadId.set).toHaveBeenCalledWith('squad-456');
+  });
+
+  it('does nothing when id is empty', () => {
+    openSquadDashboard('');
+    expect(activeTopNavTab.set).not.toHaveBeenCalled();
+    expect(activeSquadId.set).not.toHaveBeenCalled();
+    expect(activeChannelId.set).not.toHaveBeenCalled();
+    expect(activeView.set).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when id is whitespace-only', () => {
+    openSquadDashboard('   ');
+    expect(activeTopNavTab.set).not.toHaveBeenCalled();
+    expect(activeSquadId.set).not.toHaveBeenCalled();
+    expect(activeChannelId.set).not.toHaveBeenCalled();
+    expect(activeView.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/parent/clear-parent-dashboard-caches.test.ts
+++ b/src/lib/parent/clear-parent-dashboard-caches.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../dashboard/treasury-safes-cache', () => ({
+  removeTreasurySafesCacheForParent: vi.fn(),
+}));
+
+vi.mock('../dashboard/squad-infra-cache', () => ({
+  removeSquadInfraCacheForParent: vi.fn(),
+}));
+
+vi.mock('../dashboard/squad-member-evm-cache', () => ({
+  removeSquadMemberEvmCacheForParent: vi.fn(),
+}));
+
+vi.mock('../dashboard/settings-chain-cache', () => ({
+  removeSettingsChainCacheForParent: vi.fn(),
+}));
+
+import { removeTreasurySafesCacheForParent } from '../dashboard/treasury-safes-cache';
+import { removeSquadInfraCacheForParent } from '../dashboard/squad-infra-cache';
+import { removeSquadMemberEvmCacheForParent } from '../dashboard/squad-member-evm-cache';
+import { removeSettingsChainCacheForParent } from '../dashboard/settings-chain-cache';
+import { clearParentDashboardCaches } from './clear-parent-dashboard-caches';
+
+describe('clearParentDashboardCaches', () => {
+  beforeEach(() => {
+    vi.mocked(removeTreasurySafesCacheForParent).mockReset();
+    vi.mocked(removeSquadInfraCacheForParent).mockReset();
+    vi.mocked(removeSquadMemberEvmCacheForParent).mockReset();
+    vi.mocked(removeSettingsChainCacheForParent).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls all four dashboard cache removal helpers', () => {
+    clearParentDashboardCaches('npub1test', 'parent-1');
+    expect(removeTreasurySafesCacheForParent).toHaveBeenCalledWith('npub1test', 'parent-1');
+    expect(removeSquadInfraCacheForParent).toHaveBeenCalledWith('npub1test', 'parent-1');
+    expect(removeSquadMemberEvmCacheForParent).toHaveBeenCalledWith('npub1test', 'parent-1');
+    expect(removeSettingsChainCacheForParent).toHaveBeenCalledWith('npub1test', 'parent-1');
+  });
+
+  it('returns early when npub is missing', () => {
+    clearParentDashboardCaches(null, 'parent-1');
+    expect(removeTreasurySafesCacheForParent).not.toHaveBeenCalled();
+    expect(removeSquadInfraCacheForParent).not.toHaveBeenCalled();
+    expect(removeSquadMemberEvmCacheForParent).not.toHaveBeenCalled();
+    expect(removeSettingsChainCacheForParent).not.toHaveBeenCalled();
+  });
+
+  it('returns early when parentId is missing', () => {
+    clearParentDashboardCaches('npub1test', '');
+    expect(removeTreasurySafesCacheForParent).not.toHaveBeenCalled();
+    expect(removeSquadInfraCacheForParent).not.toHaveBeenCalled();
+    expect(removeSquadMemberEvmCacheForParent).not.toHaveBeenCalled();
+    expect(removeSettingsChainCacheForParent).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/parent/create-channel-flow.test.ts
+++ b/src/lib/parent/create-channel-flow.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('../api/nostr', () => ({
+  createGroupChat: vi.fn(),
+  formatChannelInSquadMessage: vi.fn(),
+  sendDmMessage: vi.fn(),
+}));
+
+vi.mock('../parent-navbar', () => ({
+  getAnnouncementsChannel: vi.fn(),
+  loadMembersForParent: vi.fn(),
+}));
+
+vi.mock('../mls/virtual-channel-bucket', () => ({
+  resolveHubChannelNameForGroupSelection: vi.fn(),
+}));
+
+vi.mock('../utils/tauri-errors', () => ({
+  getInvokeErrorMessage: vi.fn((e: unknown) =>
+    e instanceof Error ? e.message : String(e)
+  ),
+  friendlyMessage: vi.fn((msg: string) => msg),
+}));
+
+vi.mock('../squad/squad-catalog', () => ({
+  persistSquadPatch: vi.fn(),
+}));
+
+vi.mock('../../stores/squads', () => ({
+  squads: createMockWritable<Squad[]>([]),
+  DASHBOARD_CHANNEL_ID: '__dashboard__',
+}));
+
+vi.mock('../../stores/navigation', () => ({
+  activeSquadId: createMockWritable<string | null>(null),
+  activeChannelId: createMockWritable<string | null>(null),
+  activeHubChannelName: createMockWritable<string | null>(null),
+  activeView: createMockWritable<'hub' | 'profile'>('hub'),
+  lastChannelBySquadId: createMockWritable<Record<string, string>>({}),
+  lastHubChannelNameBySquadId: createMockWritable<Record<string, string>>({}),
+}));
+
+import { createGroupChat, formatChannelInSquadMessage, sendDmMessage } from '../api/nostr';
+import { getAnnouncementsChannel, loadMembersForParent } from '../parent-navbar';
+import { resolveHubChannelNameForGroupSelection } from '../mls/virtual-channel-bucket';
+import { persistSquadPatch } from '../squad/squad-catalog';
+import { squads, type Squad } from '../../stores/squads';
+import {
+  activeChannelId,
+  activeHubChannelName,
+  activeView,
+  lastChannelBySquadId,
+  lastHubChannelNameBySquadId,
+} from '../../stores/navigation';
+import {
+  loadCreateChannelMemberList,
+  runCreateChannelInParent,
+} from './create-channel-flow';
+
+function createMockWritable<T>(initial: T) {
+  let value = initial;
+  const subscribers = new Set<(v: T) => void>();
+  return {
+    set: (v: T) => {
+      value = v;
+      subscribers.forEach((fn) => fn(v));
+    },
+    update: (fn: (v: T) => T) => {
+      value = fn(value);
+      subscribers.forEach((fn) => fn(value));
+    },
+    subscribe: (fn: (v: T) => void) => {
+      fn(value);
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+  };
+}
+
+const parent: Squad = {
+  id: 'parent-1',
+  name: 'Alpha',
+  channels: [
+    { name: 'announcements', groupId: 'g-announce', order: 0 },
+    { name: 'general', groupId: 'g-general', order: 1 },
+  ],
+  kind: 'squad',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('loadCreateChannelMemberList', () => {
+  it('delegates to loadMembersForParent', async () => {
+    vi.mocked(loadMembersForParent).mockResolvedValue(['npub-a', 'npub-b']);
+    const members = await loadCreateChannelMemberList(parent, 'npub-me');
+    expect(loadMembersForParent).toHaveBeenCalledWith(parent, 'npub-me');
+    expect(members).toEqual(['npub-a', 'npub-b']);
+  });
+});
+
+describe('runCreateChannelInParent', () => {
+  beforeEach(() => {
+    squads.set([parent]);
+    activeChannelId.set('g-announce');
+    activeHubChannelName.set('announcements');
+    activeView.set('hub');
+    lastChannelBySquadId.set({});
+    lastHubChannelNameBySquadId.set({});
+
+    vi.mocked(createGroupChat).mockReset().mockResolvedValue('g-new-channel');
+    vi.mocked(formatChannelInSquadMessage).mockReset().mockReturnValue('channel-in-squad-payload');
+    vi.mocked(sendDmMessage).mockReset().mockResolvedValue(true);
+    vi.mocked(getAnnouncementsChannel).mockReset().mockReturnValue({
+      name: 'announcements',
+      groupId: 'g-announce',
+      order: 0,
+    });
+    vi.mocked(resolveHubChannelNameForGroupSelection).mockReset().mockReturnValue('announcements');
+    vi.mocked(persistSquadPatch).mockReset().mockImplementation(async (parentId, patch) => {
+      squads.update((list) =>
+        list.map((s) => (s.id !== parentId ? s : patch(s)))
+      );
+      return get(squads).find((s) => s.id === parentId) || null;
+    });
+  });
+
+  afterEach(() => {
+    squads.set([]);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
+    activeView.set('hub');
+    lastChannelBySquadId.set({});
+    lastHubChannelNameBySquadId.set({});
+  });
+
+  it('optimistically creates a placeholder channel and updates navigation', async () => {
+    const onErrorBanner = vi.fn();
+    runCreateChannelInParent({
+      parent,
+      squadId: 'parent-1',
+      name: 'new-channel',
+      selectedNpubs: ['npub-a'],
+      onErrorBanner,
+    });
+
+    const state = get(squads);
+    expect(state[0]?.channels).toHaveLength(3);
+    const placeholder = state[0]?.channels.find((c) => c.name === 'new-channel');
+    expect(placeholder?.groupId).toMatch(/^creating-\d+$/);
+    expect(placeholder?.order).toBe(2);
+
+    expect(get(activeChannelId)).toBe(placeholder?.groupId);
+    expect(get(activeHubChannelName)).toBe('new-channel');
+    expect(get(activeView)).toBe('hub');
+    expect(get(lastChannelBySquadId)['parent-1']).toBe(placeholder?.groupId);
+    expect(get(lastHubChannelNameBySquadId)['parent-1']).toBe('new-channel');
+  });
+
+  it('replaces the placeholder after MLS create and sends DMs', async () => {
+    const onErrorBanner = vi.fn();
+    runCreateChannelInParent({
+      parent,
+      squadId: 'parent-1',
+      name: 'new-channel',
+      selectedNpubs: ['npub-a', 'npub-b'],
+      onErrorBanner,
+    });
+
+    await vi.waitFor(() => {
+      expect(createGroupChat).toHaveBeenCalledWith('new-channel', ['npub-a', 'npub-b']);
+    });
+
+    await vi.waitFor(() => {
+      expect(persistSquadPatch).toHaveBeenCalled();
+    });
+
+    const state = get(squads);
+    expect(state[0]?.channels).toHaveLength(3);
+    expect(state[0]?.channels.some((c) => c.groupId === 'g-new-channel')).toBe(true);
+    expect(state[0]?.channels.some((c) => c.groupId.startsWith('creating-'))).toBe(false);
+
+    expect(formatChannelInSquadMessage).toHaveBeenCalledWith({
+      type: 'channel_in_squad',
+      squadName: 'Alpha',
+      announcementsGroupId: 'g-announce',
+      channelGroupId: 'g-new-channel',
+      channelName: 'new-channel',
+    });
+
+    await vi.waitFor(() => {
+      expect(sendDmMessage).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sendDmMessage).toHaveBeenCalledWith('npub-a', 'channel-in-squad-payload');
+    expect(sendDmMessage).toHaveBeenCalledWith('npub-b', 'channel-in-squad-payload');
+
+    expect(onErrorBanner).not.toHaveBeenCalled();
+  });
+
+  it('continues sending DMs when one recipient fails', async () => {
+    vi.mocked(sendDmMessage)
+      .mockRejectedValueOnce(new Error('dm failed'))
+      .mockResolvedValue(true);
+    const onErrorBanner = vi.fn();
+
+    runCreateChannelInParent({
+      parent,
+      squadId: 'parent-1',
+      name: 'new-channel',
+      selectedNpubs: ['npub-a', 'npub-b'],
+      onErrorBanner,
+    });
+
+    await vi.waitFor(() => {
+      expect(sendDmMessage).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sendDmMessage).toHaveBeenCalledWith('npub-a', 'channel-in-squad-payload');
+    expect(sendDmMessage).toHaveBeenCalledWith('npub-b', 'channel-in-squad-payload');
+    expect(onErrorBanner).not.toHaveBeenCalled();
+  });
+
+  it('rolls back on error and shows a banner', async () => {
+    vi.mocked(createGroupChat).mockRejectedValueOnce(new Error('mls failed'));
+    const onErrorBanner = vi.fn();
+
+    runCreateChannelInParent({
+      parent,
+      squadId: 'parent-1',
+      name: 'new-channel',
+      selectedNpubs: ['npub-a'],
+      onErrorBanner,
+    });
+
+    await vi.waitFor(() => {
+      expect(onErrorBanner).toHaveBeenCalledWith('mls failed');
+    });
+
+    const state = get(squads);
+    expect(state[0]?.channels).toHaveLength(2);
+    expect(state[0]?.channels.some((c) => c.groupId.startsWith('creating-'))).toBe(false);
+  });
+});

--- a/src/lib/parent/create-channel-flow.ts
+++ b/src/lib/parent/create-channel-flow.ts
@@ -14,7 +14,6 @@ import {
   type Squad,
 } from '../../stores/squads';
 import {
-  activeSquadId,
   activeChannelId,
   activeHubChannelName,
   activeView,

--- a/src/lib/parent/exit-parent-flow.test.ts
+++ b/src/lib/parent/exit-parent-flow.test.ts
@@ -19,7 +19,11 @@ import { deleteSquad, persistSquad } from '../squad/squad-catalog';
 import { clearParentDashboardCaches } from './clear-parent-dashboard-caches';
 import { runExitParent } from './exit-parent-flow';
 import { squads, type Squad } from '../../stores/squads';
-import { activeSquadId } from '../../stores/navigation';
+import {
+  activeSquadId,
+  activeChannelId,
+  activeHubChannelName,
+} from '../../stores/navigation';
 import { currentNpubForPersistence } from '../../stores/persistence-context';
 
 const squad: Squad = {
@@ -42,12 +46,16 @@ describe('runExitParent', () => {
     vi.mocked(clearParentDashboardCaches).mockReset();
     squads.set([squad]);
     activeSquadId.set(squad.id);
+    activeChannelId.set('parent-1');
+    activeHubChannelName.set('announcements');
     currentNpubForPersistence.set('npub1test');
   });
 
   afterEach(() => {
     squads.set([]);
     activeSquadId.set(null);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
     currentNpubForPersistence.set(null);
   });
 
@@ -56,6 +64,8 @@ describe('runExitParent', () => {
     runExitParent({ squad, wasActive: true, previousChannelId: 'parent-1', onFailure });
     expect(get(squads)).toHaveLength(0);
     expect(get(activeSquadId)).toBeNull();
+    expect(get(activeChannelId)).toBeNull();
+    expect(get(activeHubChannelName)).toBeNull();
     await vi.waitFor(() => {
       expect(deleteSquad).toHaveBeenCalledWith('parent-1');
     });
@@ -72,6 +82,51 @@ describe('runExitParent', () => {
     runExitParent({ squad, wasActive: true, previousChannelId: 'parent-1', onFailure });
     await vi.waitFor(() => {
       expect(onFailure).toHaveBeenCalled();
+    });
+    expect(persistSquad).toHaveBeenCalledWith(squad);
+    expect(get(squads)).toHaveLength(1);
+    expect(get(squads)[0]?.id).toBe('parent-1');
+    expect(get(activeSquadId)).toBe('parent-1');
+  });
+
+  it('does not touch active navigation when wasActive is false', async () => {
+    activeSquadId.set('other-parent');
+    activeChannelId.set('other-channel');
+    activeHubChannelName.set('other');
+    const onFailure = vi.fn();
+
+    runExitParent({ squad, wasActive: false, previousChannelId: null, onFailure });
+
+    expect(get(squads)).toHaveLength(0);
+    expect(get(activeSquadId)).toBe('other-parent');
+    expect(get(activeChannelId)).toBe('other-channel');
+    expect(get(activeHubChannelName)).toBe('other');
+    await vi.waitFor(() => {
+      expect(deleteSquad).toHaveBeenCalledWith('parent-1');
+    });
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('leaves no channels when the squad has none', async () => {
+    const emptySquad: Squad = { ...squad, channels: [] };
+    squads.set([emptySquad]);
+    const onFailure = vi.fn();
+    runExitParent({ squad: emptySquad, wasActive: true, previousChannelId: null, onFailure });
+    expect(get(squads)).toHaveLength(0);
+    await vi.waitFor(() => {
+      expect(deleteSquad).toHaveBeenCalledWith('parent-1');
+    });
+    expect(leaveMlsGroup).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('reverts store even when persistSquad revert fails', async () => {
+    vi.mocked(deleteSquad).mockRejectedValueOnce(new Error('db-locked'));
+    vi.mocked(persistSquad).mockRejectedValueOnce(new Error('persist-failed'));
+    const onFailure = vi.fn();
+    runExitParent({ squad, wasActive: true, previousChannelId: 'parent-1', onFailure });
+    await vi.waitFor(() => {
+      expect(onFailure).toHaveBeenCalledWith('db-locked');
     });
     expect(persistSquad).toHaveBeenCalledWith(squad);
     expect(get(squads)).toHaveLength(1);

--- a/src/lib/parent/invite-members-flow.test.ts
+++ b/src/lib/parent/invite-members-flow.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../api/nostr', () => ({
+  inviteMemberToGroup: vi.fn(),
+}));
+
+vi.mock('../parent-navbar', () => ({
+  defaultParentInvitePhysicalGroupTargets: vi.fn(),
+  getAnnouncementsChannel: vi.fn(),
+  loadMembersForParent: vi.fn(),
+}));
+
+vi.mock('../pacto-app-inbox', () => ({
+  sendSquadInviteDm: vi.fn(),
+}));
+
+vi.mock('../../stores/auth', () => ({
+  currentUser: { subscribe: vi.fn() },
+}));
+
+vi.mock('../../stores/squads', () => ({
+  squads: { set: vi.fn(), subscribe: vi.fn(), update: vi.fn() },
+}));
+
+import { inviteMemberToGroup } from '../api/nostr';
+import {
+  defaultParentInvitePhysicalGroupTargets,
+  getAnnouncementsChannel,
+  loadMembersForParent,
+} from '../parent-navbar';
+import { sendSquadInviteDm } from '../pacto-app-inbox';
+import { currentUser } from '../../stores/auth';
+import {
+  loadInviteCandidateNpubs,
+  runInviteMembersToParent,
+} from './invite-members-flow';
+import type { Squad } from '../../stores/squads';
+
+const parent: Squad = {
+  id: 'parent-1',
+  name: 'Alpha',
+  channels: [
+    { name: 'announcements', groupId: 'g-announce', order: 0 },
+    { name: 'inbox', groupId: 'g-inbox', order: 1 },
+  ],
+  kind: 'squad',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function setCurrentUser(npub: string | null) {
+  currentUser.subscribe = vi.fn((fn: (u: { npub: string } | null) => void) => {
+    fn(npub ? { npub } : null);
+    return () => {};
+  });
+}
+
+describe('loadInviteCandidateNpubs', () => {
+  it('filters out existing members and current user', async () => {
+    vi.mocked(loadMembersForParent).mockResolvedValue(['npub-member', 'npub-me']);
+    const candidates = await loadInviteCandidateNpubs(
+      parent,
+      ['npub-member', 'npub-me', 'npub-new'],
+      'npub-me'
+    );
+    expect(candidates).toEqual(['npub-new']);
+  });
+
+  it('deduplicates input npubs', async () => {
+    vi.mocked(loadMembersForParent).mockResolvedValue([]);
+    const candidates = await loadInviteCandidateNpubs(
+      parent,
+      ['npub-a', 'npub-a', 'npub-b'],
+      'npub-me'
+    );
+    expect(candidates).toEqual(['npub-a', 'npub-b']);
+  });
+});
+
+describe('runInviteMembersToParent', () => {
+  beforeEach(() => {
+    vi.mocked(inviteMemberToGroup).mockReset().mockResolvedValue(undefined);
+    vi.mocked(sendSquadInviteDm).mockReset().mockResolvedValue(true);
+    vi.mocked(defaultParentInvitePhysicalGroupTargets).mockReset().mockReturnValue([
+      { name: 'announcements', groupId: 'g-announce', order: 0 },
+      { name: 'inbox', groupId: 'g-inbox', order: 1 },
+    ]);
+    vi.mocked(getAnnouncementsChannel).mockReset().mockReturnValue({
+      name: 'announcements',
+      groupId: 'g-announce',
+      order: 0,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invites to each physical group and sends DMs', async () => {
+    setCurrentUser('npub-me');
+    const onComplete = vi.fn();
+    const onErrorBanner = vi.fn();
+
+    runInviteMembersToParent({
+      parent,
+      npubsToInvite: ['npub-a', 'npub-b'],
+      onErrorBanner,
+      onComplete,
+    });
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    expect(inviteMemberToGroup).toHaveBeenCalledTimes(4);
+    expect(inviteMemberToGroup).toHaveBeenCalledWith('g-announce', 'npub-a');
+    expect(inviteMemberToGroup).toHaveBeenCalledWith('g-inbox', 'npub-a');
+    expect(inviteMemberToGroup).toHaveBeenCalledWith('g-announce', 'npub-b');
+    expect(inviteMemberToGroup).toHaveBeenCalledWith('g-inbox', 'npub-b');
+
+    expect(sendSquadInviteDm).toHaveBeenCalledTimes(2);
+    expect(sendSquadInviteDm).toHaveBeenCalledWith(
+      'npub-a',
+      { squadName: 'Alpha', groupId: 'g-announce' },
+      'npub-me'
+    );
+    expect(sendSquadInviteDm).toHaveBeenCalledWith(
+      'npub-b',
+      { squadName: 'Alpha', groupId: 'g-announce' },
+      'npub-me'
+    );
+
+    expect(onErrorBanner).not.toHaveBeenCalled();
+  });
+
+  it('shows error banner and still completes on MLS invite failure', async () => {
+    setCurrentUser('npub-me');
+    vi.mocked(inviteMemberToGroup)
+      .mockRejectedValueOnce(new Error('invite failed'))
+      .mockResolvedValue(undefined);
+    const onComplete = vi.fn();
+    const onErrorBanner = vi.fn();
+
+    runInviteMembersToParent({
+      parent,
+      npubsToInvite: ['npub-a'],
+      onErrorBanner,
+      onComplete,
+    });
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    expect(onErrorBanner).toHaveBeenCalledWith('invite failed');
+  });
+
+  it('shows error banner when squad invite DM fails', async () => {
+    setCurrentUser('npub-me');
+    vi.mocked(inviteMemberToGroup).mockResolvedValue(undefined);
+    vi.mocked(sendSquadInviteDm)
+      .mockRejectedValueOnce(new Error('dm failed'))
+      .mockResolvedValue(true);
+    const onComplete = vi.fn();
+    const onErrorBanner = vi.fn();
+
+    runInviteMembersToParent({
+      parent,
+      npubsToInvite: ['npub-a'],
+      onErrorBanner,
+      onComplete,
+    });
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    expect(sendSquadInviteDm).toHaveBeenCalledWith(
+      'npub-a',
+      { squadName: 'Alpha', groupId: 'g-announce' },
+      'npub-me'
+    );
+    expect(onErrorBanner).toHaveBeenCalledWith('dm failed');
+  });
+});

--- a/src/lib/parent/invite-members-flow.ts
+++ b/src/lib/parent/invite-members-flow.ts
@@ -17,7 +17,7 @@ export async function loadInviteCandidateNpubs(
 ): Promise<string[]> {
   const inParent = new Set(await loadMembersForParent(parent, currentUserNpub));
   const uniqueNpubs = [...new Set(dmNpubs)];
-  return uniqueNpubs.filter((npub) => !inParent.has(npub));
+  return uniqueNpubs.filter((npub) => !inParent.has(npub) && npub !== currentUserNpub);
 }
 
 /** MLS invites + squad invite DMs for each npub. */

--- a/src/lib/parent/parent-polls.test.ts
+++ b/src/lib/parent/parent-polls.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  loadParentPolls,
+  saveParentPolls,
+  addParentPoll,
+  updateParentPoll,
+  pollReferenceToken,
+  getPollBallotMap,
+  getPollBallot,
+  setPollBallot,
+  type ParentPoll,
+} from './parent-polls';
+
+describe('parent-polls', () => {
+  const viewerNpub = 'npub1test';
+  const parentId = 'parent-1';
+  const store = new Map<string, string>();
+
+  const poll: ParentPoll = {
+    id: 'poll-1',
+    parentId,
+    title: 'T',
+    description: 'D',
+    options: [
+      { id: 'opt-1', label: 'A', votes: 0 },
+      { id: 'opt-2', label: 'B', votes: 3 },
+    ],
+    createdAtMs: 1000,
+  };
+
+  const poll2: ParentPoll = {
+    id: 'poll-2',
+    parentId,
+    title: 'T2',
+    description: 'D2',
+    options: [{ id: 'opt-3', label: 'C', votes: 1 }],
+    createdAtMs: 500,
+  };
+
+  beforeEach(() => {
+    store.clear();
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    } as Storage;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+  });
+
+  it('round-trips polls through localStorage', () => {
+    saveParentPolls(viewerNpub, parentId, [poll, poll2]);
+    const loaded = loadParentPolls(viewerNpub, parentId);
+    expect(loaded).toEqual([poll2, poll]);
+  });
+
+  it('adds a poll to the stored list', () => {
+    addParentPoll(viewerNpub, parentId, poll);
+    addParentPoll(viewerNpub, parentId, poll2);
+    expect(loadParentPolls(viewerNpub, parentId)).toEqual([poll2, poll]);
+  });
+
+  it('updates a poll by id', () => {
+    saveParentPolls(viewerNpub, parentId, [poll]);
+    updateParentPoll(viewerNpub, parentId, 'poll-1', (p) => ({
+      ...p,
+      title: 'Updated',
+      options: [{ id: 'opt-1', label: 'A', votes: 10 }],
+    }));
+    const loaded = loadParentPolls(viewerNpub, parentId)[0];
+    expect(loaded?.title).toBe('Updated');
+    expect(loaded?.options).toEqual([{ id: 'opt-1', label: 'A', votes: 10 }]);
+  });
+
+  it('ignores updates when poll id is missing', () => {
+    saveParentPolls(viewerNpub, parentId, [poll]);
+    updateParentPoll(viewerNpub, parentId, 'missing', (p) => ({ ...p, title: 'X' }));
+    expect(loadParentPolls(viewerNpub, parentId)[0]?.title).toBe('T');
+  });
+
+  it('returns a stable poll reference token', () => {
+    expect(pollReferenceToken('poll-1')).toBe('dashboard-poll:poll-1');
+    expect(pollReferenceToken('  poll-1  ')).toBe('dashboard-poll:poll-1');
+  });
+
+  it('returns empty array when localStorage is missing', () => {
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+    expect(loadParentPolls(viewerNpub, parentId)).toEqual([]);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    store.set(
+      `pacto_parent_polls_v1_${viewerNpub}_${parentId}`,
+      'not json'
+    );
+    expect(loadParentPolls(viewerNpub, parentId)).toEqual([]);
+  });
+
+  it('filters invalid poll entries while keeping valid ones', () => {
+    store.set(
+      `pacto_parent_polls_v1_${viewerNpub}_${parentId}`,
+      JSON.stringify([poll, { id: 'bad' }, null])
+    );
+    const loaded = loadParentPolls(viewerNpub, parentId);
+    expect(loaded).toEqual([poll]);
+  });
+
+  it('returns empty array for non-array JSON', () => {
+    store.set(
+      `pacto_parent_polls_v1_${viewerNpub}_${parentId}`,
+      JSON.stringify({ foo: 'bar' })
+    );
+    expect(loadParentPolls(viewerNpub, parentId)).toEqual([]);
+  });
+
+  it('ignores localStorage quota errors when saving polls', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => saveParentPolls(viewerNpub, parentId, [poll])).not.toThrow();
+  });
+
+  it('round-trips ballots', () => {
+    setPollBallot(viewerNpub, parentId, 'poll-1', 'opt-1');
+    setPollBallot(viewerNpub, parentId, 'poll-2', 'opt-3');
+    expect(getPollBallot(viewerNpub, parentId, 'poll-1')).toBe('opt-1');
+    expect(getPollBallot(viewerNpub, parentId, 'poll-2')).toBe('opt-3');
+    expect(getPollBallotMap(viewerNpub, parentId)).toEqual({
+      'poll-1': 'opt-1',
+      'poll-2': 'opt-3',
+    });
+  });
+
+  it('returns null for missing ballot', () => {
+    expect(getPollBallot(viewerNpub, parentId, 'unknown')).toBeNull();
+  });
+
+  it('ignores ballot writes when keys are missing', () => {
+    setPollBallot('', parentId, 'poll-1', 'opt-1');
+    expect(getPollBallot('', parentId, 'poll-1')).toBeNull();
+  });
+
+  it('ignores malformed ballot JSON', () => {
+    store.set(
+      `pacto_parent_poll_ballots_v1_${viewerNpub}_${parentId}`,
+      'not json'
+    );
+    expect(getPollBallotMap(viewerNpub, parentId)).toEqual({});
+  });
+
+  it('ignores localStorage quota errors when saving ballots', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => setPollBallot(viewerNpub, parentId, 'poll-1', 'opt-1')).not.toThrow();
+  });
+
+  it('filters non-string ballot values', () => {
+    store.set(
+      `pacto_parent_poll_ballots_v1_${viewerNpub}_${parentId}`,
+      JSON.stringify({ 'poll-1': 'opt-1', 'poll-2': 123 })
+    );
+    expect(getPollBallotMap(viewerNpub, parentId)).toEqual({ 'poll-1': 'opt-1' });
+  });
+});

--- a/src/lib/utils/clear-account-state.test.ts
+++ b/src/lib/utils/clear-account-state.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { clearAccountState } from './clear-account-state';
+import { setCurrentNpubForPersistence } from '../../stores/persistence-context';
+import {
+  activeTopNavTab,
+  activeView,
+  activeSquadId,
+  activeChannelId,
+  activeHubChannelName,
+  lastOpenedSquadId,
+  lastOpenedChannelId,
+  lastChannelBySquadId,
+  lastHubChannelNameBySquadId,
+  showMembersPanel,
+  parentDashboardChannelMode,
+  DEFAULT_TOP_NAV_TAB,
+} from '../../stores/navigation';
+import {
+  pinnedDmNpubs,
+  blockedDmNpubs,
+  dmChatsByNpub,
+  activeDmId,
+  lastOpenedDmByTab,
+  walletSidebarOpen,
+  composingNewChat,
+  activeDmTab,
+  dmSendError,
+  pactoAppInboxMessages,
+  dmThreadAnnouncementsByNpub,
+  type DmChatState,
+} from '../../stores/dm';
+import {
+  acceptedSquadInviteIds,
+  declinedSquadInviteIds,
+  acceptedChannelInviteMessageIds,
+  declinedChannelInviteMessageIds,
+  declinedWalletTxRequestMessageIds,
+  acceptedWalletPeerInfoRequestMessageIds,
+  declinedWalletPeerInfoRequestMessageIds,
+} from '../../stores/invite-decisions';
+import { squads, ungroupedChannels, channelMessages, type Channel, type Squad } from '../../stores/squads';
+import { recentEmojisStore, type EmojiEntry } from '../../stores/emojis';
+import { dmLastReadByNpub, dmUnreadByNpub, pactoAppInboxLastReadId } from '../../stores/dm-unread';
+
+describe('clearAccountState', () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setCurrentNpubForPersistence(null);
+    squads.set([]);
+    ungroupedChannels.set([]);
+    channelMessages.set({});
+    pinnedDmNpubs.set(new Set());
+    blockedDmNpubs.set(new Set());
+    dmChatsByNpub.set({});
+    activeDmId.set(null);
+    lastOpenedDmByTab.set({ friends: null, requests: null, pending: null, search: null, pinned: null });
+    lastOpenedSquadId.set(null);
+    lastOpenedChannelId.set(null);
+    lastChannelBySquadId.set({});
+    lastHubChannelNameBySquadId.set({});
+    activeSquadId.set(null);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
+    acceptedSquadInviteIds.set([]);
+    declinedSquadInviteIds.set([]);
+    acceptedChannelInviteMessageIds.set([]);
+    declinedChannelInviteMessageIds.set([]);
+    declinedWalletTxRequestMessageIds.set([]);
+    acceptedWalletPeerInfoRequestMessageIds.set([]);
+    declinedWalletPeerInfoRequestMessageIds.set([]);
+    activeTopNavTab.set(DEFAULT_TOP_NAV_TAB);
+    activeDmTab.set('friends');
+    activeView.set('hub');
+    parentDashboardChannelMode.set('governance');
+    showMembersPanel.set(false);
+    walletSidebarOpen.set(false);
+    composingNewChat.set(false);
+    dmSendError.set(null);
+    pactoAppInboxMessages.set([]);
+    dmThreadAnnouncementsByNpub.set({});
+    dmLastReadByNpub.set({});
+    dmUnreadByNpub.set({});
+    pactoAppInboxLastReadId.set('');
+    recentEmojisStore.set([]);
+  });
+
+  it('removes npub-scoped localStorage keys when npub is provided', () => {
+    const npub = 'npub1abcdef';
+    storage.set(`pacto_last_dm_npub_${npub}`, 'value');
+    storage.set(`pacto_pinned_dm_npubs_${npub}`, 'value');
+    storage.set(`pacto_wallet_ui_enabled_chains_v1_${npub}`, 'value');
+    storage.set('unrelated_key', 'keep');
+
+    clearAccountState(npub);
+
+    expect(storage.has(`pacto_last_dm_npub_${npub}`)).toBe(false);
+    expect(storage.has(`pacto_pinned_dm_npubs_${npub}`)).toBe(false);
+    expect(storage.has(`pacto_wallet_ui_enabled_chains_v1_${npub}`)).toBe(false);
+    expect(storage.get('unrelated_key')).toBe('keep');
+  });
+
+  it('does not remove localStorage keys when npub is omitted', () => {
+    const npub = 'npub1abcdef';
+    storage.set(`pacto_last_dm_npub_${npub}`, 'value');
+    clearAccountState();
+    expect(storage.get(`pacto_last_dm_npub_${npub}`)).toBe('value');
+  });
+
+  it('resets navigation stores to defaults', () => {
+    activeSquadId.set('squad-1');
+    activeChannelId.set('channel-1');
+    activeHubChannelName.set('hub-1');
+    activeView.set('profile');
+    activeTopNavTab.set('dms');
+    parentDashboardChannelMode.set('treasury');
+    showMembersPanel.set(true);
+
+    clearAccountState('npub1abcdef');
+
+    expect(get(activeSquadId)).toBeNull();
+    expect(get(activeChannelId)).toBeNull();
+    expect(get(activeHubChannelName)).toBeNull();
+    expect(get(activeView)).toBe('hub');
+    expect(get(activeTopNavTab)).toBe(DEFAULT_TOP_NAV_TAB);
+    expect(get(parentDashboardChannelMode)).toBe('governance');
+    expect(get(showMembersPanel)).toBe(false);
+  });
+
+  it('resets DM stores to defaults', () => {
+    const chatState: DmChatState = {
+      npub: 'npub1',
+      hasFromMe: true,
+      hasFromThem: false,
+      lastAt: 1,
+    };
+    pinnedDmNpubs.set(new Set(['npub1']));
+    blockedDmNpubs.set(new Set(['npub2']));
+    dmChatsByNpub.set({ npub1: chatState });
+    activeDmId.set('npub1');
+    activeDmTab.set('requests');
+    composingNewChat.set(true);
+    dmSendError.set('boom');
+    pactoAppInboxMessages.set([
+      { id: '1', content: 'hi', at: 1, mine: false, inviterNpub: 'npub1' },
+    ]);
+    dmThreadAnnouncementsByNpub.set({ npub1: [] });
+
+    clearAccountState('npub1abcdef');
+
+    expect(get(pinnedDmNpubs).size).toBe(0);
+    expect(get(blockedDmNpubs).size).toBe(0);
+    expect(get(dmChatsByNpub)).toEqual({});
+    expect(get(activeDmId)).toBeNull();
+    expect(get(activeDmTab)).toBe('friends');
+    expect(get(composingNewChat)).toBe(false);
+    expect(get(dmSendError)).toBeNull();
+    expect(get(pactoAppInboxMessages)).toEqual([]);
+    expect(get(dmThreadAnnouncementsByNpub)).toEqual({});
+  });
+
+  it('resets invite decision stores to defaults', () => {
+    acceptedSquadInviteIds.set(['invite-1']);
+    declinedSquadInviteIds.set(['invite-2']);
+    acceptedChannelInviteMessageIds.set(['msg-1']);
+    declinedChannelInviteMessageIds.set(['msg-2']);
+    declinedWalletTxRequestMessageIds.set(['msg-3']);
+    acceptedWalletPeerInfoRequestMessageIds.set(['msg-4']);
+    declinedWalletPeerInfoRequestMessageIds.set(['msg-5']);
+
+    clearAccountState('npub1abcdef');
+
+    expect(get(acceptedSquadInviteIds)).toEqual([]);
+    expect(get(declinedSquadInviteIds)).toEqual([]);
+    expect(get(acceptedChannelInviteMessageIds)).toEqual([]);
+    expect(get(declinedChannelInviteMessageIds)).toEqual([]);
+    expect(get(declinedWalletTxRequestMessageIds)).toEqual([]);
+    expect(get(acceptedWalletPeerInfoRequestMessageIds)).toEqual([]);
+    expect(get(declinedWalletPeerInfoRequestMessageIds)).toEqual([]);
+  });
+
+  it('resets DM read state stores', () => {
+    dmLastReadByNpub.set({ npub1: 'id' });
+    dmUnreadByNpub.set({ npub1: 1 });
+    pactoAppInboxLastReadId.set('last-read');
+
+    clearAccountState('npub1abcdef');
+
+    expect(get(dmLastReadByNpub)).toEqual({});
+    expect(get(dmUnreadByNpub)).toEqual({});
+    expect(get(pactoAppInboxLastReadId)).toBe('');
+  });
+
+  it('resets squads and recent emoji stores', () => {
+    const squad: Squad = {
+      id: 's1',
+      name: 'S',
+      channels: [],
+      kind: 'squad',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const channel: Channel = { name: 'c', groupId: 'c1', order: 0 };
+    const emoji: EmojiEntry = { emoji: '😀', name: 'grinning' };
+    squads.set([squad]);
+    ungroupedChannels.set([channel]);
+    channelMessages.set({ s1: [] });
+    recentEmojisStore.set([emoji]);
+
+    clearAccountState('npub1abcdef');
+
+    expect(get(squads)).toEqual([]);
+    expect(get(ungroupedChannels)).toEqual([]);
+    expect(get(channelMessages)).toEqual({});
+    expect(get(recentEmojisStore)).toEqual([]);
+  });
+});

--- a/src/lib/utils/dm-debug.test.ts
+++ b/src/lib/utils/dm-debug.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
+import { dmLog, dmWarn, dmError } from './dm-debug';
+
+describe('dm-debug loggers', () => {
+  let logSpy: MockInstance<typeof console.log>;
+  let warnSpy: MockInstance<typeof console.warn>;
+  let errorSpy: MockInstance<typeof console.error>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('dmLog logs only when DEV is true', () => {
+    vi.stubEnv('DEV', true);
+    dmLog('hello', 1);
+    expect(logSpy).toHaveBeenCalledWith('[DM]', 'hello', 1);
+
+    logSpy.mockClear();
+    vi.stubEnv('DEV', false);
+    dmLog('hello', 1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('dmWarn warns only when DEV is true', () => {
+    vi.stubEnv('DEV', true);
+    dmWarn('warn', 2);
+    expect(warnSpy).toHaveBeenCalledWith('[DM]', 'warn', 2);
+
+    warnSpy.mockClear();
+    vi.stubEnv('DEV', false);
+    dmWarn('warn', 2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('dmError always logs', () => {
+    vi.stubEnv('DEV', false);
+    dmError('error', 3);
+    expect(errorSpy).toHaveBeenCalledWith('[DM]', 'error', 3);
+  });
+});

--- a/src/lib/utils/dm-debug.ts
+++ b/src/lib/utils/dm-debug.ts
@@ -1,14 +1,12 @@
 /**
  * DM flow debugging. Logs only when DEV or when DM_DEBUG is true (set to true to enable in production).
  */
-const DM_DEBUG = import.meta.env.DEV;
-
 export function dmLog(...args: unknown[]) {
-  if (DM_DEBUG) console.log('[DM]', ...args);
+  if (import.meta.env.DEV) console.log('[DM]', ...args);
 }
 
 export function dmWarn(...args: unknown[]) {
-  if (DM_DEBUG) console.warn('[DM]', ...args);
+  if (import.meta.env.DEV) console.warn('[DM]', ...args);
 }
 
 export function dmError(...args: unknown[]) {

--- a/src/lib/utils/message-formatting.test.ts
+++ b/src/lib/utils/message-formatting.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  emojiToTwemojiFilename,
+  parseMarkdown,
+  sanitize,
+  formatMessageTimestamp,
+  formatMessageContent,
+} from './message-formatting';
+
+describe('emojiToTwemojiFilename', () => {
+  it('returns null for empty input', () => {
+    expect(emojiToTwemojiFilename('')).toBeNull();
+  });
+
+  it('maps single-codepoint emoji', () => {
+    expect(emojiToTwemojiFilename('🌈')).toBe('1f308.svg');
+  });
+
+  it('maps flag emoji to hyphenated codepoints', () => {
+    expect(emojiToTwemojiFilename('🇺🇸')).toBe('1f1fa-1f1f8.svg');
+  });
+
+  it('produces a filename for any non-empty string', () => {
+    // The implementation converts codepoints to hex; letters become valid hex filenames.
+    expect(emojiToTwemojiFilename('abc')).toBe('61-62-63.svg');
+  });
+});
+
+describe('parseMarkdown', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('escapes plain text when marked is unavailable', () => {
+    vi.stubGlobal('window', { marked: undefined });
+    expect(parseMarkdown('hello <script>alert(1)</script> world')).toBe(
+      'hello &lt;script&gt;alert(1)&lt;/script&gt; world',
+    );
+  });
+
+  it('returns empty string for non-string input', () => {
+    vi.stubGlobal('window', { marked: undefined });
+    expect(parseMarkdown(null as unknown as string)).toBe('');
+  });
+
+  it('uses marked.parse when available', () => {
+    const marked = {
+      use: vi.fn(),
+      parse: vi.fn().mockReturnValue('<p>parsed</p>'),
+    };
+    vi.stubGlobal('window', { marked });
+    expect(parseMarkdown('hello')).toBe('<p>parsed</p>');
+    expect(marked.parse).toHaveBeenCalledWith('hello', { async: false });
+  });
+});
+
+describe('sanitize', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns empty string for non-string input', () => {
+    vi.stubGlobal('window', { DOMPurify: undefined });
+    expect(sanitize(null as unknown as string)).toBe('');
+  });
+
+  it('escapes when DOMPurify is unavailable', () => {
+    vi.stubGlobal('window', { DOMPurify: undefined });
+    expect(sanitize('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('delegates to DOMPurify when available', () => {
+    const purify = {
+      sanitize: vi.fn().mockReturnValue('<p>clean</p>'),
+      addHook: vi.fn(),
+      removeHook: vi.fn(),
+    };
+    vi.stubGlobal('window', { DOMPurify: purify });
+    expect(sanitize('<p>dirty</p>')).toBe('<p>clean</p>');
+    expect(purify.sanitize).toHaveBeenCalledWith('<p>dirty</p>', expect.any(Object));
+  });
+});
+
+describe('formatMessageTimestamp', () => {
+  it('returns empty string for invalid input', () => {
+    expect(formatMessageTimestamp('not a date')).toBe('');
+  });
+
+  it('formats a valid ISO string', () => {
+    const result = formatMessageTimestamp('2024-05-26T23:09:00.000Z');
+    expect(result).toMatch(/May 26/);
+    expect(result).toMatch(/:\d{2}\s/);
+  });
+
+  it('includes year when different from current year', () => {
+    const past = new Date();
+    past.setFullYear(past.getFullYear() - 1);
+    const result = formatMessageTimestamp(past.toISOString());
+    expect(result).toMatch(/\d{4}/);
+  });
+});
+
+describe('formatMessageContent', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createIdentityPurify(): Window['DOMPurify'] {
+    return {
+      sanitize: vi.fn((dirty: string) => dirty),
+      addHook: vi.fn(),
+      removeHook: vi.fn(),
+    } as unknown as Window['DOMPurify'];
+  }
+
+  it('linkifies bare URLs and keeps script tags escaped by DOMPurify', () => {
+    const purify = createIdentityPurify();
+    vi.stubGlobal('window', { DOMPurify: purify, marked: undefined, twemoji: undefined });
+    const input = '<script>alert(1)</script> https://example.com';
+    const result = formatMessageContent(input);
+    expect(result).toContain('<a href="https://example.com"');
+  });
+
+  it('replaces emoji with Twemoji img tags when twemoji is available', () => {
+    const twemoji = {
+      replace: vi.fn((text: string, cb: (raw: string) => string) => cb(text)),
+      convert: { toCodePoint: () => '1f308' },
+    };
+    const purify = createIdentityPurify();
+    vi.stubGlobal('window', { DOMPurify: purify, marked: undefined, twemoji });
+    const result = formatMessageContent('hello 🌈');
+    expect(result).toContain('class="twemoji"');
+    expect(result).toContain('src="/twemoji/svg/1f308.svg"');
+  });
+
+  it('keeps URLs inside code and pre tags unlinked', () => {
+    const purify = createIdentityPurify();
+    const marked = { use: vi.fn(), parse: vi.fn((src: string) => src) };
+    vi.stubGlobal('window', { DOMPurify: purify, marked, twemoji: undefined });
+    const input = '<code>https://example.com</code>';
+    const result = formatMessageContent(input);
+    expect(result).toContain('<code>https://example.com</code>');
+    expect(result).not.toContain('<a href');
+  });
+
+  it('handles malformed unclosed tags gracefully', () => {
+    const purify = createIdentityPurify();
+    vi.stubGlobal('window', { DOMPurify: purify, marked: undefined, twemoji: undefined });
+    const input = '<span https://example.com';
+    const result = formatMessageContent(input);
+    expect(result).toContain('https://example.com');
+  });
+});

--- a/src/lib/utils/npub.test.ts
+++ b/src/lib/utils/npub.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isValidNpub } from './npub';
+
+describe('isValidNpub', () => {
+  it('returns false for empty string', () => {
+    expect(isValidNpub('')).toBe(false);
+  });
+
+  it('returns false for non-npub string', () => {
+    expect(isValidNpub('not an npub')).toBe(false);
+  });
+
+  it('returns false for npub prefix that is too short', () => {
+    expect(isValidNpub('npub1short')).toBe(false);
+  });
+
+  it('returns true for a valid-length npub1 string', () => {
+    // 5 prefix chars + 52 base32 chars = 57 total
+    const valid = 'npub1' + 'a'.repeat(52);
+    expect(isValidNpub(valid)).toBe(true);
+  });
+
+  it('trims whitespace before validating', () => {
+    const valid = 'npub1' + 'a'.repeat(52);
+    expect(isValidNpub(`  ${valid}  `)).toBe(true);
+    expect(isValidNpub('  npub1short  ')).toBe(false);
+  });
+
+  it('returns false for npub1 with exactly 56 chars', () => {
+    const tooShort = 'npub1' + 'a'.repeat(51);
+    expect(tooShort.length).toBe(56);
+    expect(isValidNpub(tooShort)).toBe(false);
+  });
+});

--- a/src/lib/utils/open-external.test.ts
+++ b/src/lib/utils/open-external.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { openExternalUrl } from './open-external';
+
+let openUrlSpy: Mock<(href: string) => Promise<void>>;
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: vi.fn((href: string) => openUrlSpy(href)),
+}));
+
+describe('openExternalUrl', () => {
+  let windowOpenSpy: Mock<typeof window.open>;
+
+  beforeEach(() => {
+    openUrlSpy = vi.fn().mockResolvedValue(undefined);
+    windowOpenSpy = vi.fn().mockReturnValue(null);
+    vi.stubGlobal('window', {
+      __TAURI__: undefined,
+      open: windowOpenSpy,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores non-http(s) hrefs even with leading/trailing whitespace', async () => {
+    await openExternalUrl('  ftp://example.com  ');
+    expect(openUrlSpy).not.toHaveBeenCalled();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens https URL in new browser tab when not in Tauri', async () => {
+    await openExternalUrl('https://example.com');
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+    expect(openUrlSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses Tauri opener when inside Tauri', async () => {
+    vi.stubGlobal('window', { __TAURI__: {}, open: windowOpenSpy });
+    await openExternalUrl('https://example.com');
+    expect(openUrlSpy).toHaveBeenCalledWith('https://example.com');
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to window.open on Tauri opener failure', async () => {
+    openUrlSpy = vi.fn().mockRejectedValue(new Error('denied'));
+    vi.stubGlobal('window', { __TAURI__: {}, open: windowOpenSpy });
+    await openExternalUrl('https://example.com');
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+  });
+
+  it('trims input for scheme validation but opens the original href', async () => {
+    await openExternalUrl('  https://example.com  ');
+    expect(windowOpenSpy).toHaveBeenCalledWith('  https://example.com  ', '_blank', 'noopener,noreferrer');
+  });
+});

--- a/src/lib/utils/portal.test.ts
+++ b/src/lib/utils/portal.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { portal } from './portal';
+
+describe('portal', () => {
+  let body: {
+    appendChild: (node: unknown) => void;
+    removeChild: (node: unknown) => void;
+    contains: (node: unknown) => boolean;
+  };
+  let node: { parentNode: typeof body | null };
+
+  beforeEach(() => {
+    body = {
+      appendChild: (n) => {
+        node.parentNode = body;
+      },
+      removeChild: (n) => {
+        node.parentNode = null;
+      },
+      contains: (n) => node.parentNode === body,
+    };
+    node = { parentNode: null };
+    vi.stubGlobal('document', { body });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('appends node to document.body', () => {
+    portal(node as unknown as HTMLElement);
+    expect(node.parentNode).toBe(body);
+  });
+
+  it('returns destroy that removes node from document.body', () => {
+    const action = portal(node as unknown as HTMLElement);
+    expect(node.parentNode).toBe(body);
+    action.destroy();
+    expect(node.parentNode).toBeNull();
+  });
+});

--- a/src/lib/utils/profile.test.ts
+++ b/src/lib/utils/profile.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { getProfileDisplayName, getProfileAvatarSrc, getProfileBannerSrc } from './profile';
+import type { NostrProfile } from '../api/nostr';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedConvertFileSrc = vi.mocked(convertFileSrc);
+
+beforeEach(() => {
+  mockedConvertFileSrc.mockReset();
+  mockedConvertFileSrc.mockImplementation((path: string) => `asset://${path}`);
+  vi.stubGlobal('window', {
+    __TAURI__: undefined,
+  });
+});
+
+function makeProfile(overrides?: Partial<NostrProfile>): NostrProfile {
+  return {
+    id: 'npub1abcdef',
+    name: 'Name',
+    display_name: 'Display',
+    nickname: '',
+    avatar: '',
+    banner: '',
+    avatar_cached: '',
+    banner_cached: '',
+    last_read: '',
+    status: { title: '', purpose: '', url: '' },
+    last_updated: 0,
+    typing_until: 0,
+    mine: false,
+    lud06: '',
+    lud16: '',
+    about: '',
+    website: '',
+    nip05: '',
+    muted: false,
+    bot: false,
+    ...overrides,
+  };
+}
+
+describe('getProfileDisplayName', () => {
+  it('returns Unknown for null/undefined', () => {
+    expect(getProfileDisplayName(null)).toBe('Unknown');
+    expect(getProfileDisplayName(undefined)).toBe('Unknown');
+  });
+
+  it('prefers nickname, then name, then display_name', () => {
+    expect(getProfileDisplayName(makeProfile({ nickname: 'Nick' }))).toBe('Nick');
+    expect(getProfileDisplayName(makeProfile({ name: 'Name', display_name: 'Display' }))).toBe('Name');
+    expect(getProfileDisplayName(makeProfile({ display_name: 'Display', name: '' }))).toBe('Display');
+  });
+
+  it('falls back to short id then Unknown', () => {
+    expect(getProfileDisplayName(makeProfile({ id: 'npub1xyz', name: '', display_name: '' }))).toBe('npub1xyz');
+    expect(getProfileDisplayName(makeProfile({ id: '', name: '', display_name: '' }))).toBe('Unknown');
+  });
+
+  it('trims whitespace', () => {
+    expect(getProfileDisplayName(makeProfile({ nickname: '  Nick  ' }))).toBe('Nick');
+  });
+});
+
+describe('getProfileAvatarSrc', () => {
+  it('returns null for null/undefined profile', () => {
+    expect(getProfileAvatarSrc(null)).toBeNull();
+    expect(getProfileAvatarSrc(undefined)).toBeNull();
+  });
+
+  it('prefers remote https avatar', () => {
+    const profile = makeProfile({
+      avatar: 'https://example.com/avatar.png',
+      avatar_cached: '/cached/avatar.png',
+    });
+    expect(getProfileAvatarSrc(profile)).toBe('https://example.com/avatar.png');
+  });
+
+  it('ignores non-http avatar and uses cached path in Tauri', () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    const profile = makeProfile({
+      avatar: 'ftp://bad',
+      avatar_cached: '/cached/avatar.png',
+    });
+    expect(getProfileAvatarSrc(profile)).toBe('asset:///cached/avatar.png');
+    expect(mockedConvertFileSrc).toHaveBeenCalledWith('/cached/avatar.png');
+  });
+
+  it('returns null when avatar is a file path and not in Tauri', () => {
+    const profile = makeProfile({ avatar: '/path/to/avatar.png' });
+    expect(getProfileAvatarSrc(profile)).toBeNull();
+  });
+});
+
+describe('getProfileBannerSrc', () => {
+  it('returns null for null/undefined profile', () => {
+    expect(getProfileBannerSrc(null)).toBeNull();
+    expect(getProfileBannerSrc(undefined)).toBeNull();
+  });
+
+  it('prefers remote https banner', () => {
+    const profile = makeProfile({
+      banner: 'https://example.com/banner.png',
+      banner_cached: '/cached/banner.png',
+    });
+    expect(getProfileBannerSrc(profile)).toBe('https://example.com/banner.png');
+  });
+
+  it('uses cached banner in Tauri when no remote http banner', () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    const profile = makeProfile({ banner_cached: '/cached/banner.png' });
+    expect(getProfileBannerSrc(profile)).toBe('asset:///cached/banner.png');
+    expect(mockedConvertFileSrc).toHaveBeenCalledWith('/cached/banner.png');
+  });
+});

--- a/src/lib/utils/tauri-errors.test.ts
+++ b/src/lib/utils/tauri-errors.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { getInvokeErrorMessage, friendlyMessage } from './tauri-errors';
+
+describe('getInvokeErrorMessage', () => {
+  it('returns fallback for null/undefined', () => {
+    expect(getInvokeErrorMessage(null)).toBe('Something went wrong');
+    expect(getInvokeErrorMessage(undefined)).toBe('Something went wrong');
+    expect(getInvokeErrorMessage(undefined, 'Custom fallback')).toBe('Custom fallback');
+  });
+
+  it('returns string errors trimmed', () => {
+    expect(getInvokeErrorMessage('  oops  ')).toBe('oops');
+  });
+
+  it('falls back when string error is empty/whitespace', () => {
+    expect(getInvokeErrorMessage('   ', 'fallback')).toBe('fallback');
+    expect(getInvokeErrorMessage('')).toBe('Something went wrong');
+  });
+
+  it('extracts message from plain object', () => {
+    expect(getInvokeErrorMessage({ message: '  backend error  ' })).toBe('backend error');
+  });
+
+  it('extracts error from plain object', () => {
+    expect(getInvokeErrorMessage({ error: '  backend error  ' })).toBe('backend error');
+  });
+
+  it('extracts message from nested data', () => {
+    expect(getInvokeErrorMessage({ data: { message: '  nested  ' } })).toBe('nested');
+  });
+
+  it('extracts error from nested data', () => {
+    expect(getInvokeErrorMessage({ data: { error: '  nested  ' } })).toBe('nested');
+  });
+
+  it('extracts message from Error instance', () => {
+    expect(getInvokeErrorMessage(new Error('  error instance  '))).toBe('error instance');
+  });
+
+  it('prefers message over error', () => {
+    expect(getInvokeErrorMessage({ message: 'first', error: 'second' })).toBe('first');
+  });
+
+  it('returns fallback when no recognizable field exists', () => {
+    expect(getInvokeErrorMessage({ code: 500 })).toBe('Something went wrong');
+  });
+});
+
+describe('friendlyMessage', () => {
+  it('passes through unknown generic messages', () => {
+    expect(friendlyMessage('some error')).toBe('some error');
+  });
+
+  it('maps invalid npub in dm_send context', () => {
+    expect(friendlyMessage('invalid npub', 'dm_send')).toBe(
+      'Please enter a valid npub (starts with npub1).'
+    );
+    expect(friendlyMessage('Invalid Pubkey', 'dm_send')).toBe(
+      'Please enter a valid npub (starts with npub1).'
+    );
+  });
+
+  it('maps not initialized in dm_send context', () => {
+    expect(friendlyMessage('client not initialized', 'dm_send')).toBe('Please log in first.');
+  });
+
+  it('maps missing required key / invalid args in dm_send context', () => {
+    expect(friendlyMessage('missing required key', 'dm_send')).toBe(
+      'Invalid request. Please try again.'
+    );
+    expect(friendlyMessage('Invalid args', 'dm_send')).toBe('Invalid request. Please try again.');
+  });
+});

--- a/src/lib/wallet/assets.test.ts
+++ b/src/lib/wallet/assets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   WALLET_ASSETS_CHAIN_IDS,
   WALLET_CHAIN_GROUPS,
+  WALLET_ASSETS,
   getWalletAssetsForChain,
   getWalletNetworkDisplayName,
   getExplorerTxUrl,
@@ -31,6 +32,30 @@ describe('WALLET_CHAIN_GROUPS', () => {
     expect(localGroup).toBeDefined();
     expect(localGroup?.chains).toEqual(['local']);
   });
+
+  it('groups l1, l2, testnet, and local chains', () => {
+    const ids = WALLET_CHAIN_GROUPS.map((g) => g.id);
+    expect(ids).toContain('l1');
+    expect(ids).toContain('l2');
+    expect(ids).toContain('testnet');
+    expect(ids).toContain('local');
+  });
+
+  it('keeps the mainnet group as l1', () => {
+    const l1 = WALLET_CHAIN_GROUPS.find((g) => g.id === 'l1');
+    expect(l1?.chains).toContain('mainnet');
+  });
+});
+
+describe('WALLET_ASSETS', () => {
+  it('has a native entry for every supported chain', () => {
+    for (const chainId of WALLET_ASSETS_CHAIN_IDS) {
+      const net = WALLET_ASSETS.networks[chainId];
+      expect(net).toBeDefined();
+      expect(net?.native.symbol).toBeDefined();
+      expect(net?.native.decimals).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('getWalletAssetsForChain', () => {
@@ -52,16 +77,48 @@ describe('getWalletAssetsForChain', () => {
       note: 'Zero-address placeholder; not selectable for transfers. Deploy a local USDT mock to test transfers.',
     });
   });
+
+  it('returns undefined for an unknown chain', () => {
+    expect(getWalletAssetsForChain('unknown' as never)).toBeUndefined();
+  });
 });
 
 describe('getWalletNetworkDisplayName', () => {
   it('returns Local Anvil for the local chain', () => {
     expect(getWalletNetworkDisplayName('local')).toBe('Local Anvil');
   });
+
+  it('returns Arbitrum for the arbitrum chain', () => {
+    expect(getWalletNetworkDisplayName('arbitrum')).toBe('Arbitrum');
+  });
+
+  it('falls back to the chain id when there is no configured display name', () => {
+    expect(getWalletNetworkDisplayName('unknown' as never)).toBe('unknown');
+  });
 });
+
 describe('getExplorerTxUrl', () => {
   it('returns null for the local chain', () => {
-    expect(getExplorerTxUrl('local', '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789')).toBeNull();
+    expect(
+      getExplorerTxUrl('local', '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'),
+    ).toBeNull();
+  });
+
+  it('returns null when the chain has no explorer', () => {
+    expect(
+      getExplorerTxUrl('unknown' as never, '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'),
+    ).toBeNull();
+  });
+
+  it('builds a Sepolia Etherscan link', () => {
+    const tx = '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+    expect(getExplorerTxUrl('sepolia', tx)).toBe(`https://sepolia.etherscan.io/tx/${tx}`);
+  });
+
+  it('trims a trailing slash from the explorer path', () => {
+    const tx = '0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+    const assets = getWalletAssetsForChain('mainnet');
+    expect(getExplorerTxUrl('mainnet', tx)).toBe(`${assets?.explorerTxPath}${tx}`);
   });
 });
 
@@ -69,12 +126,34 @@ describe('explorerTxLinkLabel', () => {
   it('returns the fallback label for the local chain', () => {
     expect(explorerTxLinkLabel('local')).toBe('View on block explorer');
   });
+
+  it('derives the label from the explorer hostname', () => {
+    expect(explorerTxLinkLabel('sepolia')).toBe('View on sepolia.etherscan.io');
+    expect(explorerTxLinkLabel('mainnet')).toBe('View on etherscan.io');
+  });
+
+  it('returns the fallback label when there is no explorer', () => {
+    expect(explorerTxLinkLabel('unknown' as never)).toBe('View on block explorer');
+  });
 });
 
 describe('listWalletAssetOptionsForChain', () => {
   it('includes ETH and excludes zero-address USDC/USDT on local', () => {
     const options = listWalletAssetOptionsForChain('local');
     expect(options.map((o) => o.code)).toEqual(['ETH']);
+    expect(
+      options.every((o) => o.kind !== 'erc20' || o.address !== '0x0000000000000000000000000000000000000000'),
+    ).toBe(true);
+  });
+
+  it('includes ETH, USDC, and USDT on Sepolia', () => {
+    const options = listWalletAssetOptionsForChain('sepolia');
+    expect(options.map((o) => o.code)).toEqual(['ETH', 'USDC', 'USDT']);
     expect(options.every((o) => o.kind !== 'erc20' || o.address !== '0x0000000000000000000000000000000000000000')).toBe(true);
+  });
+
+  it('returns only the native option when the chain is unknown', () => {
+    const options = listWalletAssetOptionsForChain('unknown' as never);
+    expect(options).toEqual([]);
   });
 });

--- a/src/lib/wallet/backend-wallet.test.ts
+++ b/src/lib/wallet/backend-wallet.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  getEvmNativeBalance,
+  getWalletSummary,
+  walletBuildAndSendTransaction,
+  walletWaitForTransaction,
+  safeDeployProxy,
+  parseWalletOpError,
+  userFacingDeploySafeMessage,
+  type WalletOpParsedError,
+} from './backend-wallet';
+
+function failureMessage<T extends { ok: true } | { ok: false; message: string }>(
+  outcome: T,
+): string {
+  if (outcome.ok) throw new Error('expected failure outcome');
+  return outcome.message;
+}
+
+function failureParsed<T extends { ok: true } | { ok: false; parsed?: WalletOpParsedError }>(
+  outcome: T,
+): WalletOpParsedError | undefined {
+  if (outcome.ok) throw new Error('expected failure outcome');
+  return outcome.parsed;
+}
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+describe('backend-wallet', () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getEvmNativeBalance', () => {
+    it('returns an error when not in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await getEvmNativeBalance('sepolia', '0xabc');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Balances are only available in the desktop app.');
+    });
+
+    it('returns an error when the address is empty', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const result = await getEvmNativeBalance('sepolia', '  ');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Address is required.');
+      expect(mockedInvoke).not.toHaveBeenCalled();
+    });
+
+    it('invokes get_evm_native_balance with trimmed address', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const balance = { balanceRaw: '1000000000000000000', balanceDecimal: '1', symbol: 'ETH' };
+      mockedInvoke.mockResolvedValueOnce(balance);
+      const result = await getEvmNativeBalance('sepolia', '  0xabc  ');
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.balance).toEqual(balance);
+      expect(mockedInvoke).toHaveBeenCalledWith('get_evm_native_balance', {
+        network: 'sepolia',
+        address: '0xabc',
+      });
+    });
+
+    it('returns the error message from a string rejection', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce('rpc error');
+      const result = await getEvmNativeBalance('sepolia', '0xabc');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('rpc error');
+    });
+
+    it('returns the error message from an Error rejection', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce(new Error('node error'));
+      const result = await getEvmNativeBalance('sepolia', '0xabc');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('node error');
+    });
+
+    it('returns a default message for unknown rejections', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce(null);
+      const result = await getEvmNativeBalance('sepolia', '0xabc');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Could not load balance.');
+    });
+  });
+
+  describe('getWalletSummary', () => {
+    it('returns an error when not in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await getWalletSummary([]);
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Wallet summary is only available in the desktop app.');
+    });
+
+    it('invokes get_wallet_summary with watched tokens', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const summary = { networks: [], totalUsdApprox: 0, prices: {} as never };
+      mockedInvoke.mockResolvedValueOnce(summary);
+      const watched = [{ network: 'sepolia', symbol: 'USDC', address: '0xabc', decimals: 6 }];
+      const result = await getWalletSummary(watched);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.summary).toEqual(summary);
+      expect(mockedInvoke).toHaveBeenCalledWith('get_wallet_summary', { watchedErc20s: watched });
+    });
+
+    it('returns the error message from a rejected invoke', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce(new Error('summary failed'));
+      const result = await getWalletSummary([]);
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('summary failed');
+    });
+  });
+
+  describe('walletBuildAndSendTransaction', () => {
+    it('returns an error when not in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await walletBuildAndSendTransaction('npub', 'sepolia', 'ETH', '1');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Sending is only available in the desktop app.');
+    });
+
+    it('invokes wallet_build_and_send_transaction with defaults', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const sent = { txHash: '0x123', network: 'sepolia', chainId: 11155111 };
+      mockedInvoke.mockResolvedValueOnce(sent);
+      const result = await walletBuildAndSendTransaction(
+        'npub1',
+        'sepolia',
+        'ETH',
+        '  1.5  ',
+        undefined,
+        '  ',
+        false,
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.result).toEqual(sent);
+      expect(mockedInvoke).toHaveBeenCalledWith('wallet_build_and_send_transaction', {
+        toNpub: 'npub1',
+        network: 'sepolia',
+        asset: 'ETH',
+        amount: '1.5',
+        erc20Transfer: null,
+        toAddressEvm: null,
+        waitForConfirmation: false,
+      });
+    });
+
+    it('includes an ERC-20 transfer and explicit EVM address when provided', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const sent = { txHash: '0x123', network: 'sepolia', chainId: 11155111 };
+      mockedInvoke.mockResolvedValueOnce(sent);
+      const erc20 = { address: '0xToken', decimals: 6 };
+      const result = await walletBuildAndSendTransaction(
+        'npub1',
+        'sepolia',
+        'USDC',
+        '10',
+        erc20,
+        '0xRecipient',
+        true,
+      );
+      expect(result.ok).toBe(true);
+      expect(mockedInvoke).toHaveBeenCalledWith('wallet_build_and_send_transaction', {
+        toNpub: 'npub1',
+        network: 'sepolia',
+        asset: 'USDC',
+        amount: '10',
+        erc20Transfer: erc20,
+        toAddressEvm: '0xRecipient',
+        waitForConfirmation: true,
+      });
+    });
+
+    it('parses a JSON error from a rejected invoke', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const raw = '{"code":"SEND_FAILED","message":"insufficient funds"}';
+      mockedInvoke.mockRejectedValueOnce(raw);
+      const result = await walletBuildAndSendTransaction('npub1', 'sepolia', 'ETH', '1');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('insufficient funds');
+      expect(failureParsed(result)).toEqual({ code: 'SEND_FAILED', message: 'insufficient funds' });
+    });
+  });
+
+  describe('walletWaitForTransaction', () => {
+    it('returns an error when not in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await walletWaitForTransaction('sepolia', '0x123');
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Confirmation polling is only available in the desktop app.');
+    });
+
+    it('invokes wallet_wait_for_transaction with trimmed hash', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const receipt = { txHash: '0x123', network: 'sepolia', chainId: 11155111 };
+      mockedInvoke.mockResolvedValueOnce(receipt);
+      const result = await walletWaitForTransaction('sepolia', '  0x123  ');
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.result).toEqual(receipt);
+      expect(mockedInvoke).toHaveBeenCalledWith('wallet_wait_for_transaction', {
+        network: 'sepolia',
+        txHash: '0x123',
+      });
+    });
+
+    it('parses a JSON error from a rejected invoke', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const raw = '{"code":"RECEIPT_TIMEOUT","message":"timeout"}';
+      mockedInvoke.mockRejectedValueOnce(raw);
+      const result = await walletWaitForTransaction('sepolia', '0x123');
+      expect(result.ok).toBe(false);
+      expect(failureParsed(result)?.code).toBe('RECEIPT_TIMEOUT');
+    });
+  });
+
+  describe('safeDeployProxy', () => {
+    it('returns an error when not in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await safeDeployProxy('sepolia', ['0xOwner'], 1);
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toBe('Deploy is only available in the desktop app.');
+    });
+
+    it('invokes safe_deploy_proxy with null optional fields', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const deployed = {
+        txHash: '0xabc',
+        safeAddress: '0xSafe',
+        chain: 'sepolia',
+        chainId: 11155111,
+      };
+      mockedInvoke.mockResolvedValueOnce(deployed);
+      const result = await safeDeployProxy('sepolia', ['0xOwner'], 1);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.result).toEqual(deployed);
+      expect(mockedInvoke).toHaveBeenCalledWith('safe_deploy_proxy', {
+        network: 'sepolia',
+        owners: ['0xOwner'],
+        threshold: 1,
+        saltNonce: null,
+        parentId: null,
+      });
+    });
+
+    it('trims parentId and preserves saltNonce when provided', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockResolvedValueOnce({
+        txHash: '0xabc',
+        safeAddress: '0xSafe',
+        chain: 'sepolia',
+        chainId: 11155111,
+      });
+      await safeDeployProxy('sepolia', ['0xOwner'], 1, '  salt  ', '  parent  ');
+      expect(mockedInvoke).toHaveBeenCalledWith('safe_deploy_proxy', {
+        network: 'sepolia',
+        owners: ['0xOwner'],
+        threshold: 1,
+        saltNonce: '  salt  ',
+        parentId: 'parent',
+      });
+    });
+
+    it('returns a parsed JSON error from a rejected invoke', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce('{"code":"NO_EVM_KEY","message":"no key"}');
+      const result = await safeDeployProxy('sepolia', ['0xOwner'], 1);
+      expect(result.ok).toBe(false);
+      expect(failureParsed(result)?.code).toBe('NO_EVM_KEY');
+    });
+  });
+
+  describe('parseWalletOpError', () => {
+    it('returns null for non-JSON strings', () => {
+      expect(parseWalletOpError('plain error')).toBeNull();
+      expect(parseWalletOpError('  ')).toBeNull();
+    });
+
+    it('returns null when required fields are missing', () => {
+      expect(parseWalletOpError('{"code":"X"}')).toBeNull();
+      expect(parseWalletOpError('{"message":"Y"}')).toBeNull();
+    });
+
+    it('parses a JSON error with optional fields', () => {
+      const raw = '{"code":"X","message":"Y","npub":"npub1","txHash":"0x123"}';
+      expect(parseWalletOpError(raw)).toEqual({
+        code: 'X',
+        message: 'Y',
+        npub: 'npub1',
+        txHash: '0x123',
+      });
+    });
+
+    it('ignores extra fields', () => {
+      const raw = '{"code":"X","message":"Y","extra":"ignored"}';
+      expect(parseWalletOpError(raw)).toEqual({ code: 'X', message: 'Y' });
+    });
+  });
+
+  describe('userFacingDeploySafeMessage', () => {
+    it('returns a default message for an undefined error', () => {
+      expect(userFacingDeploySafeMessage(undefined)).toBe('Deploy failed.');
+    });
+
+    it('shortens a long SEND_FAILED message', () => {
+      const parsed: WalletOpParsedError = {
+        code: 'SEND_FAILED',
+        message: 'a'.repeat(150),
+      };
+      expect(userFacingDeploySafeMessage(parsed)).toContain('Check your native balance');
+    });
+
+    it('returns a friendly RPC_CONNECT message', () => {
+      const parsed: WalletOpParsedError = {
+        code: 'RPC_CONNECT',
+        message: 'rpc failed',
+      };
+      expect(userFacingDeploySafeMessage(parsed)).toContain('ALCHEMY_RPC_KEY');
+    });
+
+    it('returns a friendly NO_EVM_KEY message', () => {
+      const parsed: WalletOpParsedError = {
+        code: 'NO_EVM_KEY',
+        message: 'no key',
+      };
+      expect(userFacingDeploySafeMessage(parsed)).toContain('embedded wallet key');
+    });
+
+    it('returns the raw message for other codes', () => {
+      const parsed: WalletOpParsedError = { code: 'OTHER', message: 'custom error' };
+      expect(userFacingDeploySafeMessage(parsed)).toBe('custom error');
+    });
+  });
+});

--- a/src/lib/wallet/client.test.ts
+++ b/src/lib/wallet/client.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPublicClient } from './client';
+
+vi.mock('$lib/wallet/chains', () => ({
+  createWalletPublicClient: vi.fn(),
+  DEFAULT_CHAIN_ID: 'sepolia',
+  SUPPORTED_CHAINS: {},
+}));
+
+import { createWalletPublicClient } from '$lib/wallet/chains';
+
+describe('getPublicClient', () => {
+  beforeEach(() => {
+    vi.mocked(createWalletPublicClient).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a public client for the default chain when no chain id is given', () => {
+    const fakeClient = { readContract: vi.fn() };
+    vi.mocked(createWalletPublicClient).mockReturnValue(fakeClient as never);
+
+    const result = getPublicClient();
+    expect(createWalletPublicClient).toHaveBeenCalledWith('sepolia');
+    expect(result).toBe(fakeClient);
+  });
+
+  it('creates a public client for the requested chain', () => {
+    const fakeClient = { readContract: vi.fn() };
+    vi.mocked(createWalletPublicClient).mockReturnValue(fakeClient as never);
+
+    const result = getPublicClient('mainnet');
+    expect(createWalletPublicClient).toHaveBeenCalledWith('mainnet');
+    expect(result).toBe(fakeClient);
+  });
+});

--- a/src/lib/wallet/clipboard-copy.test.ts
+++ b/src/lib/wallet/clipboard-copy.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { copyTextToClipboard } from './clipboard-copy';
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  writeText: vi.fn(),
+}));
+
+describe('copyTextToClipboard', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the Tauri plugin when running inside the desktop shell', async () => {
+    vi.mocked(writeText).mockResolvedValueOnce(undefined);
+    vi.stubGlobal('window', { __TAURI__: {} });
+    const result = await copyTextToClipboard('hello');
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('falls back to navigator.clipboard when Tauri is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValueOnce(undefined);
+    vi.stubGlobal('window', { __TAURI__: undefined });
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const result = await copyTextToClipboard('fallback');
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('fallback');
+  });
+
+  it('falls back to navigator.clipboard when the Tauri plugin fails', async () => {
+    vi.mocked(writeText).mockRejectedValueOnce(new Error('denied'));
+    const navWriteText = vi.fn().mockResolvedValueOnce(undefined);
+    vi.stubGlobal('window', { __TAURI__: {} });
+    vi.stubGlobal('navigator', { clipboard: { writeText: navWriteText } });
+    const result = await copyTextToClipboard('fallback after tauri');
+    expect(result).toBe(true);
+    expect(navWriteText).toHaveBeenCalledWith('fallback after tauri');
+  });
+
+  it('returns false when navigator.clipboard is unavailable', async () => {
+    vi.stubGlobal('window', { __TAURI__: undefined });
+    vi.stubGlobal('navigator', { clipboard: undefined });
+    const result = await copyTextToClipboard('no clipboard');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when navigator.clipboard.writeText throws', async () => {
+    const writeText = vi.fn().mockRejectedValueOnce(new Error('denied'));
+    vi.stubGlobal('window', { __TAURI__: undefined });
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const result = await copyTextToClipboard('throws');
+    expect(result).toBe(false);
+  });
+});

--- a/src/lib/wallet/evm-accounts.test.ts
+++ b/src/lib/wallet/evm-accounts.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  listEvmAccounts,
+  addEvmAccountRow,
+  importEvmAccountRow,
+  updateEvmAccountRow,
+  setActiveEvmAccount,
+  setDefaultSharedEvmAccount,
+  setActiveAdvancedEvmAccount,
+  advancedEvmAccounts,
+  evmAccountPurposeLabel,
+  evmAccountSchemeLabel,
+  getActiveAdvancedEvmSignerAddress,
+  getActiveEvmSignerAddress,
+  getActiveSquadEvmSignerAddress,
+  isAdvancedPurposeAccount,
+  isSquadPurposeAccount,
+  squadEvmAccounts,
+  type EvmAccountRow,
+} from '../wallet/evm-accounts';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('evm account purpose helpers', () => {
+  const rows: EvmAccountRow[] = [
+    {
+      id: 's1',
+      scheme: 'bip44_v1',
+      hdIndex: 0,
+      address: '0x1111111111111111111111111111111111111111',
+      label: 'Squad',
+      purpose: 'squad',
+      isActive: true,
+      isDefaultShared: true,
+      isActiveAdvanced: false,
+    },
+    {
+      id: 'a1',
+      scheme: 'imported_private_key',
+      hdIndex: null,
+      address: '0x2222222222222222222222222222222222222222',
+      label: '',
+      purpose: 'advanced',
+      isActive: false,
+      isDefaultShared: false,
+      isActiveAdvanced: true,
+    },
+  ];
+
+  it('filters squad and advanced lists', () => {
+    expect(squadEvmAccounts(rows)).toHaveLength(1);
+    expect(advancedEvmAccounts(rows)).toHaveLength(1);
+    expect(squadEvmAccounts(null)).toEqual([]);
+    expect(advancedEvmAccounts(undefined)).toEqual([]);
+  });
+
+  it('classifies purpose flags', () => {
+    expect(isSquadPurposeAccount(rows[0])).toBe(true);
+    expect(isAdvancedPurposeAccount(rows[1])).toBe(true);
+  });
+});
+
+describe('evm account label helpers', () => {
+  it('labels the known schemes', () => {
+    expect(evmAccountSchemeLabel('bip44_v1')).toBe('Derived');
+    expect(evmAccountSchemeLabel('imported_private_key')).toBe('Imported');
+    expect(evmAccountSchemeLabel('other')).toBe('other');
+  });
+
+  it('labels squad and advanced purposes', () => {
+    expect(evmAccountPurposeLabel('squad')).toBe('Squad');
+    expect(evmAccountPurposeLabel('advanced')).toBe('Advanced');
+  });
+});
+
+describe('active evm signer address', () => {
+  it('resolves the active squad signer address', async () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    mockedInvoke.mockResolvedValueOnce([
+      {
+        id: 'a1',
+        scheme: 'bip44_v1',
+        hdIndex: 0,
+        address: '  0xSquadActive  ',
+        label: 'Squad',
+        purpose: 'squad',
+        isActive: true,
+        isDefaultShared: true,
+        isActiveAdvanced: false,
+      },
+      {
+        id: 'a2',
+        scheme: 'bip44_v1',
+        hdIndex: 1,
+        address: '0xAdvancedActive',
+        label: 'Advanced',
+        purpose: 'advanced',
+        isActive: false,
+        isDefaultShared: false,
+        isActiveAdvanced: true,
+      },
+    ]);
+    const address = await getActiveSquadEvmSignerAddress();
+    expect(address).toBe('0xSquadActive');
+  });
+
+  it('resolves the active advanced signer address', async () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    mockedInvoke.mockResolvedValueOnce([
+      {
+        id: 'a1',
+        scheme: 'bip44_v1',
+        hdIndex: 0,
+        address: '0xSquadActive',
+        label: 'Squad',
+        purpose: 'squad',
+        isActive: true,
+        isDefaultShared: true,
+        isActiveAdvanced: false,
+      },
+      {
+        id: 'a2',
+        scheme: 'imported_private_key',
+        hdIndex: null,
+        address: '  0xAdvancedActive  ',
+        label: 'Advanced',
+        purpose: 'advanced',
+        isActive: false,
+        isDefaultShared: false,
+        isActiveAdvanced: true,
+      },
+    ]);
+    const address = await getActiveAdvancedEvmSignerAddress();
+    expect(address).toBe('0xAdvancedActive');
+  });
+
+  it('returns null when there is no active signer', async () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    mockedInvoke.mockResolvedValueOnce([]);
+    expect(await getActiveSquadEvmSignerAddress()).toBeNull();
+    expect(await getActiveAdvancedEvmSignerAddress()).toBeNull();
+  });
+
+  it('deprecated getActiveEvmSignerAddress delegates to squad signer', async () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    mockedInvoke.mockResolvedValueOnce([
+      {
+        id: 'a1',
+        scheme: 'bip44_v1',
+        hdIndex: 0,
+        address: '0xSquadActive',
+        label: 'Squad',
+        purpose: 'squad',
+        isActive: true,
+        isDefaultShared: true,
+        isActiveAdvanced: false,
+      },
+    ]);
+    expect(await getActiveEvmSignerAddress()).toBe('0xSquadActive');
+  });
+});
+
+describe('evm-accounts command wrappers', () => {
+  it('listEvmAccounts returns null when not running inside Tauri', async () => {
+    vi.stubGlobal('window', undefined);
+    const result = await listEvmAccounts();
+    expect(result).toBeNull();
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it('listEvmAccounts sends list_evm_accounts when Tauri is present', async () => {
+    vi.stubGlobal('window', { __TAURI__: {} });
+    mockedInvoke.mockResolvedValueOnce([]);
+    const result = await listEvmAccounts();
+    expect(mockedInvoke).toHaveBeenCalledWith('list_evm_accounts');
+    expect(result).toEqual([]);
+  });
+
+  it('addEvmAccountRow sends add_evm_account with defaults', async () => {
+    const row = {
+      id: '1',
+      scheme: 'bip44_v1',
+      hdIndex: 0,
+      address: '0xabc',
+      label: 'Squad',
+      purpose: 'squad',
+      isActive: true,
+      isDefaultShared: true,
+      isActiveAdvanced: false,
+    };
+    mockedInvoke.mockResolvedValueOnce(row);
+    const result = await addEvmAccountRow({
+      label: 'Squad',
+      setActiveSigner: true,
+      setDefaultShared: true,
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('add_evm_account', {
+      label: 'Squad',
+      setActiveSigner: true,
+      setDefaultShared: true,
+      purpose: 'squad',
+    });
+    expect(result).toEqual(row);
+  });
+
+  it('importEvmAccountRow sends import_evm_account with private key', async () => {
+    const row = {
+      id: '2',
+      scheme: 'imported_private_key',
+      hdIndex: null,
+      address: '0xdef',
+      label: 'Imported',
+      purpose: 'squad',
+      isActive: false,
+      isDefaultShared: false,
+      isActiveAdvanced: false,
+    };
+    mockedInvoke.mockResolvedValueOnce(row);
+    const result = await importEvmAccountRow('0xkey');
+    expect(mockedInvoke).toHaveBeenCalledWith('import_evm_account', {
+      privateKeyHex: '0xkey',
+      setActiveSigner: false,
+    });
+    expect(result).toEqual(row);
+  });
+
+  it('updateEvmAccountRow sends update_evm_account with all fields', async () => {
+    const row = {
+      id: '1',
+      scheme: 'bip44_v1',
+      hdIndex: 0,
+      address: '0xabc',
+      label: 'Updated',
+      purpose: 'squad',
+      isActive: true,
+      isDefaultShared: false,
+      isActiveAdvanced: false,
+    };
+    mockedInvoke.mockResolvedValueOnce(row);
+    const result = await updateEvmAccountRow({
+      accountId: '1',
+      label: 'Updated',
+      setActiveSigner: true,
+      setDefaultShared: false,
+    });
+    expect(mockedInvoke).toHaveBeenCalledWith('update_evm_account', {
+      accountId: '1',
+      label: 'Updated',
+      setActiveSigner: true,
+      setDefaultShared: false,
+    });
+    expect(result).toEqual(row);
+  });
+
+  it('setActiveEvmAccount sends set_active_evm_account', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await setActiveEvmAccount('1');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_active_evm_account', { accountId: '1' });
+  });
+
+  it('setDefaultSharedEvmAccount sends set_default_shared_evm_account', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await setDefaultSharedEvmAccount('1');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_default_shared_evm_account', { accountId: '1' });
+  });
+
+  it('setActiveAdvancedEvmAccount sends set_active_advanced_evm_account', async () => {
+    mockedInvoke.mockResolvedValueOnce(undefined);
+    await setActiveAdvancedEvmAccount('1');
+    expect(mockedInvoke).toHaveBeenCalledWith('set_active_advanced_evm_account', { accountId: '1' });
+  });
+});

--- a/src/lib/wallet/index.test.ts
+++ b/src/lib/wallet/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import * as wallet from './index';
+
+describe('wallet index re-exports', () => {
+  it('re-exports chain helpers', () => {
+    expect(wallet.SUPPORTED_CHAINS).toBeDefined();
+    expect(wallet.DEFAULT_CHAIN_ID).toBe('sepolia');
+    expect(wallet.getChainConfig).toBeInstanceOf(Function);
+    expect(wallet.getEffectiveRpcUrlsForChain).toBeInstanceOf(Function);
+    expect(wallet.createWalletPublicClient).toBeInstanceOf(Function);
+  });
+
+  it('re-exports public client and backend wallet helpers', () => {
+    expect(wallet.getPublicClient).toBeInstanceOf(Function);
+    expect(wallet.getWalletSummary).toBeInstanceOf(Function);
+    expect(wallet.walletBuildAndSendTransaction).toBeInstanceOf(Function);
+    expect(wallet.walletWaitForTransaction).toBeInstanceOf(Function);
+    expect(wallet.parseWalletOpError).toBeInstanceOf(Function);
+    expect(wallet.safeDeployProxy).toBeInstanceOf(Function);
+    expect(wallet.userFacingDeploySafeMessage).toBeInstanceOf(Function);
+  });
+
+  it('re-exports Safe and pricing helpers', () => {
+    expect(wallet.getSafeState).toBeInstanceOf(Function);
+    expect(wallet.getWalletUsdSpotPrices).toBeInstanceOf(Function);
+    expect(wallet.amountToApproxUsd).toBeInstanceOf(Function);
+    expect(wallet.formatApproxUsd).toBeInstanceOf(Function);
+  });
+
+  it('re-exports asset and watched-token helpers', () => {
+    expect(wallet.WALLET_ASSETS).toBeDefined();
+    expect(wallet.WALLET_ASSETS_CHAIN_IDS).toBeDefined();
+    expect(wallet.getWalletAssetsForChain).toBeInstanceOf(Function);
+    expect(wallet.loadWatchedErc20Rows).toBeInstanceOf(Function);
+    expect(wallet.saveWatchedErc20Rows).toBeInstanceOf(Function);
+    expect(wallet.defaultWatchedErc20Rows).toBeInstanceOf(Function);
+  });
+
+  it('re-exports DM wallet and clipboard helpers', () => {
+    expect(wallet.parseWalletTxRequest).toBeInstanceOf(Function);
+    expect(wallet.parseWalletTxAnnouncement).toBeInstanceOf(Function);
+    expect(wallet.copyTextToClipboard).toBeInstanceOf(Function);
+  });
+});

--- a/src/lib/wallet/pricing.test.ts
+++ b/src/lib/wallet/pricing.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  getWalletUsdSpotPrices,
+  amountToApproxUsd,
+  formatApproxUsd,
+  type WalletUsdSpotPricesResult,
+} from './pricing';
+
+function failureMessage(outcome: WalletUsdSpotPricesResult): string {
+  if (outcome.ok) throw new Error('expected failure outcome');
+  return outcome.message;
+}
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+describe('pricing', () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getWalletUsdSpotPrices', () => {
+    it('returns a browser-only error when not running in Tauri', async () => {
+      vi.stubGlobal('window', undefined);
+      const result = await getWalletUsdSpotPrices();
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toContain('Pacto desktop app');
+      expect(mockedInvoke).not.toHaveBeenCalled();
+    });
+
+    it('invokes wallet_get_usd_spot_prices and returns prices in Tauri', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      const prices = {
+        ethUsd: 3500,
+        usdcUsd: 1,
+        usdtUsd: 0.99,
+        source: 'chainlink',
+        feedNetwork: 'mainnet',
+        fetchedAtMsEpoch: 1710000000000,
+      };
+      mockedInvoke.mockResolvedValueOnce(prices);
+      const result = await getWalletUsdSpotPrices();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.prices).toEqual(prices);
+      }
+      expect(mockedInvoke).toHaveBeenCalledWith('wallet_get_usd_spot_prices');
+    });
+
+    it('returns a user-facing error when the invoke fails', async () => {
+      vi.stubGlobal('window', { __TAURI__: {} });
+      mockedInvoke.mockRejectedValueOnce(new Error('rpc down'));
+      const result = await getWalletUsdSpotPrices();
+      expect(result.ok).toBe(false);
+      expect(failureMessage(result)).toContain('Live USD prices are unavailable');
+    });
+  });
+
+  describe('amountToApproxUsd', () => {
+    const prices = {
+      ethUsd: 3500,
+      usdcUsd: 1,
+      usdtUsd: 0.99,
+      source: 'chainlink',
+      feedNetwork: 'mainnet',
+      fetchedAtMsEpoch: 1710000000000,
+    };
+
+    it('returns null for invalid, negative, or blank amounts', () => {
+      expect(amountToApproxUsd('', 'ETH', prices)).toBeNull();
+      expect(amountToApproxUsd('not-a-number', 'ETH', prices)).toBeNull();
+      expect(amountToApproxUsd('-1', 'ETH', prices)).toBeNull();
+      expect(amountToApproxUsd('  ', 'ETH', prices)).toBeNull();
+    });
+
+    it('returns null for unknown assets', () => {
+      expect(amountToApproxUsd('1', 'BTC', prices)).toBeNull();
+    });
+
+    it('returns null when the price is non-positive', () => {
+      expect(amountToApproxUsd('1', 'ETH', { ...prices, ethUsd: 0 })).toBeNull();
+      expect(amountToApproxUsd('1', 'ETH', { ...prices, ethUsd: Number.NaN })).toBeNull();
+    });
+
+    it('converts a valid amount to USD using the live price', () => {
+      expect(amountToApproxUsd('2', 'ETH', prices)).toBe(7000);
+      expect(amountToApproxUsd('100', 'USDC', prices)).toBe(100);
+      expect(amountToApproxUsd('100', 'USDT', prices)).toBe(99);
+    });
+  });
+
+  describe('formatApproxUsd', () => {
+    it('returns an em-dash for non-finite values', () => {
+      expect(formatApproxUsd(Number.NaN)).toBe('—');
+      expect(formatApproxUsd(Number.POSITIVE_INFINITY)).toBe('—');
+    });
+
+    it('formats small amounts with up to two decimals', () => {
+      expect(formatApproxUsd(99.99)).toBe('$99.99');
+      expect(formatApproxUsd(0.5)).toBe('$0.5');
+    });
+
+    it('formats large amounts without decimals', () => {
+      expect(formatApproxUsd(100)).toBe('$100');
+      expect(formatApproxUsd(12345.67)).toBe('$12,346');
+    });
+  });
+});

--- a/src/lib/wallet/safe.test.ts
+++ b/src/lib/wallet/safe.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPublicClient } from '$lib/wallet/client';
+import { getSafeState } from './safe';
+
+vi.mock('$lib/wallet/client', () => ({
+  getPublicClient: vi.fn(),
+}));
+
+const MOCK_ADDRESS = '0x1111111111111111111111111111111111111111';
+
+describe('getSafeState', () => {
+  beforeEach(() => {
+    vi.mocked(getPublicClient).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reads owners, threshold, nonce, and balance from a Safe contract', async () => {
+    const mockClient = {
+      readContract: vi.fn(async ({ functionName }: { functionName: string }) => {
+        if (functionName === 'getOwners') return [MOCK_ADDRESS];
+        if (functionName === 'getThreshold') return 2n;
+        if (functionName === 'nonce') return 5n;
+        throw new Error(`Unexpected function ${functionName}`);
+      }),
+      getBalance: vi.fn().mockResolvedValue(10_000_000_000_000_000n),
+    };
+    vi.mocked(getPublicClient).mockReturnValue(mockClient as never);
+
+    const state = await getSafeState(MOCK_ADDRESS);
+
+    expect(state).toEqual({
+      address: MOCK_ADDRESS,
+      owners: [MOCK_ADDRESS],
+      threshold: 2,
+      nonce: 5n,
+      balanceWei: 10_000_000_000_000_000n,
+      balanceFormatted: '0.01',
+    });
+    expect(mockClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_ADDRESS,
+        functionName: 'getOwners',
+      }),
+    );
+    expect(mockClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_ADDRESS,
+        functionName: 'getThreshold',
+      }),
+    );
+    expect(mockClient.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MOCK_ADDRESS,
+        functionName: 'nonce',
+      }),
+    );
+    expect(mockClient.getBalance).toHaveBeenCalledWith({ address: MOCK_ADDRESS });
+  });
+
+  it('uses the provided chain id', async () => {
+    const mockClient = {
+      readContract: vi.fn().mockResolvedValue([]),
+      getBalance: vi.fn().mockResolvedValue(0n),
+    };
+    vi.mocked(getPublicClient).mockReturnValue(mockClient as never);
+
+    await getSafeState(MOCK_ADDRESS, 'mainnet');
+    expect(getPublicClient).toHaveBeenCalledWith('mainnet');
+  });
+});

--- a/src/lib/wallet/wallet-dm-transfer.test.ts
+++ b/src/lib/wallet/wallet-dm-transfer.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../stores/dm', () => ({
+  appendPendingOutboundDmMessage: vi.fn().mockReturnValue('opt-id'),
+  patchOutboundWalletTxByHash: vi.fn(),
+}));
+
+vi.mock('../../stores/toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('../evm/on-chain-background', () => ({
+  toastOnChainSubmitted: vi.fn(),
+  toastOnChainConfirmed: vi.fn(),
+}));
+
+vi.mock('./backend-wallet', () => ({
+  walletWaitForTransaction: vi.fn(),
+}));
+
+vi.mock('./evm-accounts', () => ({
+  getActiveEvmSignerAddress: vi.fn(),
+}));
+
+vi.mock('./dm-messages', () => ({
+  formatWalletTxAnnouncement: vi.fn().mockReturnValue('ann-content'),
+  parseWalletTxAnnouncement: vi.fn(),
+  isWalletTxAnnouncementOnChainPending: vi.fn(),
+}));
+
+import { appendPendingOutboundDmMessage, patchOutboundWalletTxByHash } from '../../stores/dm';
+import { showToast } from '../../stores/toast';
+import { toastOnChainSubmitted, toastOnChainConfirmed } from '../evm/on-chain-background';
+import { walletWaitForTransaction } from './backend-wallet';
+import { getActiveEvmSignerAddress } from './evm-accounts';
+import { formatWalletTxAnnouncement, parseWalletTxAnnouncement, isWalletTxAnnouncementOnChainPending } from './dm-messages';
+import type { DmMessage } from '../../stores/dm';
+
+describe('wallet-dm-transfer', () => {
+  let mod: typeof import('./wallet-dm-transfer');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    vi.mocked(appendPendingOutboundDmMessage).mockReset().mockReturnValue('opt-id');
+    vi.mocked(patchOutboundWalletTxByHash).mockReset();
+    vi.mocked(showToast).mockReset();
+    vi.mocked(toastOnChainSubmitted).mockReset();
+    vi.mocked(toastOnChainConfirmed).mockReset();
+    vi.mocked(walletWaitForTransaction).mockReset();
+    vi.mocked(getActiveEvmSignerAddress).mockReset();
+    vi.mocked(formatWalletTxAnnouncement).mockReset().mockReturnValue('ann-content');
+    vi.mocked(parseWalletTxAnnouncement).mockReset();
+    vi.mocked(isWalletTxAnnouncementOnChainPending).mockReset();
+    mod = await import('./wallet-dm-transfer');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('toastWalletBroadcastSubmitted', () => {
+    it('delegates to toastOnChainSubmitted', () => {
+      const result = { txHash: '0xabc', network: 'sepolia', chainId: 11155111 } as const;
+      mod.toastWalletBroadcastSubmitted(result);
+      expect(toastOnChainSubmitted).toHaveBeenCalledWith('sepolia', '0xabc', 'Transaction');
+    });
+  });
+
+  describe('finalizeWalletDmTransferAfterBroadcast', () => {
+    const params = {
+      peerNpub: 'npub1peer',
+      network: 'sepolia' as const,
+      asset: 'ETH',
+      amount: '1',
+      txHash: '0xabc',
+      fromNpub: 'npub1me',
+      sendDm: vi.fn().mockResolvedValue(true),
+      onBalanceRefresh: vi.fn(),
+    };
+
+    it('shows a toast and skips the optimistic note when there is no active signer', async () => {
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue(null);
+      await mod.finalizeWalletDmTransferAfterBroadcast(params);
+      expect(showToast).toHaveBeenCalledWith(expect.stringContaining('no active EVM address'));
+      expect(appendPendingOutboundDmMessage).not.toHaveBeenCalled();
+      expect(walletWaitForTransaction).not.toHaveBeenCalled();
+    });
+
+    it('posts an optimistic note and finalizes on confirmation', async () => {
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue('0xFrom');
+      vi.mocked(walletWaitForTransaction).mockResolvedValue({
+        ok: true,
+        result: { txHash: '0xabc', network: 'sepolia', chainId: 11155111, blockNumber: '123' },
+      });
+      params.sendDm.mockResolvedValue(true);
+
+      await mod.finalizeWalletDmTransferAfterBroadcast(params);
+      await vi.runAllTimersAsync();
+
+      expect(formatWalletTxAnnouncement).toHaveBeenCalled();
+      expect(appendPendingOutboundDmMessage).toHaveBeenCalledWith('npub1peer', 'ann-content');
+      expect(walletWaitForTransaction).toHaveBeenCalledWith('sepolia', '0xabc');
+      expect(patchOutboundWalletTxByHash).toHaveBeenCalledWith(
+        'npub1peer',
+        '0xabc',
+        expect.objectContaining({ pending: false, failed: false }),
+      );
+      expect(params.sendDm).toHaveBeenCalledWith('ann-content');
+      expect(params.onBalanceRefresh).toHaveBeenCalled();
+      expect(toastOnChainConfirmed).toHaveBeenCalledWith('sepolia', '0xabc', 'Transfer');
+    });
+
+    it('shows a timeout toast when the receipt times out', async () => {
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue('0xFrom');
+      vi.mocked(walletWaitForTransaction).mockResolvedValue({
+        ok: false,
+        message: 'timeout',
+        parsed: { code: 'RECEIPT_TIMEOUT', message: 'timeout' },
+      });
+
+      const promise = mod.finalizeWalletDmTransferAfterBroadcast(params);
+      await vi.advanceTimersByTimeAsync(15_000 * 25);
+      await promise;
+
+      expect(showToast).toHaveBeenCalledWith(expect.stringContaining('still waiting'));
+      expect(patchOutboundWalletTxByHash).not.toHaveBeenCalled();
+    });
+
+    it('marks the optimistic card as failed on a non-timeout error', async () => {
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue('0xFrom');
+      vi.mocked(walletWaitForTransaction).mockResolvedValue({
+        ok: false,
+        message: 'reverted',
+        parsed: { code: 'OTHER', message: 'reverted' },
+      });
+
+      await mod.finalizeWalletDmTransferAfterBroadcast(params);
+      await vi.runAllTimersAsync();
+
+      expect(patchOutboundWalletTxByHash).toHaveBeenCalledWith(
+        'npub1peer',
+        '0xabc',
+        expect.objectContaining({ pending: false, failed: true }),
+      );
+      expect(showToast).toHaveBeenCalledWith('reverted');
+    });
+  });
+
+  describe('resumePendingWalletTxConfirmations', () => {
+    const ctx = {
+      fromNpub: 'npub1me',
+      sendDm: vi.fn().mockResolvedValue(true),
+      onBalanceRefresh: vi.fn(),
+    };
+
+    it('does nothing for non-mine or non-pending messages', async () => {
+      const messages = [
+        { id: '1', mine: false, content: 'hello' },
+        { id: '2', mine: true, content: 'not an announcement' },
+      ] as DmMessage[];
+      vi.mocked(parseWalletTxAnnouncement).mockReturnValue(null);
+      vi.mocked(isWalletTxAnnouncementOnChainPending).mockReturnValue(false);
+
+      mod.resumePendingWalletTxConfirmations('npub1peer', messages, ctx);
+      await Promise.resolve();
+
+      expect(walletWaitForTransaction).not.toHaveBeenCalled();
+    });
+
+    it('resumes a pending wallet announcement and confirms it', async () => {
+      const messages = [
+        {
+          id: '1',
+          mine: true,
+          content: 'wallet announcement',
+          pending: true,
+          failed: false,
+        },
+      ] as DmMessage[];
+      vi.mocked(parseWalletTxAnnouncement).mockReturnValue({
+        network: 'sepolia',
+        asset: 'ETH',
+        amount: '1',
+        tx_hash: '0xabc',
+        from_npub: 'npub1me',
+        to_npub: 'npub1peer',
+        from_evm_address: '0xFrom',
+      } as never);
+      vi.mocked(isWalletTxAnnouncementOnChainPending).mockReturnValue(true);
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue('0xFrom');
+      vi.mocked(walletWaitForTransaction).mockResolvedValue({
+        ok: true,
+        result: { txHash: '0xabc', network: 'sepolia', chainId: 11155111, blockNumber: '123' },
+      });
+
+      mod.resumePendingWalletTxConfirmations('npub1peer', messages, ctx);
+      await vi.runAllTimersAsync();
+
+      expect(walletWaitForTransaction).toHaveBeenCalledWith('sepolia', '0xabc');
+      expect(patchOutboundWalletTxByHash).toHaveBeenCalled();
+      expect(ctx.sendDm).toHaveBeenCalled();
+    });
+
+    it('marks the card as failed when confirmation fails', async () => {
+      const messages = [
+        {
+          id: '1',
+          mine: true,
+          content: 'wallet announcement',
+          pending: true,
+          failed: false,
+        },
+      ] as DmMessage[];
+      vi.mocked(parseWalletTxAnnouncement).mockReturnValue({
+        network: 'sepolia',
+        asset: 'ETH',
+        amount: '1',
+        tx_hash: '0xabc',
+      } as never);
+      vi.mocked(isWalletTxAnnouncementOnChainPending).mockReturnValue(true);
+      vi.mocked(getActiveEvmSignerAddress).mockResolvedValue('0xFrom');
+      vi.mocked(walletWaitForTransaction).mockResolvedValue({
+        ok: false,
+        message: 'reverted',
+        parsed: { code: 'OTHER', message: 'reverted' },
+      });
+
+      mod.resumePendingWalletTxConfirmations('npub1peer', messages, ctx);
+      await vi.runAllTimersAsync();
+
+      expect(patchOutboundWalletTxByHash).toHaveBeenCalledWith(
+        'npub1peer',
+        '0xabc',
+        expect.objectContaining({ pending: false, failed: true }),
+      );
+    });
+  });
+});

--- a/src/lib/wallet/wallet-summary-prefetch.test.ts
+++ b/src/lib/wallet/wallet-summary-prefetch.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writable } from 'svelte/store';
+
+vi.mock('../../stores/auth', () => ({
+  currentUser: writable(null),
+}));
+
+vi.mock('./backend-wallet', () => ({
+  getWalletSummary: vi.fn(),
+}));
+
+vi.mock('./watched-tokens', () => ({
+  loadWatchedErc20Rows: vi.fn().mockReturnValue([]),
+  watchedRowsToWire: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('./wallet-summary-cache', () => ({
+  persistWalletSummaryCache: vi.fn(),
+}));
+
+import { currentUser } from '../../stores/auth';
+import { getWalletSummary } from './backend-wallet';
+import { loadWatchedErc20Rows, watchedRowsToWire } from './watched-tokens';
+import { persistWalletSummaryCache } from './wallet-summary-cache';
+
+describe('scheduleWalletSummaryBackgroundPrefetch', () => {
+  let schedule: (npub: string | null | undefined) => void;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    vi.setSystemTime(0);
+    currentUser.set(null);
+    vi.mocked(getWalletSummary).mockReset();
+    vi.mocked(loadWatchedErc20Rows).mockReset().mockReturnValue([]);
+    vi.mocked(watchedRowsToWire).mockReset().mockReturnValue([]);
+    vi.mocked(persistWalletSummaryCache).mockReset();
+    const mod = await import('./wallet-summary-prefetch');
+    schedule = mod.scheduleWalletSummaryBackgroundPrefetch;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does nothing when no npub is provided', async () => {
+    schedule(undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getWalletSummary).not.toHaveBeenCalled();
+  });
+
+  it('fetches and persists a summary for a logged-in account', async () => {
+    const summary = {
+      networks: [],
+      totalUsdApprox: 0,
+      prices: {} as never,
+    };
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary });
+    vi.mocked(loadWatchedErc20Rows).mockReturnValueOnce([{ symbol: 'USDC' } as never]);
+    vi.mocked(watchedRowsToWire).mockReturnValueOnce([{ network: 'sepolia', symbol: 'USDC', address: '0xabc', decimals: 6 }]);
+    currentUser.set({ npub: 'npub1' } as never);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(loadWatchedErc20Rows).toHaveBeenCalledWith('npub1');
+    expect(getWalletSummary).toHaveBeenCalledWith([{ network: 'sepolia', symbol: 'USDC', address: '0xabc', decimals: 6 }]);
+    expect(persistWalletSummaryCache).toHaveBeenCalledWith(
+      'npub1',
+      [{ network: 'sepolia', symbol: 'USDC', address: '0xabc', decimals: 6 }],
+      summary,
+    );
+  });
+
+  it('does not persist for the stale account and instead fetches the current account', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+    currentUser.set({ npub: 'npub2' } as never);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getWalletSummary).toHaveBeenCalled();
+    expect(persistWalletSummaryCache).not.toHaveBeenCalledWith(
+      'npub1',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(persistWalletSummaryCache).toHaveBeenCalledWith(
+      'npub2',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('skips while the same account is already in-flight', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+
+    schedule('npub1');
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getWalletSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a different account while another is in-flight', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+
+    schedule('npub1');
+    schedule('npub2');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getWalletSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles repeat success for the same account', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+    currentUser.set({ npub: 'npub1' } as never);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getWalletSummary).toHaveBeenCalledTimes(1);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getWalletSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs again after the throttle window has passed', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+    currentUser.set({ npub: 'npub1' } as never);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getWalletSummary).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(60_000);
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getWalletSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('schedules a fetch for the current account when the finished account is stale', async () => {
+    vi.mocked(getWalletSummary).mockResolvedValue({ ok: true, summary: { networks: [], totalUsdApprox: 0, prices: {} as never } });
+    vi.mocked(loadWatchedErc20Rows).mockReturnValueOnce([]);
+    currentUser.set({ npub: 'npub2' } as never);
+
+    schedule('npub1');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(loadWatchedErc20Rows).toHaveBeenCalledWith('npub2');
+  });
+});

--- a/src/lib/wallet/watched-tokens.test.ts
+++ b/src/lib/wallet/watched-tokens.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  catalogTokenId,
+  customTokenId,
+  defaultWatchedErc20Rows,
+  loadWatchedErc20Rows,
+  saveWatchedErc20Rows,
+  watchedRowsToWire,
+  buildCatalogSearchEntries,
+  catalogEntryToRow,
+  listWalletAssetOptionsForChainWithWatched,
+  type WatchedErc20Row,
+} from './watched-tokens';
+
+describe('watched-tokens', () => {
+  let storage: Record<string, string> = {};
+
+  beforeEach(() => {
+    storage = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete storage[key];
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('token id helpers', () => {
+    it('builds catalog ids in uppercase', () => {
+      expect(catalogTokenId('sepolia', 'usdc')).toBe('catalog_sepolia_USDC');
+    });
+
+    it('builds custom ids from a lowercased address', () => {
+      expect(customTokenId('sepolia', '  0xAbC  ')).toBe('custom_sepolia_0xabc');
+    });
+  });
+
+  describe('defaultWatchedErc20Rows', () => {
+    it('returns USDC and USDT for every configured chain', () => {
+      const rows = defaultWatchedErc20Rows();
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(['USDC', 'USDT']).toContain(row.symbol);
+        expect(row.source).toBe('catalog');
+      }
+    });
+  });
+
+  describe('loadWatchedErc20Rows', () => {
+    it('returns defaults when no account is given', () => {
+      const rows = loadWatchedErc20Rows(null);
+      expect(rows).toEqual(defaultWatchedErc20Rows());
+    });
+
+    it('returns defaults when no stored data exists', () => {
+      const rows = loadWatchedErc20Rows('npub1');
+      expect(rows).toEqual(defaultWatchedErc20Rows());
+    });
+
+    it('loads stored rows with the correct version', () => {
+      const stored: WatchedErc20Row[] = [
+        {
+          id: catalogTokenId('sepolia', 'USDC'),
+          network: 'sepolia',
+          symbol: 'USDC',
+          address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+          decimals: 6,
+          source: 'catalog',
+        },
+      ];
+      saveWatchedErc20Rows('npub1', stored);
+      const rows = loadWatchedErc20Rows('npub1');
+      expect(rows).toEqual(stored);
+    });
+
+    it('falls back to defaults when the stored version is wrong', () => {
+      storage[`pacto_wallet_watched_erc20_v1_npub1`] = JSON.stringify({
+        version: 0,
+        rows: [],
+      });
+      expect(loadWatchedErc20Rows('npub1')).toEqual(defaultWatchedErc20Rows());
+    });
+
+    it('falls back to defaults when the stored JSON is malformed', () => {
+      storage[`pacto_wallet_watched_erc20_v1_npub1`] = 'not-json';
+      expect(loadWatchedErc20Rows('npub1')).toEqual(defaultWatchedErc20Rows());
+    });
+
+    it('filters invalid rows and keeps valid ones', () => {
+      const stored = {
+        version: 1,
+        rows: [
+          {
+            id: 'valid',
+            network: 'sepolia',
+            symbol: 'USDC',
+            address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+            decimals: 6,
+            source: 'catalog',
+          },
+          'not-an-object',
+          { network: 'sepolia', symbol: 'BAD', address: '0xabc', decimals: 6, source: 'catalog' },
+        ],
+      };
+      storage[`pacto_wallet_watched_erc20_v1_npub1`] = JSON.stringify(stored);
+      const rows = loadWatchedErc20Rows('npub1');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe('valid');
+    });
+
+    it('dedupes rows with the same network and address', () => {
+      const address = '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238';
+      const rows: WatchedErc20Row[] = [
+        {
+          id: catalogTokenId('sepolia', 'USDC'),
+          network: 'sepolia',
+          symbol: 'USDC',
+          address,
+          decimals: 6,
+          source: 'catalog',
+        },
+        {
+          id: customTokenId('sepolia', address),
+          network: 'sepolia',
+          symbol: 'USDC2',
+          address,
+          decimals: 6,
+          source: 'custom',
+        },
+      ];
+      saveWatchedErc20Rows('npub1', rows);
+      const loaded = loadWatchedErc20Rows('npub1');
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0]?.id).toBe(catalogTokenId('sepolia', 'USDC'));
+    });
+
+    it('migrates legacy all_tokens mode', () => {
+      storage['pacto_wallet_bar_token_filter'] = 'all_tokens';
+      const rows = loadWatchedErc20Rows('npub1');
+      expect(rows).toEqual(defaultWatchedErc20Rows());
+      expect(storage['pacto_wallet_bar_token_filter']).toBeUndefined();
+    });
+
+    it('migrates legacy native_only mode to an empty list', () => {
+      storage['pacto_wallet_bar_token_filter'] = 'native_only';
+      expect(loadWatchedErc20Rows('npub1')).toEqual([]);
+    });
+
+    it('migrates legacy native_usdc mode to only USDC rows', () => {
+      storage['pacto_wallet_bar_token_filter'] = 'native_usdc';
+      const rows = loadWatchedErc20Rows('npub1');
+      expect(rows.every((r) => r.symbol === 'USDC')).toBe(true);
+    });
+  });
+
+  describe('saveWatchedErc20Rows', () => {
+    it('does nothing when localStorage is unavailable', () => {
+      vi.stubGlobal('localStorage', undefined);
+      expect(() => saveWatchedErc20Rows('npub1', [])).not.toThrow();
+    });
+
+    it('writes normalized rows with the current version', () => {
+      const rows: WatchedErc20Row[] = [
+        {
+          id: catalogTokenId('sepolia', 'USDC'),
+          network: 'sepolia',
+          symbol: 'USDC',
+          address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+          decimals: 6,
+          source: 'catalog',
+        },
+      ];
+      saveWatchedErc20Rows('npub1', rows);
+      const raw = storage['pacto_wallet_watched_erc20_v1_npub1'];
+      expect(JSON.parse(raw)).toEqual({ version: 1, rows });
+    });
+  });
+
+  describe('watchedRowsToWire', () => {
+    it('maps rows to the wire format expected by the backend', () => {
+      const rows: WatchedErc20Row[] = [
+        {
+          id: 'x',
+          network: 'sepolia',
+          symbol: 'USDC',
+          address: '0xabc',
+          decimals: 6,
+          source: 'catalog',
+        },
+      ];
+      expect(watchedRowsToWire(rows)).toEqual([
+        { network: 'sepolia', symbol: 'USDC', address: '0xabc', decimals: 6 },
+      ]);
+    });
+  });
+
+  describe('buildCatalogSearchEntries', () => {
+    it('includes a search entry for every chain and token pair', () => {
+      const entries = buildCatalogSearchEntries();
+      expect(entries.length).toBeGreaterThan(0);
+      for (const entry of entries) {
+        expect(entry.symbol).toMatch(/USDC|USDT/);
+        expect(entry.address.startsWith('0x')).toBe(true);
+        expect(entry.searchText).toContain(entry.network.toLowerCase());
+      }
+    });
+  });
+
+  describe('catalogEntryToRow', () => {
+    it('converts a search entry to a catalog row', () => {
+      const entry = buildCatalogSearchEntries()[0]!;
+      const row = catalogEntryToRow(entry);
+      expect(row.id).toBe(entry.id);
+      expect(row.network).toBe(entry.network);
+      expect(row.symbol).toBe(entry.symbol);
+      expect(row.address).toBe(entry.address);
+      expect(row.decimals).toBe(entry.decimals);
+      expect(row.source).toBe('catalog');
+    });
+  });
+
+  describe('listWalletAssetOptionsForChainWithWatched', () => {
+    it('returns the native option first', () => {
+      const options = listWalletAssetOptionsForChainWithWatched('sepolia', []);
+      expect(options[0]).toEqual({ code: 'ETH', kind: 'native', decimals: 18 });
+    });
+
+    it('includes watched ERC-20 tokens for the requested chain', () => {
+      const watched: WatchedErc20Row[] = [
+        {
+          id: 'custom_sepolia_0xabc',
+          network: 'sepolia',
+          symbol: 'MOCK',
+          address: '0x1111111111111111111111111111111111111111',
+          decimals: 18,
+          source: 'custom',
+        },
+      ];
+      const options = listWalletAssetOptionsForChainWithWatched('sepolia', watched);
+      expect(options.map((o) => o.code)).toEqual(['ETH', 'MOCK']);
+    });
+
+    it('excludes zero-address tokens', () => {
+      const watched: WatchedErc20Row[] = [
+        {
+          id: 'zero',
+          network: 'sepolia',
+          symbol: 'ZERO',
+          address: '0x0000000000000000000000000000000000000000',
+          decimals: 18,
+          source: 'custom',
+        },
+      ];
+      const options = listWalletAssetOptionsForChainWithWatched('sepolia', watched);
+      expect(options.map((o) => o.code)).toEqual(['ETH']);
+    });
+
+    it('ignores watched tokens from other chains', () => {
+      const watched: WatchedErc20Row[] = [
+        {
+          id: 'other',
+          network: 'mainnet',
+          symbol: 'MOCK',
+          address: '0x1111111111111111111111111111111111111111',
+          decimals: 18,
+          source: 'custom',
+        },
+      ];
+      const options = listWalletAssetOptionsForChainWithWatched('sepolia', watched);
+      expect(options.map((o) => o.code)).toEqual(['ETH']);
+    });
+  });
+});

--- a/src/lib/wallet/watched-tokens.ts
+++ b/src/lib/wallet/watched-tokens.ts
@@ -157,6 +157,8 @@ function legacyModeToRows(): WatchedErc20Row[] | null {
   ) {
     return null;
   }
+  localStorage.removeItem(LEGACY_TOKEN_FILTER);
+  localStorage.removeItem(LEGACY_TOKEN_VISIBILITY);
   if (mode === 'all_tokens') return defaultWatchedErc20Rows();
   if (mode === 'native_only') return [];
   const only: 'USDC' | 'USDT' = mode === 'native_usdc' ? 'USDC' : 'USDT';

--- a/src/routes/layout.test.ts
+++ b/src/routes/layout.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { ssr } from './+layout';
+
+describe('+layout', () => {
+  it('disables SSR for Tauri static SPA mode', () => {
+    expect(ssr).toBe(false);
+  });
+});

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  isAuthenticated,
+  authLoading,
+  authError,
+  currentUser,
+  isLoggedIn,
+  checkAuthStatus,
+  createAccount,
+  importAccount,
+  unlockWithPin,
+  logout,
+  clearAuthError,
+  type CurrentUser,
+} from './auth';
+import {
+  login,
+  loginWithRecoveryPhrase,
+  createAccount as apiCreateAccount,
+  connect,
+  checkAnyAccountExists,
+  getCurrentAccount,
+} from '../lib/api/auth';
+import {
+  hasStoredKey,
+  encryptAndSaveKey,
+  encryptAndSaveEvmKey,
+  loadAndDecryptKey,
+  validatePrivateKeyFormat,
+  validateRecoveryPhraseForImport,
+} from '../lib/api/encryption';
+import { runPostLoginNetworkSync } from '../lib/app/post-login-sync';
+import { loadAccountState } from './persistence';
+import { clearAccountState } from '../lib/utils/clear-account-state';
+import { activeTopNavTab, DEFAULT_TOP_NAV_TAB } from './navigation';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('../lib/api/auth', () => ({
+  login: vi.fn(),
+  loginWithRecoveryPhrase: vi.fn(),
+  createAccount: vi.fn(),
+  connect: vi.fn(),
+  checkAnyAccountExists: vi.fn(),
+  getCurrentAccount: vi.fn(),
+}));
+
+vi.mock('../lib/api/encryption', () => ({
+  hasStoredKey: vi.fn(),
+  encryptAndSaveKey: vi.fn(),
+  encryptAndSaveEvmKey: vi.fn(),
+  loadAndDecryptKey: vi.fn(),
+  validatePrivateKeyFormat: vi.fn(),
+  validateRecoveryPhraseForImport: vi.fn(),
+}));
+
+vi.mock('../lib/app/post-login-sync', () => ({
+  runPostLoginNetworkSync: vi.fn(),
+}));
+
+vi.mock('./persistence', () => ({
+  loadAccountState: vi.fn(),
+}));
+
+vi.mock('../lib/utils/clear-account-state', () => ({
+  clearAccountState: vi.fn(),
+}));
+
+function setDev(value: boolean) {
+  (import.meta.env as { DEV?: boolean }).DEV = value;
+}
+
+describe('auth', () => {
+  const npub = 'npub1test';
+  const keys = {
+    private: 'nsec1private',
+    public: 'pubkey',
+    evm_private_key: '0xevmprivate',
+    evm_address: '0xevmaddress',
+  };
+
+  beforeEach(() => {
+    setDev(false);
+    vi.mocked(checkAnyAccountExists).mockReset();
+    vi.mocked(hasStoredKey).mockReset();
+    vi.mocked(apiCreateAccount).mockReset();
+    vi.mocked(encryptAndSaveKey).mockReset();
+    vi.mocked(encryptAndSaveEvmKey).mockReset();
+    vi.mocked(connect).mockReset();
+    vi.mocked(getCurrentAccount).mockReset();
+    vi.mocked(loginWithRecoveryPhrase).mockReset();
+    vi.mocked(validateRecoveryPhraseForImport).mockReset();
+    vi.mocked(loadAndDecryptKey).mockReset();
+    vi.mocked(login).mockReset();
+    vi.mocked(runPostLoginNetworkSync).mockReset();
+    vi.mocked(loadAccountState).mockReset();
+    vi.mocked(clearAccountState).mockReset();
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    isAuthenticated.set(false);
+    authLoading.set(false);
+    authError.set(null);
+    currentUser.set(null);
+    activeTopNavTab.set(DEFAULT_TOP_NAV_TAB);
+    setCurrentNpubForPersistence(null);
+    vi.clearAllMocks();
+  });
+
+  it('has expected initial values', () => {
+    expect(get(isAuthenticated)).toBe(false);
+    expect(get(authLoading)).toBe(false);
+    expect(get(authError)).toBeNull();
+    expect(get(currentUser)).toBeNull();
+    expect(get(isLoggedIn)).toBe(false);
+  });
+
+  describe('isLoggedIn', () => {
+    it('is true when authenticated and user is set', () => {
+      isAuthenticated.set(true);
+      currentUser.set({ npub, pubkey: 'pk' });
+      expect(get(isLoggedIn)).toBe(true);
+    });
+
+    it('is false when not authenticated', () => {
+      currentUser.set({ npub, pubkey: 'pk' });
+      expect(get(isLoggedIn)).toBe(false);
+    });
+
+    it('is false when user is missing', () => {
+      isAuthenticated.set(true);
+      expect(get(isLoggedIn)).toBe(false);
+    });
+  });
+
+  describe('checkAuthStatus', () => {
+    it('returns needs-auth when no account exists', async () => {
+      vi.mocked(checkAnyAccountExists).mockResolvedValue(false);
+      const status = await checkAuthStatus();
+      expect(status).toBe('needs-auth');
+    });
+
+    it('returns needs-auth when account exists but no stored key', async () => {
+      vi.mocked(checkAnyAccountExists).mockResolvedValue(true);
+      vi.mocked(hasStoredKey).mockResolvedValue(false);
+      const status = await checkAuthStatus();
+      expect(status).toBe('needs-auth');
+    });
+
+    it('returns needs-pin when account and key exist', async () => {
+      vi.mocked(checkAnyAccountExists).mockResolvedValue(true);
+      vi.mocked(hasStoredKey).mockResolvedValue(true);
+      const status = await checkAuthStatus();
+      expect(status).toBe('needs-pin');
+    });
+
+    it('sets auth error on failure and returns needs-auth', async () => {
+      vi.mocked(checkAnyAccountExists).mockRejectedValue(new Error('backend down'));
+      const status = await checkAuthStatus();
+      expect(status).toBe('needs-auth');
+      expect(get(authError)).toBe('backend down');
+    });
+  });
+
+  describe('createAccount', () => {
+    it('creates and sets up a new account', async () => {
+      vi.mocked(apiCreateAccount).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await createAccount('123456');
+
+      expect(clearAccountState).toHaveBeenCalled();
+      expect(encryptAndSaveKey).toHaveBeenCalledWith(keys.private, '123456');
+      expect(encryptAndSaveEvmKey).toHaveBeenCalledWith(keys.evm_private_key, keys.evm_address, '123456');
+      expect(get(isAuthenticated)).toBe(true);
+      expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
+      expect(get(activeTopNavTab)).toBe(DEFAULT_TOP_NAV_TAB);
+      expect(loadAccountState).toHaveBeenCalledWith(npub);
+    });
+
+    it('sets auth error on failure', async () => {
+      vi.mocked(apiCreateAccount).mockRejectedValue(new Error('key gen failed'));
+      await expect(createAccount('123456')).rejects.toThrow('key gen failed');
+      expect(get(authError)).toBe('key gen failed');
+    });
+  });
+
+  describe('importAccount', () => {
+    it('imports from a recovery phrase and sets up the account', async () => {
+      vi.mocked(validateRecoveryPhraseForImport).mockReturnValue(true);
+      vi.mocked(loginWithRecoveryPhrase).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await importAccount('word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12', '123456');
+
+      expect(encryptAndSaveKey).toHaveBeenCalledWith(keys.private, '123456');
+      expect(get(isAuthenticated)).toBe(true);
+      expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
+      expect(runPostLoginNetworkSync).toHaveBeenCalledWith(npub);
+    });
+
+    it('rejects an invalid recovery phrase', async () => {
+      vi.mocked(validateRecoveryPhraseForImport).mockReturnValue(false);
+      await expect(importAccount('bad phrase', '123456')).rejects.toThrow('Enter a valid 12- or 24-word recovery phrase');
+    });
+  });
+
+  describe('unlockWithPin', () => {
+    it('unlocks an existing account', async () => {
+      vi.mocked(loadAndDecryptKey).mockResolvedValue(keys.private);
+      vi.mocked(login).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await unlockWithPin('123456');
+
+      expect(login).toHaveBeenCalledWith(keys.private);
+      expect(get(isAuthenticated)).toBe(true);
+      expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
+      expect(runPostLoginNetworkSync).toHaveBeenCalledWith(npub);
+    });
+
+    it('sets auth error on failure', async () => {
+      vi.mocked(loadAndDecryptKey).mockRejectedValue(new Error('bad pin'));
+      await expect(unlockWithPin('123456')).rejects.toThrow('bad pin');
+      expect(get(authError)).toBe('bad pin');
+    });
+  });
+
+  describe('logout', () => {
+    it('clears auth state and invokes the backend logout', async () => {
+      currentUser.set({ npub, pubkey: 'pk' });
+      isAuthenticated.set(true);
+      vi.mocked(invoke).mockResolvedValue(undefined);
+
+      await logout();
+
+      expect(get(isAuthenticated)).toBe(false);
+      expect(get(currentUser)).toBeNull();
+      expect(invoke).toHaveBeenCalledWith('logout');
+      expect(clearAccountState).toHaveBeenCalledWith(npub);
+    });
+
+    it('sets auth error when logout fails but clears auth state', async () => {
+      currentUser.set({ npub, pubkey: 'pk' });
+      isAuthenticated.set(true);
+      vi.mocked(invoke).mockRejectedValue(new Error('logout failed'));
+
+      await expect(logout()).rejects.toThrow('logout failed');
+      expect(get(isAuthenticated)).toBe(false);
+      expect(get(currentUser)).toBeNull();
+      expect(get(authError)).toBe('logout failed');
+    });
+  });
+
+  describe('clearAuthError', () => {
+    it('clears the auth error', () => {
+      authError.set('oops');
+      clearAuthError();
+      expect(get(authError)).toBeNull();
+    });
+  });
+});

--- a/src/stores/commons-ui.test.ts
+++ b/src/stores/commons-ui.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { CommonsBroadcastLocalState } from '../lib/commons/types';
+import {
+  commonsBroadcastModalOpen,
+  commonsBroadcastModalClosedNonce,
+  commonsUserHasActiveBroadcast,
+  syncCommonsUserActiveBroadcast,
+  openCommonsBroadcastModal,
+  closeCommonsBroadcastModal,
+} from './commons-ui';
+import { fetchActiveUserCommonsBroadcast } from '../lib/commons/user-broadcast';
+
+vi.mock('../lib/commons/user-broadcast', () => ({
+  fetchActiveUserCommonsBroadcast: vi.fn(),
+}));
+
+describe('commons-ui', () => {
+  beforeEach(() => {
+    vi.mocked(fetchActiveUserCommonsBroadcast).mockReset();
+  });
+
+  afterEach(() => {
+    commonsBroadcastModalOpen.set(false);
+    commonsBroadcastModalClosedNonce.set(0);
+    commonsUserHasActiveBroadcast.set(false);
+  });
+
+  it('has expected initial values', () => {
+    expect(get(commonsBroadcastModalOpen)).toBe(false);
+    expect(get(commonsBroadcastModalClosedNonce)).toBe(0);
+    expect(get(commonsUserHasActiveBroadcast)).toBe(false);
+  });
+
+  it('syncs active broadcast state when npub is provided', async () => {
+    vi.mocked(fetchActiveUserCommonsBroadcast).mockResolvedValue({ eventId: 'b1', subject: 'user', subjectId: 'npub1abc' } as CommonsBroadcastLocalState);
+    await syncCommonsUserActiveBroadcast('npub1abc');
+    expect(get(commonsUserHasActiveBroadcast)).toBe(true);
+    expect(fetchActiveUserCommonsBroadcast).toHaveBeenCalledWith('npub1abc');
+  });
+
+  it('syncs inactive broadcast state when npub is provided', async () => {
+    vi.mocked(fetchActiveUserCommonsBroadcast).mockResolvedValue(null);
+    await syncCommonsUserActiveBroadcast('npub1abc');
+    expect(get(commonsUserHasActiveBroadcast)).toBe(false);
+  });
+
+  it('sets active broadcast to false when npub is missing', async () => {
+    commonsUserHasActiveBroadcast.set(true);
+    await syncCommonsUserActiveBroadcast(undefined);
+    expect(get(commonsUserHasActiveBroadcast)).toBe(false);
+    expect(fetchActiveUserCommonsBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('opens the broadcast modal when no active broadcast', () => {
+    openCommonsBroadcastModal();
+    expect(get(commonsBroadcastModalOpen)).toBe(true);
+  });
+
+  it('does not open the broadcast modal when an active broadcast exists', () => {
+    commonsUserHasActiveBroadcast.set(true);
+    openCommonsBroadcastModal();
+    expect(get(commonsBroadcastModalOpen)).toBe(false);
+  });
+
+  it('closes the modal and bumps the closed nonce', () => {
+    commonsBroadcastModalOpen.set(true);
+    closeCommonsBroadcastModal();
+    expect(get(commonsBroadcastModalOpen)).toBe(false);
+    expect(get(commonsBroadcastModalClosedNonce)).toBe(1);
+  });
+
+  it('does not bump the nonce when the modal is already closed', () => {
+    closeCommonsBroadcastModal();
+    expect(get(commonsBroadcastModalClosedNonce)).toBe(0);
+  });
+});

--- a/src/stores/dm-unread.test.ts
+++ b/src/stores/dm-unread.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  dmLastReadByNpub,
+  dmUnreadByNpub,
+  pactoAppInboxLastReadId,
+  dmThreadScrolledToBottom,
+  pactoAppInboxUnreadCount,
+  dmTabHasUnread,
+  unreadCountForNpub,
+  hydrateDmUnreadFromInitChats,
+  syncUnreadCountForNpub,
+  incrementDmUnread,
+  clearDmUnread,
+  clearPactoAppInboxUnread,
+  unreadCountForSidebarEntry,
+  PACTO_APP_INBOX_LAST_READ_PREFIX,
+  dmSidebarCategoryForNpub,
+} from './dm-unread';
+import {
+  dmChatsByNpub,
+  pinnedDmNpubs,
+  blockedDmNpubs,
+  pactoAppInboxMessages,
+  PACTO_APP_DM_THREAD_ID,
+} from './dm';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+describe('dm-unread', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    dmLastReadByNpub.set({});
+    dmUnreadByNpub.set({});
+    pactoAppInboxLastReadId.set('');
+    dmThreadScrolledToBottom.set(false);
+    dmChatsByNpub.set({});
+    pinnedDmNpubs.set(new Set());
+    blockedDmNpubs.set(new Set());
+    pactoAppInboxMessages.set([]);
+    setCurrentNpubForPersistence(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('has expected initial values', () => {
+    expect(get(dmLastReadByNpub)).toEqual({});
+    expect(get(dmUnreadByNpub)).toEqual({});
+    expect(get(pactoAppInboxLastReadId)).toBe('');
+    expect(get(dmThreadScrolledToBottom)).toBe(false);
+  });
+
+  it('computes pacto app inbox unread count', () => {
+    pactoAppInboxMessages.set([
+      { id: 'a', mine: false },
+      { id: 'b', mine: false },
+      { id: 'c', mine: false },
+    ] as Parameters<typeof pactoAppInboxMessages.set>[0]);
+    expect(get(pactoAppInboxUnreadCount)).toBe(3);
+    pactoAppInboxLastReadId.set('b');
+    expect(get(pactoAppInboxUnreadCount)).toBe(1);
+    pactoAppInboxLastReadId.set('c');
+    expect(get(pactoAppInboxUnreadCount)).toBe(0);
+  });
+
+  it('computes tab unread flags from peer unread counts and inbox', () => {
+    dmChatsByNpub.set({
+      alice: { npub: 'alice', hasFromMe: true, hasFromThem: true, lastAt: 1 },
+      bob: { npub: 'bob', hasFromMe: false, hasFromThem: true, lastAt: 1 },
+      carol: { npub: 'carol', hasFromMe: true, hasFromThem: false, lastAt: 1 },
+      dave: { npub: 'dave', hasFromMe: true, hasFromThem: true, lastAt: 1 },
+    });
+    pinnedDmNpubs.set(new Set(['alice']));
+    dmUnreadByNpub.set({ alice: 1, bob: 1, carol: 1, dave: 1 });
+
+    const flags = get(dmTabHasUnread);
+    expect(flags.pinned).toBe(true);
+    expect(flags.friends).toBe(true);
+    expect(flags.requests).toBe(true);
+    expect(flags.pending).toBe(true);
+  });
+
+  it('returns zero unread for an unknown npub', () => {
+    expect(unreadCountForNpub('unknown')).toBe(0);
+  });
+
+  it('hydrates unread state from init chats', () => {
+    hydrateDmUnreadFromInitChats([
+      { id: 'npub1alice', last_read: 'b', messages: [{ id: 'a', mine: false }, { id: 'b', mine: false }, { id: 'c', mine: false }] },
+      { id: 'npub1bob', messages: [{ id: 'x', mine: false }] },
+      { id: 'non-npub-squad', last_read: 'z', messages: [{ id: 'z', mine: false }] },
+    ]);
+
+    expect(get(dmLastReadByNpub)).toEqual({ 'npub1alice': 'b' });
+    expect(get(dmUnreadByNpub)).toEqual({ 'npub1alice': 1, 'npub1bob': 1 });
+  });
+
+  it('syncs unread count for a peer from messages', () => {
+    dmLastReadByNpub.set({ 'npub1alice': 'b' });
+    syncUnreadCountForNpub('npub1alice', [
+      { id: 'a', mine: false },
+      { id: 'b', mine: false },
+      { id: 'c', mine: false },
+    ]);
+    expect(unreadCountForNpub('npub1alice')).toBe(1);
+  });
+
+  it('increments and clears unread count', () => {
+    incrementDmUnread('npub1alice');
+    incrementDmUnread('npub1alice');
+    expect(unreadCountForNpub('npub1alice')).toBe(2);
+
+    clearDmUnread('npub1alice', 'msg-3');
+    expect(unreadCountForNpub('npub1alice')).toBe(0);
+    expect(get(dmLastReadByNpub)['npub1alice']).toBe('msg-3');
+  });
+
+  it('clears pacto app inbox unread', () => {
+    clearPactoAppInboxUnread('msg-9');
+    expect(get(pactoAppInboxLastReadId)).toBe('msg-9');
+  });
+
+  it('persists pacto app inbox last read id to localStorage', () => {
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+      clear: () => storage.clear(),
+      key: (i: number) => [...storage.keys()][i] ?? null,
+      get length() {
+        return storage.size;
+      },
+    } as Storage);
+
+    setCurrentNpubForPersistence('npub1abc');
+    pactoAppInboxLastReadId.set('msg-5');
+    expect(storage.get(`${PACTO_APP_INBOX_LAST_READ_PREFIX}_npub1abc`)).toBe('msg-5');
+  });
+
+  it('returns sidebar unread count for pacto app inbox', () => {
+    pactoAppInboxMessages.set([{ id: 'a', mine: false }, { id: 'b', mine: false }] as Parameters<typeof pactoAppInboxMessages.set>[0]);
+    pactoAppInboxLastReadId.set('a');
+    expect(unreadCountForSidebarEntry(PACTO_APP_DM_THREAD_ID, {}, new Set())).toBe(1);
+  });
+
+  it('returns sidebar unread count for a peer npub', () => {
+    dmUnreadByNpub.set({ 'npub1alice': 3 });
+    expect(unreadCountForSidebarEntry('npub1alice', {}, new Set())).toBe(3);
+  });
+
+  it('re-exports dmSidebarCategoryForNpub', () => {
+    dmChatsByNpub.set({
+      alice: { npub: 'alice', hasFromMe: true, hasFromThem: true, lastAt: 1 },
+    });
+    pinnedDmNpubs.set(new Set(['alice']));
+    expect(dmSidebarCategoryForNpub('alice', get(dmChatsByNpub), get(pinnedDmNpubs))).toBe('pinned');
+    expect(dmSidebarCategoryForNpub('unknown', get(dmChatsByNpub), get(pinnedDmNpubs))).toBe('friends');
+  });
+});

--- a/src/stores/dm.test.ts
+++ b/src/stores/dm.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  activeDmTab,
+  pinnedDmNpubs,
+  blockedDmNpubs,
+  dmChatsByNpub,
+  dmList,
+  requestsList,
+  pendingList,
+  pinnedList,
+  allDmEntriesUnified,
+  dmSidebarCategoryForNpub,
+  setDmChatState,
+  addPendingDm,
+  activeDmId,
+  backendDmMessages,
+  dmThreadAnnouncementsByNpub,
+  pactoAppInboxMessages,
+  appendPactoAppInboxMessage,
+  reconcilePeerThreadInvites,
+  appendPendingOutboundDmMessage,
+  removeOutboundDmMessage,
+  patchOutboundDmMessage,
+  patchOutboundWalletTxByHash,
+  appendDmThreadAnnouncement,
+  messageCountByChat,
+  loadedOffsetByChat,
+  typingByChat,
+  deleteDmChat,
+  revertDmChat,
+  walletSidebarOpen,
+  toggleWalletSidebar,
+  closeWalletSidebar,
+  composingNewChat,
+  newChatDraftNpub,
+  newChatDraftMessage,
+  walletSendPrefillFromRequest,
+  dmWalletPeerExchangeTick,
+  dmSyncStatus,
+  dmSendError,
+  lastOpenedDmByTab,
+  type DmChatSnapshot,
+  type DmMessage,
+  PACTO_APP_DM_THREAD_ID,
+} from './dm';
+import {
+  toPactoAppInboxEntry,
+  mergePactoAppInboxEntry,
+  isPactoAppRoutableInviteContent,
+  resolveInviteInviterNpub,
+} from '../lib/pacto-app-inbox';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+vi.mock('../lib/pacto-app-inbox', () => ({
+  toPactoAppInboxEntry: vi.fn((message: DmMessage, inviterNpub: string) => ({
+    ...message,
+    inviterNpub,
+  })),
+  mergePactoAppInboxEntry: vi.fn((list: unknown[], entry: unknown) => [...list, entry]),
+  isPactoAppRoutableInviteContent: vi.fn(() => false),
+  resolveInviteInviterNpub: vi.fn((_message: DmMessage, peerNpub: string) => peerNpub),
+  PACTO_APP_DM_THREAD_ID: '__pacto_app__',
+  PACTO_APP_DISPLAY_NAME: 'Inbox',
+  isPactoAppThreadId: vi.fn((id: string | null | undefined) => id === '__pacto_app__'),
+}));
+
+function makeChat(npub: string, flags: { hasFromMe?: boolean; hasFromThem?: boolean; lastAt?: number } = {}) {
+  return {
+    npub,
+    name: npub,
+    hasFromMe: flags.hasFromMe ?? false,
+    hasFromThem: flags.hasFromThem ?? false,
+    lastAt: flags.lastAt ?? 1,
+  };
+}
+
+describe('dm', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+      clear: () => storage.clear(),
+      key: (i: number) => [...storage.keys()][i] ?? null,
+      get length() {
+        return storage.size;
+      },
+    } as Storage);
+  });
+
+  afterEach(() => {
+    activeDmTab.set('friends');
+    pinnedDmNpubs.set(new Set());
+    blockedDmNpubs.set(new Set());
+    dmChatsByNpub.set({});
+    activeDmId.set(null);
+    backendDmMessages.set({});
+    dmThreadAnnouncementsByNpub.set({});
+    pactoAppInboxMessages.set([]);
+    messageCountByChat.set({});
+    loadedOffsetByChat.set({});
+    typingByChat.set({});
+    walletSidebarOpen.set(false);
+    composingNewChat.set(false);
+    newChatDraftNpub.set('');
+    newChatDraftMessage.set('');
+    walletSendPrefillFromRequest.set(null);
+    dmWalletPeerExchangeTick.set(0);
+    dmSyncStatus.set('idle');
+    dmSendError.set(null);
+    lastOpenedDmByTab.set({ friends: null, requests: null, pending: null, search: null, pinned: null });
+    setCurrentNpubForPersistence(null);
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('has expected initial values', () => {
+    expect(get(activeDmTab)).toBe('friends');
+    expect(get(walletSidebarOpen)).toBe(false);
+    expect(get(composingNewChat)).toBe(false);
+    expect(get(newChatDraftNpub)).toBe('');
+    expect(get(newChatDraftMessage)).toBe('');
+    expect(get(dmWalletPeerExchangeTick)).toBe(0);
+    expect(get(dmSendError)).toBeNull();
+    expect(get(dmSyncStatus)).toBe('idle');
+  });
+
+  describe('wallet sidebar', () => {
+    it('toggles the wallet sidebar', () => {
+      toggleWalletSidebar();
+      expect(get(walletSidebarOpen)).toBe(true);
+      toggleWalletSidebar();
+      expect(get(walletSidebarOpen)).toBe(false);
+    });
+
+    it('closes the wallet sidebar', () => {
+      walletSidebarOpen.set(true);
+      closeWalletSidebar();
+      expect(get(walletSidebarOpen)).toBe(false);
+    });
+  });
+
+  describe('derived lists', () => {
+    it('classifies chats into friends, requests, pending, and pinned', () => {
+      dmChatsByNpub.set({
+        alice: makeChat('alice', { hasFromMe: true, hasFromThem: true, lastAt: 10 }),
+        bob: makeChat('bob', { hasFromMe: false, hasFromThem: true, lastAt: 20 }),
+        carol: makeChat('carol', { hasFromMe: true, hasFromThem: false, lastAt: 30 }),
+        dave: makeChat('dave', { hasFromMe: true, hasFromThem: true, lastAt: 40 }),
+        eve: makeChat('eve', { hasFromMe: true, hasFromThem: true, lastAt: 50 }),
+      });
+      pinnedDmNpubs.set(new Set(['dave']));
+      blockedDmNpubs.set(new Set(['eve']));
+
+      expect(get(dmList).map((e) => e.npub)).toEqual(['alice']);
+      expect(get(requestsList).map((e) => e.npub)).toEqual(['bob']);
+      expect(get(pendingList).map((e) => e.npub)).toEqual(['carol']);
+      expect(get(pinnedList).map((e) => e.npub)).toEqual(['dave']);
+      expect(get(allDmEntriesUnified).map((e) => e.npub)).toEqual(['dave', 'carol', 'bob', 'alice']);
+    });
+
+    it('sorts by lastAt descending', () => {
+      dmChatsByNpub.set({
+        alice: makeChat('alice', { hasFromMe: true, hasFromThem: true, lastAt: 5 }),
+        bob: makeChat('bob', { hasFromMe: true, hasFromThem: true, lastAt: 100 }),
+        carol: makeChat('carol', { hasFromMe: true, hasFromThem: true, lastAt: 50 }),
+      });
+      expect(get(dmList).map((e) => e.npub)).toEqual(['bob', 'carol', 'alice']);
+    });
+  });
+
+  describe('dmSidebarCategoryForNpub', () => {
+    it('returns pinned for pacto app thread', () => {
+      expect(dmSidebarCategoryForNpub(PACTO_APP_DM_THREAD_ID, {}, new Set())).toBe('pinned');
+    });
+
+    it('classifies by chat flags', () => {
+      const chats = {
+        alice: makeChat('alice', { hasFromMe: true, hasFromThem: true }),
+        bob: makeChat('bob', { hasFromMe: false, hasFromThem: true }),
+        carol: makeChat('carol', { hasFromMe: true, hasFromThem: false }),
+      };
+      expect(dmSidebarCategoryForNpub('alice', chats, new Set())).toBe('friends');
+      expect(dmSidebarCategoryForNpub('bob', chats, new Set())).toBe('requests');
+      expect(dmSidebarCategoryForNpub('carol', chats, new Set())).toBe('pending');
+      expect(dmSidebarCategoryForNpub('alice', chats, new Set(['alice']))).toBe('pinned');
+      expect(dmSidebarCategoryForNpub('unknown', chats, new Set())).toBe('friends');
+    });
+  });
+
+  describe('setDmChatState and addPendingDm', () => {
+    it('creates and updates chat state', () => {
+      setDmChatState('alice', { name: 'Alice', hasFromMe: true, hasFromThem: true, lastAt: 10 });
+      const chat = get(dmChatsByNpub)['alice'];
+      expect(chat).toMatchObject({ npub: 'alice', name: 'Alice', hasFromMe: true, hasFromThem: true, lastAt: 10 });
+
+      setDmChatState('alice', { hasFromThem: false });
+      expect(get(dmChatsByNpub)['alice']?.hasFromThem).toBe(false);
+    });
+
+    it('adds a pending DM entry', () => {
+      addPendingDm('alice');
+      const chat = get(dmChatsByNpub)['alice'];
+      expect(chat?.hasFromMe).toBe(true);
+      expect(chat?.hasFromThem).toBe(false);
+      expect(chat?.lastAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe('activeDmId persistence', () => {
+    it('persists the active DM id under an npub-scoped key', () => {
+      setCurrentNpubForPersistence('npub1abc');
+      activeDmId.set('alice');
+      const storage = (globalThis as unknown as { localStorage: Storage }).localStorage;
+      expect(storage.getItem('pacto_last_dm_npub_npub1abc')).toBe('alice');
+    });
+  });
+
+  describe('pacto app inbox', () => {
+    it('appends a pacto app inbox message', () => {
+      const message = { id: 'm1', content: 'hello', at: 1, mine: false } as DmMessage;
+      appendPactoAppInboxMessage(message, 'inviter');
+      const list = get(pactoAppInboxMessages);
+      expect(list.length).toBe(1);
+      expect(list[0]).toMatchObject({ id: 'm1', inviterNpub: 'inviter' });
+      expect(toPactoAppInboxEntry).toHaveBeenCalledWith(message, 'inviter');
+    });
+  });
+
+  describe('reconcilePeerThreadInvites', () => {
+    it('moves routable invite messages into the pacto app inbox', () => {
+      vi.mocked(isPactoAppRoutableInviteContent).mockImplementation((content: string) => content === 'invite');
+      backendDmMessages.set({
+        alice: [
+          { id: 'm1', content: 'invite', at: 1, mine: false } as DmMessage,
+          { id: 'm2', content: 'hello', at: 2, mine: false } as DmMessage,
+        ],
+      });
+      pactoAppInboxMessages.set([]);
+
+      reconcilePeerThreadInvites();
+
+      expect(get(backendDmMessages)['alice']).toEqual([{ id: 'm2', content: 'hello', at: 2, mine: false }]);
+      expect(get(pactoAppInboxMessages).length).toBe(1);
+      expect(isPactoAppRoutableInviteContent).toHaveBeenCalledWith('invite');
+    });
+  });
+
+  describe('outbound DM messages', () => {
+    it('appends and removes an optimistic outbound message', () => {
+      const id = appendPendingOutboundDmMessage('alice', 'hello');
+      expect(get(backendDmMessages)['alice']).toHaveLength(1);
+      expect(get(backendDmMessages)['alice']?.[0]).toMatchObject({ content: 'hello', mine: true, pending: true });
+
+      removeOutboundDmMessage('alice', id);
+      expect(get(backendDmMessages)['alice']).toHaveLength(0);
+    });
+
+    it('patches an outbound message by id', () => {
+      const id = appendPendingOutboundDmMessage('alice', 'hello');
+      patchOutboundDmMessage('alice', id, { failed: true });
+      expect(get(backendDmMessages)['alice']?.[0]?.failed).toBe(true);
+    });
+
+    it('patches outbound wallet tx by hash', () => {
+      backendDmMessages.set({
+        alice: [
+          { id: 'm1', content: JSON.stringify({ tx_hash: '0xabc' }), at: 1, mine: true } as DmMessage,
+        ],
+      });
+      patchOutboundWalletTxByHash('alice', '0xABC', { pending: false });
+      expect(get(backendDmMessages)['alice']?.[0]?.pending).toBe(false);
+    });
+
+    it('ignores patch when tx hash is missing or invalid', () => {
+      backendDmMessages.set({
+        alice: [
+          { id: 'm1', content: JSON.stringify({ tx_hash: '0xabc' }), at: 1, mine: true } as DmMessage,
+        ],
+      });
+      patchOutboundWalletTxByHash('alice', '0xwrong', { pending: false });
+      expect(get(backendDmMessages)['alice']?.[0]?.pending).toBeUndefined();
+      patchOutboundWalletTxByHash('alice', 'not-hex', { pending: false });
+      expect(get(backendDmMessages)['alice']?.[0]?.pending).toBeUndefined();
+    });
+  });
+
+  describe('thread announcements', () => {
+    it('appends a local thread announcement', () => {
+      appendDmThreadAnnouncement('alice', 'Announcement');
+      expect(get(dmThreadAnnouncementsByNpub)['alice']).toHaveLength(1);
+      expect(get(dmThreadAnnouncementsByNpub)['alice']?.[0]).toMatchObject({
+        content: 'Announcement',
+        mine: true,
+        is_local_announcement: true,
+      });
+    });
+  });
+
+  describe('deleteDmChat', () => {
+    it('removes all chat state for a peer', () => {
+      dmChatsByNpub.set({ alice: makeChat('alice', { hasFromMe: true, hasFromThem: true, lastAt: 1 }) });
+      backendDmMessages.set({ alice: [{ id: 'm1', content: 'hi', at: 1, mine: false } as DmMessage] });
+      messageCountByChat.set({ alice: 5 });
+      loadedOffsetByChat.set({ alice: 10 });
+      pinnedDmNpubs.set(new Set(['alice']));
+      activeDmId.set('alice');
+
+      deleteDmChat('alice');
+
+      expect(get(dmChatsByNpub)['alice']).toBeUndefined();
+      expect(get(backendDmMessages)['alice']).toBeUndefined();
+      expect(get(messageCountByChat)['alice']).toBeUndefined();
+      expect(get(loadedOffsetByChat)['alice']).toBeUndefined();
+      expect(get(pinnedDmNpubs).has('alice')).toBe(false);
+      expect(get(activeDmId)).toBeNull();
+    });
+  });
+
+  describe('revertDmChat', () => {
+    it('restores chat state, messages, and pinned status from a snapshot', () => {
+      const chat = makeChat('alice', { hasFromMe: true, hasFromThem: true, lastAt: 5 });
+      const messages = [{ id: 'm1', content: 'hi', at: 1, mine: false } as DmMessage];
+      const snapshot: DmChatSnapshot = {
+        chatState: chat,
+        messages,
+        messageCount: 3,
+        loadedOffset: 0,
+        wasPinned: true,
+      };
+
+      revertDmChat('alice', snapshot);
+
+      expect(get(dmChatsByNpub)['alice']).toEqual(chat);
+      expect(get(backendDmMessages)['alice']).toEqual(messages);
+      expect(get(messageCountByChat)['alice']).toBe(3);
+      expect(get(loadedOffsetByChat)['alice']).toBe(0);
+      expect(get(pinnedDmNpubs).has('alice')).toBe(true);
+    });
+  });
+});

--- a/src/stores/invite-decisions.test.ts
+++ b/src/stores/invite-decisions.test.ts
@@ -1,10 +1,95 @@
-import { describe, expect, it } from 'vitest';
-import { INVITE_DECISION_SCOPED_PREFIXES } from './invite-decisions';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  INVITE_DECISION_SCOPED_PREFIXES,
+  initInviteDecisionPersistence,
+  getInviteDecisionLoadEntries,
+  acceptedSquadInviteIds,
+  declinedSquadInviteIds,
+  acceptedChannelInviteMessageIds,
+  declinedChannelInviteMessageIds,
+  declinedWalletTxRequestMessageIds,
+  acceptedWalletPeerInfoRequestMessageIds,
+  declinedWalletPeerInfoRequestMessageIds,
+} from './invite-decisions';
+
+function makeGetKey(prefix: string): string | null {
+  return `test_${prefix}`;
+}
 
 describe('invite-decisions', () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+      clear: () => storage.clear(),
+      key: (i: number) => [...storage.keys()][i] ?? null,
+      get length() {
+        return storage.size;
+      },
+    } as Storage);
+    initInviteDecisionPersistence(makeGetKey);
+  });
+
+  afterEach(() => {
+    acceptedSquadInviteIds.set([]);
+    declinedSquadInviteIds.set([]);
+    acceptedChannelInviteMessageIds.set([]);
+    declinedChannelInviteMessageIds.set([]);
+    declinedWalletTxRequestMessageIds.set([]);
+    acceptedWalletPeerInfoRequestMessageIds.set([]);
+    declinedWalletPeerInfoRequestMessageIds.set([]);
+    vi.unstubAllGlobals();
+  });
+
   it('does not persist removed squad invite EVM share prefixes', () => {
     const prefixes = INVITE_DECISION_SCOPED_PREFIXES as readonly string[];
     expect(prefixes).not.toContain('pacto_squad_invite_evm_shared');
     expect(prefixes).not.toContain('pacto_squad_invite_evm_skipped');
+  });
+
+  it('writes each invite decision list to localStorage when changed', () => {
+    acceptedSquadInviteIds.set(['s1', 's2']);
+    declinedSquadInviteIds.set(['s3']);
+    acceptedChannelInviteMessageIds.set(['m1']);
+    declinedChannelInviteMessageIds.set(['m2']);
+    declinedWalletTxRequestMessageIds.set(['m3']);
+    acceptedWalletPeerInfoRequestMessageIds.set(['m4']);
+    declinedWalletPeerInfoRequestMessageIds.set(['m5']);
+
+    expect(JSON.parse(storage.get('test_pacto_invite_accepted_squad') ?? '[]')).toEqual(['s1', 's2']);
+    expect(JSON.parse(storage.get('test_pacto_invite_declined_squad') ?? '[]')).toEqual(['s3']);
+    expect(JSON.parse(storage.get('test_pacto_invite_accepted_channel') ?? '[]')).toEqual(['m1']);
+    expect(JSON.parse(storage.get('test_pacto_invite_declined_channel') ?? '[]')).toEqual(['m2']);
+    expect(JSON.parse(storage.get('test_pacto_wallet_tx_request_declined') ?? '[]')).toEqual(['m3']);
+    expect(JSON.parse(storage.get('test_pacto_wallet_peer_info_request_accepted') ?? '[]')).toEqual(['m4']);
+    expect(JSON.parse(storage.get('test_pacto_wallet_peer_info_request_declined') ?? '[]')).toEqual(['m5']);
+  });
+
+  it('returns load entries that hydrate stores from localStorage keys', () => {
+    const npub = 'npub1abc';
+    const entries = getInviteDecisionLoadEntries(npub);
+    expect(entries).toHaveLength(INVITE_DECISION_SCOPED_PREFIXES.length);
+
+    const expectedPrefixes = INVITE_DECISION_SCOPED_PREFIXES.map((p) => `${p}_${npub}`);
+    const actualPrefixes = entries.map(([key]) => key);
+    expect(actualPrefixes).toEqual(expectedPrefixes);
+
+    // Apply a value through each setter and verify the corresponding store updates.
+    entries.forEach(([, setStore], index) => {
+      setStore([`id-${index}`]);
+    });
+
+    expect(get(acceptedSquadInviteIds)).toEqual(['id-0']);
+    expect(get(declinedSquadInviteIds)).toEqual(['id-1']);
+    expect(get(acceptedChannelInviteMessageIds)).toEqual(['id-2']);
+    expect(get(declinedChannelInviteMessageIds)).toEqual(['id-3']);
+    expect(get(declinedWalletTxRequestMessageIds)).toEqual(['id-4']);
+    expect(get(acceptedWalletPeerInfoRequestMessageIds)).toEqual(['id-5']);
+    expect(get(declinedWalletPeerInfoRequestMessageIds)).toEqual(['id-6']);
   });
 });

--- a/src/stores/mls-chat.test.ts
+++ b/src/stores/mls-chat.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  backendGroupMessages,
+  backendGroupTimelineMessages,
+  groupSendError,
+  pendingMlsWelcomes,
+  membershipVersionByGroupId,
+  bumpMembershipVersion,
+} from './mls-chat';
+import { buildBackendGroupTimelineMessages } from '../lib/mls/virtual-channel-bucket';
+
+vi.mock('../lib/mls/virtual-channel-bucket', () => ({
+  buildBackendGroupTimelineMessages: vi.fn((input: Record<string, unknown[]>) => input),
+}));
+
+describe('mls-chat', () => {
+  beforeEach(() => {
+    vi.mocked(buildBackendGroupTimelineMessages).mockReset();
+  });
+
+  afterEach(() => {
+    backendGroupMessages.set({});
+    groupSendError.set(null);
+    pendingMlsWelcomes.set([]);
+    membershipVersionByGroupId.set({});
+  });
+
+  it('has expected initial values', () => {
+    expect(get(backendGroupMessages)).toEqual({});
+    expect(get(groupSendError)).toBeNull();
+    expect(get(pendingMlsWelcomes)).toEqual([]);
+    expect(get(membershipVersionByGroupId)).toEqual({});
+  });
+
+  it('derives timeline messages from backend group messages', () => {
+    const messages = {
+      group1: [
+        { id: 'a', content: 'hello', at: 1, mine: false },
+      ],
+    };
+    backendGroupMessages.set(messages);
+    expect(get(backendGroupTimelineMessages)).toEqual(messages);
+    expect(buildBackendGroupTimelineMessages).toHaveBeenCalledWith(
+      messages,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it('bumps the membership version for a group', () => {
+    bumpMembershipVersion('g1');
+    expect(get(membershipVersionByGroupId)).toEqual({ g1: 1 });
+    bumpMembershipVersion('g1');
+    expect(get(membershipVersionByGroupId)).toEqual({ g1: 2 });
+    bumpMembershipVersion('g2');
+    expect(get(membershipVersionByGroupId)).toEqual({ g1: 2, g2: 1 });
+  });
+});

--- a/src/stores/navigation.test.ts
+++ b/src/stores/navigation.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  activeTopNavTab,
+  DEFAULT_TOP_NAV_TAB,
+  activeSquadId,
+  activeChannelId,
+  activeHubChannelName,
+  activeView,
+  parentDashboardChannelMode,
+  PARENT_DASHBOARD_MODE_PREFIX,
+  parseParentDashboardChannelMode,
+  showMembersPanel,
+  lastOpenedSquadId,
+  lastOpenedChannelId,
+  lastChannelBySquadId,
+  lastHubChannelNameBySquadId,
+  LAST_SQUAD_ID_PREFIX,
+  LAST_CHANNEL_ID_PREFIX,
+  LAST_CHANNEL_BY_SQUAD_PREFIX,
+  LAST_HUB_CHANNEL_NAME_BY_SQUAD_PREFIX,
+  dashboardPollReplicaNonceByParentId,
+} from './navigation';
+import { currentNpubForPersistence, setCurrentNpubForPersistence } from './persistence-context';
+
+function mockStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size;
+    },
+  } as Storage);
+  return store;
+}
+
+describe('navigation', () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = mockStorage();
+  });
+
+  afterEach(() => {
+    activeTopNavTab.set(DEFAULT_TOP_NAV_TAB);
+    activeSquadId.set(null);
+    activeChannelId.set(null);
+    activeHubChannelName.set(null);
+    activeView.set('hub');
+    parentDashboardChannelMode.set('governance');
+    showMembersPanel.set(false);
+    lastOpenedSquadId.set(null);
+    lastOpenedChannelId.set(null);
+    lastChannelBySquadId.set({});
+    lastHubChannelNameBySquadId.set({});
+    dashboardPollReplicaNonceByParentId.set({});
+    setCurrentNpubForPersistence(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('has expected initial values', () => {
+    expect(get(activeTopNavTab)).toBe('commons');
+    expect(get(activeSquadId)).toBeNull();
+    expect(get(activeChannelId)).toBeNull();
+    expect(get(activeHubChannelName)).toBeNull();
+    expect(get(activeView)).toBe('hub');
+    expect(get(parentDashboardChannelMode)).toBe('governance');
+    expect(get(showMembersPanel)).toBe(false);
+  });
+
+  it('parses known parent dashboard channel modes', () => {
+    expect(parseParentDashboardChannelMode('governance')).toBe('governance');
+    expect(parseParentDashboardChannelMode('roles_tree')).toBe('roles_tree');
+    expect(parseParentDashboardChannelMode('treasury')).toBe('treasury');
+    expect(parseParentDashboardChannelMode('settings')).toBe('settings');
+  });
+
+  it('resets unknown or legacy parent dashboard modes to governance', () => {
+    expect(parseParentDashboardChannelMode(null)).toBe('governance');
+    expect(parseParentDashboardChannelMode('')).toBe('governance');
+    expect(parseParentDashboardChannelMode('nope')).toBe('governance');
+    expect(parseParentDashboardChannelMode('polls')).toBe('governance');
+    expect(parseParentDashboardChannelMode('modules')).toBe('governance');
+  });
+
+  it('persists parent dashboard channel mode under an npub-scoped key', () => {
+    setCurrentNpubForPersistence('npub1abc');
+    parentDashboardChannelMode.set('treasury');
+    expect(storage.get(`${PARENT_DASHBOARD_MODE_PREFIX}_npub1abc`)).toBe('treasury');
+  });
+
+  it('persists last opened squad and channel ids', () => {
+    setCurrentNpubForPersistence('npub1abc');
+    lastOpenedSquadId.set('squad-1');
+    lastOpenedChannelId.set('channel-1');
+    expect(storage.get(`${LAST_SQUAD_ID_PREFIX}_npub1abc`)).toBe('squad-1');
+    expect(storage.get(`${LAST_CHANNEL_ID_PREFIX}_npub1abc`)).toBe('channel-1');
+  });
+
+  it('removes squad and channel keys when set to null', () => {
+    setCurrentNpubForPersistence('npub1abc');
+    lastOpenedSquadId.set('squad-1');
+    lastOpenedChannelId.set('channel-1');
+    expect(storage.get(`${LAST_SQUAD_ID_PREFIX}_npub1abc`)).toBe('squad-1');
+    expect(storage.get(`${LAST_CHANNEL_ID_PREFIX}_npub1abc`)).toBe('channel-1');
+    lastOpenedSquadId.set(null);
+    lastOpenedChannelId.set(null);
+    expect(storage.has(`${LAST_SQUAD_ID_PREFIX}_npub1abc`)).toBe(false);
+    expect(storage.has(`${LAST_CHANNEL_ID_PREFIX}_npub1abc`)).toBe(false);
+  });
+
+  it('persists last channel maps by squad', () => {
+    setCurrentNpubForPersistence('npub1abc');
+    lastChannelBySquadId.set({ s1: 'c1' });
+    lastHubChannelNameBySquadId.set({ s1: 'announcements' });
+    expect(JSON.parse(storage.get(`${LAST_CHANNEL_BY_SQUAD_PREFIX}_npub1abc`) ?? '{}')).toEqual({ s1: 'c1' });
+    expect(JSON.parse(storage.get(`${LAST_HUB_CHANNEL_NAME_BY_SQUAD_PREFIX}_npub1abc`) ?? '{}')).toEqual({
+      s1: 'announcements',
+    });
+  });
+
+  it('skips persistence when no npub is set', () => {
+    parentDashboardChannelMode.set('settings');
+    expect(storage.size).toBe(0);
+  });
+
+  it('bumps the dashboard poll replica nonce', () => {
+    dashboardPollReplicaNonceByParentId.set({ p1: 1 });
+    expect(get(dashboardPollReplicaNonceByParentId)).toEqual({ p1: 1 });
+  });
+});

--- a/src/stores/profiles.test.ts
+++ b/src/stores/profiles.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  profiles,
+  profileLoadingStates,
+  loadProfile,
+  getProfile,
+  isProfileLoading,
+  type NostrProfile,
+} from './profiles';
+import { dmChatsByNpub, blockedDmNpubs, activeDmId } from './dm';
+import { currentUser } from './auth';
+import { fetchNostrProfile, loadNostrProfile, startNotifs, syncAllProfiles } from '../lib/api/nostr';
+import { showToast } from './toast';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+const { handlers } = vi.hoisted(() => {
+  const handlers = new Map<string, (event: unknown) => void>();
+  return { handlers };
+});
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (event: string, handler: (event: unknown) => void) => {
+    handlers.set(event, handler);
+    return Promise.resolve(() => {});
+  },
+}));
+
+vi.mock('../lib/api/nostr', () => ({
+  fetchNostrProfile: vi.fn(),
+  loadNostrProfile: vi.fn(),
+  startNotifs: vi.fn().mockResolvedValue(undefined),
+  syncAllProfiles: vi.fn().mockResolvedValue(undefined),
+  type: {},
+}));
+
+vi.mock('./toast', () => ({
+  showToast: vi.fn(),
+}));
+
+describe('profiles', () => {
+  const npub = 'npub1alice';
+  const baseProfile: NostrProfile = {
+    id: npub,
+    name: 'Alice',
+    display_name: 'Alice',
+    avatar: 'https://example.com/avatar.png',
+    banner: 'https://example.com/banner.png',
+    about: 'About Alice',
+    website: 'https://example.com',
+    nip05: 'alice@example.com',
+    lud06: '',
+    lud16: '',
+    nickname: '',
+    last_read: '',
+    status: { title: '', purpose: '', url: '' },
+    last_updated: 0,
+    typing_until: 0,
+    mine: false,
+    muted: false,
+    bot: false,
+    avatar_cached: '',
+    banner_cached: '',
+  };
+
+  beforeEach(() => {
+    vi.mocked(fetchNostrProfile).mockReset();
+    vi.mocked(loadNostrProfile).mockReset();
+    vi.mocked(showToast).mockReset();
+  });
+
+  afterEach(() => {
+    profiles.set({});
+    profileLoadingStates.set({});
+    dmChatsByNpub.set({});
+    blockedDmNpubs.set(new Set());
+    activeDmId.set(null);
+    currentUser.set(null);
+    setCurrentNpubForPersistence(null);
+    vi.clearAllMocks();
+  });
+
+  it('has expected initial values', () => {
+    expect(get(profiles)).toEqual({});
+    expect(get(profileLoadingStates)).toEqual({});
+  });
+
+  it('returns a profile from the cache via derived store', () => {
+    profiles.set({ [npub]: baseProfile });
+    const derived = getProfile(npub);
+    expect(get(derived)).toEqual(baseProfile);
+  });
+
+  it('returns undefined when profile is not cached', () => {
+    const derived = getProfile(npub);
+    expect(get(derived)).toBeUndefined();
+  });
+
+  it('reports loading state via derived store', () => {
+    profileLoadingStates.set({ [npub]: true });
+    expect(get(isProfileLoading(npub))).toBe(true);
+  });
+
+  it('returns cached profile without fetching', async () => {
+    profiles.set({ [npub]: baseProfile });
+    const result = await loadProfile(npub);
+    expect(result).toEqual(baseProfile);
+    expect(fetchNostrProfile).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches a profile when not in cache', async () => {
+    vi.mocked(fetchNostrProfile).mockResolvedValue(baseProfile);
+    const result = await loadProfile(npub);
+    expect(result).toEqual(baseProfile);
+    expect(get(profiles)[npub]).toEqual(baseProfile);
+    expect(fetchNostrProfile).toHaveBeenCalledWith(npub);
+  });
+
+  it('clears loading state after fetch', async () => {
+    vi.mocked(fetchNostrProfile).mockResolvedValue(baseProfile);
+    await loadProfile(npub);
+    expect(get(profileLoadingStates)[npub]).toBe(false);
+  });
+
+  it('throws when fetch ultimately fails', async () => {
+    vi.mocked(fetchNostrProfile).mockRejectedValue(new Error('not found'));
+    await expect(loadProfile(npub)).rejects.toThrow('not found');
+  });
+
+  describe('event listeners', () => {
+    it('init_finished sets profiles and dm state', () => {
+      const initHandler = handlers.get('init_finished');
+      expect(initHandler).toBeDefined();
+      initHandler?.({
+        payload: {
+          profiles: [baseProfile],
+          chats: [{ id: npub, chat_type: 'DirectMessage', messages: [{ at: 1, mine: false }] }],
+        },
+      });
+      expect(get(profiles)[npub]).toEqual(baseProfile);
+      expect(get(dmChatsByNpub)[npub]).toBeDefined();
+    });
+
+    it('profile_update updates the profile and blocked list', () => {
+      profiles.set({ [npub]: baseProfile });
+      const updateHandler = handlers.get('profile_update');
+      expect(updateHandler).toBeDefined();
+      updateHandler?.({
+        payload: { id: npub, display_name: 'Alice Updated', blocked: true },
+      });
+      expect(get(profiles)[npub]?.display_name).toBe('Alice Updated');
+      expect(get(blockedDmNpubs).has(npub)).toBe(true);
+    });
+
+    it('profile_nick_changed updates the profile and dm chat name', () => {
+      profiles.set({ [npub]: baseProfile });
+      dmChatsByNpub.set({ [npub]: { npub, name: 'Alice', hasFromMe: true, hasFromThem: true, lastAt: 1 } });
+      const nickHandler = handlers.get('profile_nick_changed');
+      expect(nickHandler).toBeDefined();
+      nickHandler?.({ payload: { profile_id: npub, value: 'Al' } });
+      expect(get(profiles)[npub]?.nickname).toBe('Al');
+      expect(get(dmChatsByNpub)[npub]?.name).toBe('Al');
+    });
+
+    it('kind0_profile_published shows a toast', () => {
+      const publishedHandler = handlers.get('kind0_profile_published');
+      expect(publishedHandler).toBeDefined();
+      publishedHandler?.({ payload: {} });
+      expect(showToast).toHaveBeenCalledWith('Profile metadata (Kind 0) published to the network.');
+    });
+
+    it('kind0_profile_publish_failed shows a toast with the error', () => {
+      const failedHandler = handlers.get('kind0_profile_publish_failed');
+      expect(failedHandler).toBeDefined();
+      failedHandler?.({ payload: 'publish failed' });
+      expect(showToast).toHaveBeenCalledWith('publish failed');
+    });
+  });
+});

--- a/src/stores/profiles.ts
+++ b/src/stores/profiles.ts
@@ -1,6 +1,8 @@
 import { writable, derived, get } from 'svelte/store';
 import { listen } from '@tauri-apps/api/event';
-import { fetchNostrProfile, loadNostrProfile, startNotifs, syncAllProfiles, type NostrProfile } from '../lib/api/nostr';
+import { fetchNostrProfile, loadNostrProfile, startNotifs, syncAllProfiles } from '../lib/api/nostr';
+import type { NostrProfile } from '../lib/api/nostr';
+export type { NostrProfile };
 import { dmLog } from '../lib/utils/dm-debug';
 import { getProfileDisplayName } from '../lib/utils/profile';
 import { activeDmId, dmChatsByNpub, blockedDmNpubs, dmSyncStatus, type DmChatState } from './dm';

--- a/src/stores/safe.test.ts
+++ b/src/stores/safe.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { Address } from 'viem';
+import {
+  safeStateByTreasuryId,
+  refreshSafeStateForTreasuryEntry,
+  type SafeStateEntry,
+} from './safe';
+import { getSafeState, type SafeState } from '$lib/wallet/safe';
+import { withReadPlaneLimit } from '$lib/evm/read-plane-limiter';
+import { persistSafeStateCacheEntry } from '$lib/dashboard/safe-state-disk-cache';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+vi.mock('$lib/wallet/safe', () => ({
+  getSafeState: vi.fn(),
+}));
+
+vi.mock('$lib/evm/read-plane-limiter', () => ({
+  withReadPlaneLimit: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('$lib/dashboard/safe-state-disk-cache', () => ({
+  SAFE_STATE_DISK_CACHE_VERSION: 1,
+  SAFE_STATE_DISK_CACHE_PREFIX: 'pacto_safe_state_cache_v1',
+  SAFE_STATE_DISK_TTL_MS: 15 * 60 * 1000,
+  persistSafeStateCacheEntry: vi.fn(),
+}));
+
+describe('safe', () => {
+  const baseEntry = (id: string, overrides?: { safeAddress?: string; chain?: string }) => ({
+    id,
+    parentId: 'parent-1',
+    safeAddress: overrides?.safeAddress ?? '0x0000000000000000000000000000000000000001',
+    chain: overrides?.chain ?? 'sepolia',
+    label: 'Test Safe',
+    createdAtMs: 1,
+  });
+
+  const baseState: SafeState = {
+    address: '0x0000000000000000000000000000000000000001' as Address,
+    owners: ['0x0000000000000000000000000000000000000002' as Address],
+    threshold: 1,
+    nonce: 0n,
+    balanceWei: 0n,
+    balanceFormatted: '0',
+  };
+
+  beforeEach(() => {
+    vi.mocked(getSafeState).mockReset();
+    vi.mocked(withReadPlaneLimit).mockReset();
+    vi.mocked(withReadPlaneLimit).mockImplementation((fn: () => Promise<unknown>) => fn());
+    vi.mocked(persistSafeStateCacheEntry).mockReset();
+  });
+
+  afterEach(() => {
+    safeStateByTreasuryId.set({});
+    setCurrentNpubForPersistence(null);
+    vi.clearAllMocks();
+  });
+
+  it('starts with an empty cache', () => {
+    expect(get(safeStateByTreasuryId)).toEqual({});
+  });
+
+  it('does nothing when entry id or safe address is missing', async () => {
+    await refreshSafeStateForTreasuryEntry(baseEntry('', { safeAddress: '' }));
+    expect(getSafeState).not.toHaveBeenCalled();
+  });
+
+  it('fetches and stores safe state', async () => {
+    vi.mocked(getSafeState).mockResolvedValue(baseState);
+    setCurrentNpubForPersistence('npub1abc');
+
+    await refreshSafeStateForTreasuryEntry(baseEntry('t1'));
+
+    const state = get(safeStateByTreasuryId);
+    expect(state['t1']).toMatchObject({
+      treasuryEntryId: 't1',
+      safeAddress: '0x0000000000000000000000000000000000000001',
+      chainId: 'sepolia',
+      state: baseState,
+      error: null,
+      loading: false,
+    });
+    expect(state['t1']?.lastFetchedAt).toBeGreaterThan(0);
+    expect(persistSafeStateCacheEntry).toHaveBeenCalledOnce();
+  });
+
+  it('skips a fresh fetch without force', async () => {
+    vi.mocked(getSafeState).mockResolvedValue(baseState);
+    await refreshSafeStateForTreasuryEntry(baseEntry('t2'));
+    vi.mocked(getSafeState).mockClear();
+
+    await refreshSafeStateForTreasuryEntry(baseEntry('t2'));
+    expect(getSafeState).not.toHaveBeenCalled();
+    expect(get(safeStateByTreasuryId)['t2']?.loading).toBe(false);
+  });
+
+  it('forces a fresh fetch', async () => {
+    vi.mocked(getSafeState).mockResolvedValue(baseState);
+    await refreshSafeStateForTreasuryEntry(baseEntry('t3'));
+    vi.mocked(getSafeState).mockClear();
+
+    await refreshSafeStateForTreasuryEntry(baseEntry('t3'), { force: true });
+    expect(getSafeState).toHaveBeenCalledOnce();
+  });
+
+  it('records an error when the fetch fails', async () => {
+    vi.mocked(getSafeState).mockRejectedValue(new Error('RPC down'));
+    await refreshSafeStateForTreasuryEntry(baseEntry('t4'));
+
+    const state = get(safeStateByTreasuryId)['t4'];
+    expect(state?.error).toBe('RPC down');
+    expect(state?.loading).toBe(false);
+  });
+
+  it('does not persist when no npub is set', async () => {
+    vi.mocked(getSafeState).mockResolvedValue(baseState);
+    await refreshSafeStateForTreasuryEntry(baseEntry('t5'));
+    expect(persistSafeStateCacheEntry).not.toHaveBeenCalled();
+  });
+
+  it('does not update a stale entry when safe address or chain changes', async () => {
+    vi.mocked(getSafeState).mockResolvedValue(baseState);
+    await refreshSafeStateForTreasuryEntry(baseEntry('t6'));
+    vi.mocked(getSafeState).mockRejectedValue(new Error('should not fetch'));
+
+    await refreshSafeStateForTreasuryEntry({ ...baseEntry('t6'), safeAddress: '0x0000000000000000000000000000000000000003' });
+    const state = get(safeStateByTreasuryId)['t6'];
+    expect(state?.safeAddress).toBe('0x0000000000000000000000000000000000000003');
+    expect(state?.state).toBeNull();
+  });
+});

--- a/src/stores/theme.test.ts
+++ b/src/stores/theme.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { theme, setTheme, getStoredTheme, THEME_OPTIONS, DEFAULT_THEME } from './theme';
+
+describe('theme', () => {
+  let storage: Map<string, string>;
+  let documentAttribute: string | null;
+
+  beforeEach(() => {
+    storage = new Map();
+    documentAttribute = null;
+    theme.set(DEFAULT_THEME);
+
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => storage.set(k, v),
+      removeItem: (k: string) => storage.delete(k),
+      clear: () => storage.clear(),
+      key: (i: number) => [...storage.keys()][i] ?? null,
+      get length() {
+        return storage.size;
+      },
+    } as Storage);
+
+    vi.stubGlobal('document', {
+      documentElement: {
+        setAttribute: (_name: string, value: string) => {
+          documentAttribute = value;
+        },
+        getAttribute: (_name: string) => documentAttribute,
+      },
+    });
+  });
+
+  afterEach(() => {
+    theme.set(DEFAULT_THEME);
+    vi.unstubAllGlobals();
+  });
+
+  it('starts at the default theme', () => {
+    expect(get(theme)).toBe(DEFAULT_THEME);
+    expect(THEME_OPTIONS.length).toBeGreaterThan(0);
+  });
+
+  it('stores and applies a valid theme', () => {
+    setTheme('union');
+    expect(get(theme)).toBe('union');
+    expect(storage.get('pacto_theme')).toBe('union');
+    expect(documentAttribute).toBe('union');
+  });
+
+  it('ignores invalid theme values', () => {
+    setTheme('not-a-theme' as unknown as typeof DEFAULT_THEME);
+    expect(get(theme)).toBe(DEFAULT_THEME);
+    expect(storage.get('pacto_theme')).toBeUndefined();
+    expect(documentAttribute).toBeNull();
+  });
+
+  it('reads a stored valid theme', () => {
+    expect(getStoredTheme()).toBeNull();
+    storage.set('pacto_theme', 'midnight');
+    expect(getStoredTheme()).toBe('midnight');
+  });
+
+  it('returns null for missing or invalid stored themes', () => {
+    storage.set('pacto_theme', 'invalid');
+    expect(getStoredTheme()).toBeNull();
+  });
+});

--- a/src/stores/toast.test.ts
+++ b/src/stores/toast.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { toastMessage, pendingReadyToast, showToast, clearToast, runToastRetryAction } from './toast';
+
+describe('toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearToast();
+    pendingReadyToast.set(null);
+  });
+
+  it('starts empty', () => {
+    expect(get(toastMessage)).toBeNull();
+    expect(get(pendingReadyToast)).toBeNull();
+  });
+
+  it('shows a toast and auto-clears after the default duration', () => {
+    showToast('Hello');
+    expect(get(toastMessage)).toEqual({ text: 'Hello' });
+    vi.advanceTimersByTime(3999);
+    expect(get(toastMessage)).toEqual({ text: 'Hello' });
+    vi.advanceTimersByTime(2);
+    expect(get(toastMessage)).toBeNull();
+  });
+
+  it('extends duration for goTo toasts', () => {
+    showToast('Ready', { type: 'squad', name: 'Alpha', id: 's1', channelId: 'c1' });
+    vi.advanceTimersByTime(4001);
+    expect(get(toastMessage)).not.toBeNull();
+    vi.advanceTimersByTime(8000);
+    expect(get(toastMessage)).toBeNull();
+  });
+
+  it('extends duration for retry toasts', () => {
+    const retry = { label: 'Retry', action: vi.fn() };
+    showToast('Failed', undefined, retry);
+    vi.advanceTimersByTime(4001);
+    expect(get(toastMessage)).not.toBeNull();
+    vi.advanceTimersByTime(8000);
+    expect(get(toastMessage)).toBeNull();
+  });
+
+  it('clears toast and cancels the timer', () => {
+    showToast('Hello');
+    clearToast();
+    expect(get(toastMessage)).toBeNull();
+    vi.advanceTimersByTime(10000);
+    expect(get(toastMessage)).toBeNull();
+  });
+
+  it('runs the retry action when requested', () => {
+    const retry = { label: 'Retry', action: vi.fn() };
+    showToast('Failed', undefined, retry);
+    runToastRetryAction();
+    expect(retry.action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when running retry without an action', () => {
+    showToast('Hello');
+    expect(() => runToastRetryAction()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Splits the frontend and Rust test coverage, CI hardening, and supporting code changes from PR #59 into a focused PR.

## What changed

- **Frontend tests:** added Vitest suites for stores, utilities, API wrappers, app services, dashboard, governance, DMs, invites, wallet, EVM, parent flows, and commons.
- **Backend tests:** added `cargo test` coverage for crypto helpers, EVM config/contract calls, storage, and catalog helpers.
- **CI:** split the monolithic workflow into separate frontend and backend jobs and removed the `continue-on-error` / `ignore-failure` gates.
- **Tooling:** fixed `svelte-check` errors and updated mock signatures to match the current `getWalletSummary` and DM-store APIs.
- **Source changes:** minor testability/type tweaks needed to make the new suites pass.

## Design decisions

- Tests are co-located with source (`.test.ts` / `#[cfg(test)]` modules) so they live next to the code they exercise.
- Tauri-heavy frontend code is tested with `vi.mock` rather than spawning the backend, keeping the suite fast and deterministic.
- Rust DB tests use in-memory SQLite with the minimal schema DDL inline, avoiding filesystem state.
- The CI split lets frontend and backend failures surface independently instead of being masked by a single green/red cell.

## Test plan

- `pnpm test` — 116 files, 1075 tests passed
- `pnpm check` — 0 errors
- `cd src-tauri && cargo test` — 160 tests passed

## Supersedes

- Closes #59 (split into docs + tests PRs).
- Companion docs PR: #60.
