### PR TITLE
build(ci): split CI into frontend and backend jobs and remove ignore-failure gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,15 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        id: typecheck
         run: pnpm check
-        continue-on-error: true
-
-      - name: Report typecheck result
-        if: steps.typecheck.outcome == 'failure'
-        run: |
-          echo "::warning::Typecheck failed. See the 'Typecheck' step logs for diagnostics."
-          echo "- Typecheck: failed" >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     runs-on: ubuntu-latest
@@ -56,17 +48,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        id: lint
         run: pnpm lint
-        continue-on-error: true
 
-      - name: Report lint result
-        if: steps.lint.outcome == 'failure'
-        run: |
-          echo "::warning::Lint failed. See the 'Lint' step logs for violations."
-          echo "- Lint: failed" >> "$GITHUB_STEP_SUMMARY"
-
-  test:
+  frontend-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -87,97 +71,27 @@ jobs:
         run: pnpm svelte-kit sync
 
       - name: Unit tests with coverage
-        id: test
         run: pnpm test:coverage
-        continue-on-error: true
-
-      - name: Report test result
-        if: steps.test.outcome == 'failure'
-        run: |
-          echo "::warning::Unit tests or coverage threshold failed. See the 'Unit tests with coverage' step logs for details."
-          echo "- Unit tests / coverage: failed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
-        if: steps.test.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage/
           if-no-files-found: ignore
 
-  coverage:
+  backend-tests:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6.4.0
-        with:
-          node-version: lts/*
+      - uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 11.7.0
-          run_install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
-
-      - name: Check coverage thresholds
-        id: coverage
+      - name: Install Rust system dependencies
         run: |
-          node - <<'NODE'
-          const fs = require('fs');
-          const data = JSON.parse(fs.readFileSync('coverage/coverage-final.json', 'utf8'));
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake clang libclang-dev file curl wget git pkg-config libssl-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libasound2-dev
 
-          const totals = { statements: { total: 0, covered: 0 }, branches: { total: 0, covered: 0 }, functions: { total: 0, covered: 0 }, lines: { total: 0, covered: 0 } };
-          for (const file of Object.values(data)) {
-            const s = file.s;
-            totals.statements.total += Object.keys(s).length;
-            totals.statements.covered += Object.values(s).filter(v => v > 0).length;
-
-            totals.lines.total += Object.keys(file.statementMap).length;
-            totals.lines.covered += Object.keys(file.statementMap).filter(k => s[k] > 0).length;
-
-            const f = file.f;
-            totals.functions.total += Object.keys(f).length;
-            totals.functions.covered += Object.values(f).filter(v => v > 0).length;
-
-            const b = file.b;
-            for (const branches of Object.values(b)) {
-              totals.branches.total += branches.length;
-              totals.branches.covered += branches.filter(v => v > 0).length;
-            }
-          }
-
-          const threshold = 80;
-          let failed = false;
-          const summary = [];
-          for (const [key, { total, covered }] of Object.entries(totals)) {
-            const pct = total ? (covered / total) * 100 : 0;
-            const ok = pct >= threshold;
-            if (!ok) failed = true;
-            summary.push(`${key}: ${pct.toFixed(2)}% (${covered}/${total}) ${ok ? '✓' : '✗'}`);
-          }
-
-          console.log('Coverage summary:');
-          for (const line of summary) console.log(line);
-
-          if (failed) {
-            console.log(`::error::Coverage is below the ${threshold}% threshold.`);
-            process.exit(1);
-          }
-          NODE
-        continue-on-error: true
-
-      - name: Report coverage result
-        if: steps.coverage.outcome == 'failure'
-        run: |
-          echo "::warning::Coverage is below the 80% threshold. See the 'Check coverage thresholds' step logs for details."
-          echo "- Coverage: below 80% threshold" >> "$GITHUB_STEP_SUMMARY"
+      - name: Rust unit tests
+        working-directory: src-tauri
+        run: cargo test --lib


### PR DESCRIPTION
## Summary

Splits the monolithic CI workflow into separate frontend and backend jobs so failures surface independently, and removes the `continue-on-error` / ignore-failure gates that were masking broken builds.

## Changes

- `.github/workflows/ci.yaml` now has distinct jobs for frontend and backend validation.

## Test plan

- Workflow runs on this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
