### PR TITLE
test(rust): add backend unit tests for crypto, EVM, storage, and catalog helpers

### DIFF
--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -211,3 +211,97 @@ pub fn decrypt_data(encrypted_data: &[u8], key_hex: &str, nonce_hex: &str) -> Re
 
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Runtime::new().expect("tokio runtime")
+    }
+
+    #[test]
+    fn generate_params_has_valid_hex_lengths() {
+        let params = generate_encryption_params();
+        assert_eq!(params.key.len(), 64, "32-byte key = 64 hex chars");
+        assert_eq!(params.nonce.len(), 32, "16-byte nonce = 32 hex chars");
+        assert!(hex::decode(&params.key).is_ok());
+        assert!(hex::decode(&params.nonce).is_ok());
+    }
+
+    #[test]
+    fn aes_gcm_round_trip() {
+        let params = EncryptionParams {
+            key: hex::encode([0u8; 32]),
+            nonce: hex::encode([0u8; 16]),
+        };
+        let plaintext = b"hello pacto";
+        let encrypted = encrypt_data(plaintext, &params).expect("encrypt");
+        assert!(!encrypted.is_empty());
+        let decrypted = decrypt_data(&encrypted, &params.key, &params.nonce).expect("decrypt");
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_rejects_too_short_input() {
+        let result = decrypt_data(
+            &[0u8; 15],
+            &hex::encode([0u8; 32]),
+            &hex::encode([0u8; 16]),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decrypt_rejects_wrong_tag() {
+        let params = EncryptionParams {
+            key: hex::encode([0u8; 32]),
+            nonce: hex::encode([0u8; 16]),
+        };
+        let mut encrypted = encrypt_data(b"hello", &params).expect("encrypt");
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 0xff;
+        let result = decrypt_data(&encrypted, &params.key, &params.nonce);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hash_pass_is_deterministic() {
+        let first = rt().block_on(hash_pass("pacto-secret".to_string()));
+        let second = rt().block_on(hash_pass("pacto-secret".to_string()));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn chacha_round_trip_with_password() {
+        let ciphertext = rt().block_on(internal_encrypt(
+            "plaintext message".to_string(),
+            Some("password".to_string()),
+        ));
+        assert!(!ciphertext.is_empty());
+        let decrypted = rt().block_on(internal_decrypt(ciphertext, Some("password".to_string())));
+        assert_eq!(decrypted.expect("decrypt"), "plaintext message");
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_wrong_password() {
+        let ciphertext = rt().block_on(internal_encrypt(
+            "plaintext message".to_string(),
+            Some("password".to_string()),
+        ));
+        let decrypted = rt().block_on(internal_decrypt(ciphertext, Some("wrong".to_string())));
+        assert!(decrypted.is_err());
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_short_ciphertext() {
+        let decrypted = rt().block_on(internal_decrypt("0x00".to_string(), Some("password".to_string())));
+        assert!(decrypted.is_err());
+    }
+
+    #[test]
+    fn chacha_decrypt_rejects_malformed_hex() {
+        let decrypted = rt().block_on(internal_decrypt("not-hex".to_string(), Some("password".to_string())));
+        assert!(decrypted.is_err());
+    }
+}

--- a/src-tauri/src/evm/contract_call_params.rs
+++ b/src-tauri/src/evm/contract_call_params.rs
@@ -44,4 +44,41 @@ mod tests {
     fn parse_value_wei_decimal() {
         assert_eq!(parse_value_wei("1000").unwrap(), U256::from(1000u64));
     }
+
+    #[test]
+    fn parse_value_wei_empty_is_zero() {
+        assert_eq!(parse_value_wei("").unwrap(), U256::ZERO);
+        assert_eq!(parse_value_wei("   ").unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn parse_value_wei_rejects_negative() {
+        assert!(parse_value_wei("-1").is_err());
+    }
+
+    #[test]
+    fn parse_value_wei_rejects_hex() {
+        assert!(parse_value_wei("0x1a").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_rejects_odd_length() {
+        assert!(parse_data_hex("0xabc").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_rejects_non_hex() {
+        assert!(parse_data_hex("0xzz").is_err());
+    }
+
+    #[test]
+    fn parse_data_hex_uppercase_prefix_and_case() {
+        assert_eq!(parse_data_hex("0XDEADBEEF").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn parse_data_hex_zero_prefix_returns_empty() {
+        assert!(parse_data_hex("0x").unwrap().is_empty());
+        assert!(parse_data_hex("0X").unwrap().is_empty());
+    }
 }

--- a/src-tauri/src/evm/pacto_chain_config.rs
+++ b/src-tauri/src/evm/pacto_chain_config.rs
@@ -303,6 +303,12 @@ mod tests {
 
     #[test]
     fn sepolia_book_safe_bundle_overrides_legacy_defaults() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
         let safe = safe_factory_addresses("sepolia", 11_155_111).expect("safe book");
         assert_eq!(
             safe.proxy_factory,
@@ -312,5 +318,94 @@ mod tests {
             safe.singleton,
             address!("0x41675C099F32341bf84BFc5382aF534df5C7461a")
         );
+    }
+
+    #[test]
+    fn net_suffix_uppercases_and_replaces_dashes() {
+        assert_eq!(net_suffix("sepolia"), "SEPOLIA");
+        assert_eq!(net_suffix("arbitrum-one"), "ARBITRUM_ONE");
+    }
+
+    #[test]
+    fn safe_factory_addresses_env_override_wins() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
+        let factory = address!("0x1111111111111111111111111111111111111111");
+        let singleton = address!("0x2222222222222222222222222222222222222222");
+        let fallback = address!("0x3333333333333333333333333333333333333333");
+        let _guard = EnvVarGuard::new()
+            .set("PACTO_SAFE_PROXY_FACTORY", "0x1111111111111111111111111111111111111111")
+            .set("PACTO_SAFE_SINGLETON", "0x2222222222222222222222222222222222222222")
+            .set("PACTO_SAFE_FALLBACK_HANDLER", "0x3333333333333333333333333333333333333333");
+        let safe = safe_factory_addresses("sepolia", 11_155_111).expect("env override");
+        assert_eq!(safe.proxy_factory, factory);
+        assert_eq!(safe.singleton, singleton);
+        assert_eq!(safe.fallback_handler, fallback);
+    }
+
+    #[test]
+    fn safe_factory_addresses_mainnet_defaults() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&[
+            "PACTO_SAFE_PROXY_FACTORY",
+            "PACTO_SAFE_SINGLETON",
+            "PACTO_SAFE_FALLBACK_HANDLER",
+        ]);
+        let safe = safe_factory_addresses("mainnet", 1).expect("mainnet defaults");
+        assert_eq!(
+            safe.singleton,
+            address!("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552")
+        );
+    }
+
+    #[test]
+    fn default_fallback_for_chain_id_mainnet() {
+        let _lock = ENV_TEST_MUTEX.lock();
+        clear_env(&["PACTO_SAFE_FALLBACK_HANDLER"]);
+        let fb = default_fallback_for_chain_id(1).expect("mainnet fallback");
+        assert_eq!(fb, address!("0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4"));
+    }
+
+    #[test]
+    fn default_fallback_for_chain_id_unknown() {
+        assert!(default_fallback_for_chain_id(999_999).is_none());
+    }
+
+    static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn clear_env(keys: &[&str]) {
+        for key in keys {
+            std::env::remove_var(key);
+        }
+    }
+
+    struct EnvVarGuard {
+        _prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvVarGuard {
+        fn new() -> Self {
+            Self { _prev: Vec::new() }
+        }
+        fn set(mut self, key: &'static str, value: &str) -> Self {
+            self._prev.push((key, std::env::var_os(key)));
+            std::env::set_var(key, value);
+            self
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, prev) in &self._prev {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
     }
 }

--- a/src-tauri/src/evm/rpc/address.rs
+++ b/src-tauri/src/evm/rpc/address.rs
@@ -13,3 +13,51 @@ pub fn parse_address(s: &str) -> Result<Address, String> {
     }
     Ok(Address::from(b))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_valid_with_prefix() {
+        let a = parse_address("0x0000000000000000000000000000000000000001").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_valid_without_prefix() {
+        let a = parse_address("0000000000000000000000000000000000000001").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_uppercase_prefix() {
+        let a = parse_address("0Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        let b = parse_address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn parse_address_trims_whitespace() {
+        let a = parse_address("  0x0000000000000000000000000000000000000001  ").unwrap();
+        assert_eq!(a, Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn parse_address_rejects_wrong_length() {
+        assert!(parse_address("0x123").is_err());
+        assert!(parse_address("0x").is_err());
+        assert!(parse_address("0x0000000000000000000000000000000000000001a").is_err());
+    }
+
+    #[test]
+    fn parse_address_rejects_non_hex() {
+        assert!(parse_address("0xgggggggggggggggggggggggggggggggggggggggg").is_err());
+    }
+
+    #[test]
+    fn parse_address_rejects_empty() {
+        assert!(parse_address("").is_err());
+        assert!(parse_address("   ").is_err());
+    }
+}

--- a/src-tauri/src/evm/rpc/call.rs
+++ b/src-tauri/src/evm/rpc/call.rs
@@ -94,4 +94,30 @@ mod tests {
         word[31] = 42;
         assert_eq!(decode_abi_u256_return(&word), U256::from(42));
     }
+
+    #[test]
+    fn decode_abi_u256_takes_last_32_bytes() {
+        let mut data = vec![0u8; 40];
+        data[39] = 5;
+        assert_eq!(decode_abi_u256_return(&data), U256::from(5));
+    }
+
+    #[test]
+    fn decode_abi_u256_left_pads_short_data() {
+        let data = vec![0u8, 0u8, 0u8, 1u8];
+        assert_eq!(decode_abi_u256_return(&data), U256::from(1));
+    }
+
+    #[test]
+    fn decode_abi_u256_zero_bytes() {
+        assert_eq!(decode_abi_u256_return(&[0u8; 0]), U256::ZERO);
+    }
+
+    #[test]
+    fn decode_abi_u256_large_value() {
+        let mut word = [0u8; 32];
+        word[0] = 0xff;
+        word[31] = 0xff;
+        assert_eq!(decode_abi_u256_return(&word), U256::from_be_slice(&word));
+    }
 }

--- a/src-tauri/src/evm/squad_admin_write.rs
+++ b/src-tauri/src/evm/squad_admin_write.rs
@@ -159,4 +159,36 @@ mod tests {
         expected[..8].copy_from_slice(b"TREASURY");
         assert_eq!(role.as_slice(), expected);
     }
+
+    #[test]
+    fn role_tag_exactly_32_bytes() {
+        let label = "TREASURY";
+        let role = bytes32_role_tag(label).unwrap();
+        assert_eq!(role.len(), 32);
+    }
+
+    #[test]
+    fn role_tag_rejects_empty() {
+        assert!(bytes32_role_tag("").is_err());
+        assert!(bytes32_role_tag("   ").is_err());
+    }
+
+    #[test]
+    fn role_tag_rejects_too_long() {
+        let label = "a".repeat(33);
+        assert!(bytes32_role_tag(&label).is_err());
+    }
+
+    #[test]
+    fn role_tag_rejects_non_ascii() {
+        assert!(bytes32_role_tag("rôle").is_err());
+    }
+
+    #[test]
+    fn role_tag_left_pads_short_label() {
+        let role = bytes32_role_tag("A").unwrap();
+        let mut expected = [0u8; 32];
+        expected[0] = b'A';
+        assert_eq!(role.as_slice(), expected);
+    }
 }

--- a/src-tauri/src/evm/squad_sponsor_common.rs
+++ b/src-tauri/src/evm/squad_sponsor_common.rs
@@ -65,3 +65,50 @@ pub async fn read_squad_record<P: Provider>(
     }
     Ok((sponsor, decoded.variant, decoded.topHatId))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn squad_id_from_parent_id_is_deterministic_and_trims() {
+        let a = squad_id_from_parent_id("parent-id");
+        let b = squad_id_from_parent_id("parent-id");
+        let c = squad_id_from_parent_id("  parent-id  ");
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn parse_deposit_wei_decimal() {
+        assert_eq!(parse_deposit_wei(Some("1000")).unwrap(), U256::from(1000u64));
+        assert_eq!(parse_deposit_wei(Some("  1000  ")).unwrap(), U256::from(1000u64));
+    }
+
+    #[test]
+    fn parse_deposit_wei_hex() {
+        assert_eq!(parse_deposit_wei(Some("0xff")).unwrap(), U256::from(255u64));
+        assert_eq!(parse_deposit_wei(Some("0XFF")).unwrap(), U256::from(255u64));
+    }
+
+    #[test]
+    fn parse_deposit_wei_rejects_empty() {
+        assert!(parse_deposit_wei(None).is_err());
+        assert!(parse_deposit_wei(Some("")).is_err());
+        assert!(parse_deposit_wei(Some("   ")).is_err());
+    }
+
+    #[test]
+    fn parse_deposit_wei_rejects_invalid() {
+        assert!(parse_deposit_wei(Some("not-a-number")).is_err());
+        assert!(parse_deposit_wei(Some("0xzz")).is_err());
+    }
+
+    #[test]
+    fn squad_variant_label_maps_variants() {
+        assert_eq!(squad_variant_label(SquadVariant::NONE), "none");
+        assert_eq!(squad_variant_label(SquadVariant::SPONSOR), "sponsor");
+        assert_eq!(squad_variant_label(SquadVariant::EXT), "ext");
+        assert_eq!(squad_variant_label(SquadVariant::__Invalid), "unknown");
+    }
+}

--- a/src-tauri/src/evm/wallet_chain_config.rs
+++ b/src-tauri/src/evm/wallet_chain_config.rs
@@ -243,5 +243,57 @@ mod tests {
         assert_eq!(explorer_url_for_tx(local, "0xabc..."), "");
     }
 
+    #[test]
+    fn mainnet_network_is_in_wallet_networks() {
+        let net = wallet_networks()
+            .iter()
+            .find(|n| n.key == "mainnet")
+            .expect("mainnet should be present");
+        assert_eq!(net.chain_id, 1);
+    }
+
+    #[test]
+    fn network_by_key_unknown_returns_none() {
+        assert!(network_by_key("unknown").is_none());
+    }
+
+    #[test]
+    fn rpc_urls_for_network_includes_public_fallbacks() {
+        let net = network_by_key("sepolia").unwrap();
+        let urls = rpc_urls_for(net);
+        assert!(!urls.is_empty());
+        assert!(urls.iter().any(|u| u.contains("publicnode.com")));
+    }
+
+    #[test]
+    fn explorer_url_for_tx_formats_hash_without_double_prefix() {
+        let net = WalletNetworkConfig {
+            key: "test".to_string(),
+            chain_id: 1,
+            display_name: "Test".to_string(),
+            explorer_tx_path: "https://explorer.com/tx/".to_string(),
+            native_symbol: "ETH".to_string(),
+            native_decimals: 18,
+            usdc_address: "".to_string(),
+            usdt_address: "".to_string(),
+            usdc_decimals: 6,
+            usdt_decimals: 6,
+        };
+        assert_eq!(
+            explorer_url_for_tx(&net, "0xdeadbeef"),
+            "https://explorer.com/tx/0xdeadbeef"
+        );
+    }
+
+    #[test]
+    fn alchemy_key_injected_into_mainnet_urls() {
+        let prev = std::env::var_os("ALCHEMY_RPC_KEY");
+        std::env::set_var("ALCHEMY_RPC_KEY", "test-key");
+        let _guard = EnvVarGuard("ALCHEMY_RPC_KEY", prev);
+        let mainnet = network_by_key("mainnet").unwrap();
+        let urls = rpc_urls_for(mainnet);
+        assert!(urls.iter().any(|u| u.contains("g.alchemy.com")));
+        assert!(urls.iter().any(|u| u.contains("publicnode.com")));
+    }
 
 }

--- a/src-tauri/src/evm/wallet_rpc_providers.rs
+++ b/src-tauri/src/evm/wallet_rpc_providers.rs
@@ -38,18 +38,12 @@ mod tests {
 
     #[test]
     fn alchemy_url_uses_host_map() {
-        std::env::set_var(ALCHEMY_KEY_ENV, "test-key");
-        let url = provider_primary_rpc_url("sepolia").unwrap();
-        assert_eq!(
-            url,
-            "https://eth-sepolia.g.alchemy.com/v2/test-key"
-        );
-        std::env::remove_var(ALCHEMY_KEY_ENV);
+        let url = alchemy_url("sepolia", "test-key").unwrap();
+        assert_eq!(url, "https://eth-sepolia.g.alchemy.com/v2/test-key");
     }
 
     #[test]
     fn missing_key_returns_none() {
-        std::env::remove_var(ALCHEMY_KEY_ENV);
-        assert!(provider_primary_rpc_url("mainnet").is_none());
+        assert!(alchemy_url("mainnet", "").is_none());
     }
 }

--- a/src-tauri/src/evm/wallet_security.rs
+++ b/src-tauri/src/evm/wallet_security.rs
@@ -163,4 +163,67 @@ mod tests {
         let r = redact_urls_in_text(&e);
         assert!(!r.contains("abc"));
     }
+
+    #[test]
+    fn redacts_various_sensitive_query_keys() {
+        for key in ["key", "token", "secret", "password", "auth", "api_key", "apikey", "access_token", "refresh_token"] {
+            let url = format!("https://example.com?{}=leaked", key);
+            let r = redact_rpc_url_for_log(&url);
+            assert!(!r.contains("leaked"), "key {} should be redacted", key);
+            assert!(r.contains("[REDACTED]"));
+        }
+    }
+
+    #[test]
+    fn preserves_non_sensitive_query_values() {
+        let u = "https://example.com?foo=bar";
+        let r = redact_rpc_url_for_log(u);
+        assert!(r.contains("foo=bar"));
+        assert!(!r.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_provider_path_segments() {
+        let u = "https://eth-mainnet.g.alchemy.com/v2/secret-key";
+        let r = redact_rpc_url_for_log(u);
+        assert!(!r.contains("secret-key"));
+        assert!(r.contains("/v2/[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_infura_v3_path_segment() {
+        let u = "https://mainnet.infura.io/v3/project-id";
+        let r = redact_rpc_url_for_log(u);
+        assert!(!r.contains("project-id"));
+        assert!(r.contains("/v3/[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_handles_multiple_urls() {
+        let text = "https://a.com?key=1 https://b.com?token=2";
+        let r = redact_urls_in_text(text);
+        assert!(!r.contains("key=1"));
+        assert!(!r.contains("token=2"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_handles_http() {
+        let text = "http://a.com?secret=x";
+        let r = redact_urls_in_text(text);
+        assert!(!r.contains("secret=x"));
+    }
+
+    #[test]
+    fn redact_unparsed_url_heuristic_strips_userinfo() {
+        let raw = "https://user:pass@host.com/path";
+        let r = redact_unparsed_url_heuristic(raw);
+        assert!(!r.contains("user"));
+        assert!(!r.contains("pass"));
+        assert!(r.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_unparsed_url_heuristic_without_scheme_returns_placeholder() {
+        assert_eq!(redact_unparsed_url_heuristic("just text"), "[rpc-url-unparsed]");
+    }
 }

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -4,7 +4,7 @@
 //! support and graceful fallback when images fail to load.
 //!
 //! ## Storage Structure
-//! ```
+//! ```text
 //! AppData/cache/
 //!   avatars/{hash}.{ext}
 //!   banners/{hash}.{ext}

--- a/src-tauri/src/squad_catalog.rs
+++ b/src-tauri/src/squad_catalog.rs
@@ -599,4 +599,137 @@ mod tests {
         input.commons_tags = None;
         assert!(prepare_row(input).is_err());
     }
+
+    #[test]
+    fn normalize_kind_defaults_to_squad() {
+        assert_eq!(normalize_kind(None).unwrap(), KIND_SQUAD);
+        assert_eq!(normalize_kind(Some("  ")).unwrap(), KIND_SQUAD);
+        assert_eq!(normalize_kind(Some("SQUAD-PAIR")).unwrap(), KIND_SQUAD_PAIR);
+        assert!(normalize_kind(Some("invalid")).is_err());
+    }
+
+    #[test]
+    fn normalize_visibility_defaults_to_private() {
+        assert_eq!(normalize_visibility(None).unwrap(), VIS_PRIVATE);
+        assert_eq!(normalize_visibility(Some("  ")).unwrap(), VIS_PRIVATE);
+        assert_eq!(normalize_visibility(Some("PUBLIC")).unwrap(), VIS_PUBLIC);
+        assert!(normalize_visibility(Some("hidden")).is_err());
+    }
+
+    #[test]
+    fn normalize_commons_tag_filters() {
+        assert_eq!(normalize_commons_tag(" #Foo_Bar "), Some("foo_bar".to_string()));
+        assert_eq!(normalize_commons_tag("new"), None);
+        assert_eq!(normalize_commons_tag("a"), Some("a".to_string()));
+        assert_eq!(normalize_commons_tag("a_very_long_tag_exceeding_32_chars_limit"), None);
+        assert_eq!(normalize_commons_tag("bad-tag"), None);
+        assert_eq!(normalize_commons_tag("bad!tag"), None);
+    }
+
+    #[test]
+    fn normalize_commons_tags_private_returns_none() {
+        assert_eq!(normalize_commons_tags(None, VIS_PRIVATE).unwrap(), None);
+        assert_eq!(normalize_commons_tags(Some(&["tag".to_string()]), VIS_PRIVATE).unwrap(), None);
+    }
+
+    #[test]
+    fn public_squad_commons_tags_validated() {
+        let tags = vec!["pacto".to_string()];
+        assert_eq!(
+            normalize_commons_tags(Some(&tags), VIS_PUBLIC).unwrap(),
+            Some(vec!["pacto".to_string()])
+        );
+        assert!(normalize_commons_tags(None, VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&[]), VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&["new".to_string()]), VIS_PUBLIC).is_err());
+        assert!(normalize_commons_tags(Some(&["a".to_string(), "b".to_string(), "c".to_string(), "d".to_string()]), VIS_PUBLIC).is_err());
+    }
+
+    #[test]
+    fn paired_squads_required_for_squad_pair() {
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        assert!(prepare_row(input).is_err());
+
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        input.paired_squads = Some(vec![
+            PairedSquadRef { id: "a".to_string(), name: "A".to_string() },
+            PairedSquadRef { id: "b".to_string(), name: "B".to_string() },
+        ]);
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.paired_squads.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn paired_squads_rejects_non_two() {
+        let mut input = sample_upsert("pair", "Pair");
+        input.kind = Some(KIND_SQUAD_PAIR.to_string());
+        input.paired_squads = Some(vec![
+            PairedSquadRef { id: "a".to_string(), name: "A".to_string() },
+        ]);
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn prepare_row_rejects_empty_id_or_name() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.id = "   ".to_string();
+        assert!(prepare_row(input).is_err());
+
+        let input = sample_upsert("grp", "  ");
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn prepare_row_trims_icon_url_and_blank_becomes_none() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.icon_url = Some("  https://example.com/icon.png  ".to_string());
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.icon_url, Some("https://example.com/icon.png".to_string()));
+
+        let mut input = sample_upsert("grp", "Squad");
+        input.icon_url = Some("   ".to_string());
+        let row = prepare_row(input).unwrap();
+        assert_eq!(row.icon_url, None);
+    }
+
+    #[test]
+    fn validate_channels_rejects_blank_fields() {
+        let mut input = sample_upsert("grp", "Squad");
+        input.channels = vec![SquadChannelRow { name: "  ".to_string(), group_id: "g".to_string(), order: 0 }];
+        assert!(prepare_row(input).is_err());
+
+        let mut input = sample_upsert("grp", "Squad");
+        input.channels = vec![SquadChannelRow { name: "n".to_string(), group_id: "  ".to_string(), order: 0 }];
+        assert!(prepare_row(input).is_err());
+    }
+
+    #[test]
+    fn row_from_query_rejects_invalid_channels_json() {
+        let result = row_from_query(
+            "id".to_string(), "name".to_string(), None, KIND_SQUAD.to_string(), VIS_PRIVATE.to_string(),
+            None, None, "not-json".to_string(), 1, 2,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_squad_inner_blank_id_returns_none() {
+        let conn = test_conn();
+        assert!(get_squad_inner(&conn, "  ").unwrap().is_none());
+    }
+
+    #[test]
+    fn upsert_squad_inner_updates_existing_row() {
+        let conn = test_conn();
+        let row = prepare_row(sample_upsert("grp", "Alpha")).unwrap();
+        upsert_squad_inner(&conn, &row).unwrap();
+        let mut updated = prepare_row(sample_upsert("grp", "Beta")).unwrap();
+        updated.updated_at_ms = 2000;
+        upsert_squad_inner(&conn, &updated).unwrap();
+        let got = get_squad_inner(&conn, "grp").unwrap().unwrap();
+        assert_eq!(got.name, "Beta");
+        assert_eq!(got.updated_at_ms, 2000);
+    }
 }

--- a/src-tauri/src/stored_event.rs
+++ b/src-tauri/src/stored_event.rs
@@ -428,4 +428,92 @@ mod tests {
         assert_eq!(event.reference_id, Some("msg456".to_string()));
         assert!(event.mine);
     }
+
+    #[test]
+    fn known_kinds_match_expected() {
+        assert!(StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::FILE_ATTACHMENT, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::REACTION, 1, "".to_string(), 1).is_known_kind());
+        assert!(StoredEvent::new("x".to_string(), event_kind::APPLICATION_SPECIFIC, 1, "".to_string(), 1).is_known_kind());
+        assert!(!StoredEvent::new("x".to_string(), event_kind::MLS_WELCOME, 1, "".to_string(), 1).is_known_kind());
+    }
+
+    #[test]
+    fn is_message_covers_dm_and_file() {
+        assert!(StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1).is_message());
+        assert!(StoredEvent::new("x".to_string(), event_kind::FILE_ATTACHMENT, 1, "".to_string(), 1).is_message());
+        assert!(!StoredEvent::new("x".to_string(), event_kind::REACTION, 1, "".to_string(), 1).is_message());
+    }
+
+    #[test]
+    fn get_tags_returns_all_values_for_key() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1);
+        event.tags = vec![
+            vec!["p".to_string(), "a".to_string()],
+            vec!["e".to_string(), "ref1".to_string()],
+            vec!["p".to_string(), "b".to_string()],
+        ];
+        assert_eq!(event.get_tags("p"), vec!["a", "b"]);
+        assert_eq!(event.get_tags("missing"), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn get_reply_reference_requires_marker() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1);
+        event.tags = vec![vec!["e".to_string(), "ref1".to_string()]];
+        assert_eq!(event.get_reply_reference(), None);
+        event.tags = vec![vec!["e".to_string(), "ref1".to_string(), "".to_string(), "reply".to_string()]];
+        assert_eq!(event.get_reply_reference(), Some("ref1"));
+    }
+
+    #[test]
+    fn timestamp_ms_edge_cases() {
+        let mut event = StoredEvent::new("x".to_string(), event_kind::PRIVATE_DIRECT_MESSAGE, 1, "".to_string(), 1234567890);
+        // No ms tag
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // Valid ms tag 0
+        event.tags = vec![vec!["ms".to_string(), "0".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // ms tag beyond 999 ignored
+        event.tags = vec![vec!["ms".to_string(), "1000".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+        // Non-numeric ms tag ignored
+        event.tags = vec![vec!["ms".to_string(), "abc".to_string()]];
+        assert_eq!(event.timestamp_ms(), 1234567890000);
+    }
+
+    #[test]
+    fn builder_sets_all_optional_fields() {
+        let event = StoredEventBuilder::new()
+            .id("id1")
+            .kind(event_kind::FILE_ATTACHMENT)
+            .chat_id(7)
+            .user_id(Some(42))
+            .content("content")
+            .tags(vec![vec!["e".to_string(), "ref".to_string()]])
+            .reference_id(Some("ref".to_string()))
+            .created_at(1000)
+            .mine(true)
+            .pending(true)
+            .failed(true)
+            .wrapper_event_id(Some("wrap".to_string()))
+            .npub(Some("npub".to_string()))
+            .virtual_bucket(Some("inbox".to_string()))
+            .build();
+
+        assert_eq!(event.id, "id1");
+        assert_eq!(event.kind, event_kind::FILE_ATTACHMENT);
+        assert_eq!(event.chat_id, 7);
+        assert_eq!(event.user_id, Some(42));
+        assert_eq!(event.content, "content");
+        assert_eq!(event.tags, vec![vec!["e".to_string(), "ref".to_string()]]);
+        assert_eq!(event.reference_id, Some("ref".to_string()));
+        assert_eq!(event.created_at, 1000);
+        assert!(event.mine);
+        assert!(event.pending);
+        assert!(event.failed);
+        assert_eq!(event.wrapper_event_id, Some("wrap".to_string()));
+        assert_eq!(event.npub, Some("npub".to_string()));
+        assert_eq!(event.virtual_bucket, Some("inbox".to_string()));
+    }
 }

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -852,3 +852,124 @@ pub fn mime_from_extension_safe(extension: &str, image_only: bool) -> Result<Str
 pub fn is_image_mime(mime: &str) -> bool {
     mime.trim().starts_with("image/")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_https_urls_basic() {
+        let text = "Check https://example.com and https://foo.bar/path?x=1.";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://example.com", "https://foo.bar/path?x=1"]);
+    }
+
+    #[test]
+    fn extract_https_urls_trims_trailing_punctuation() {
+        let text = "See https://example.com, (https://foo.bar), and https://baz.com.";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://example.com", "https://foo.bar", "https://baz.com"]);
+    }
+
+    #[test]
+    fn extract_https_urls_ignores_http() {
+        let text = "http://insecure.com and https://secure.com";
+        let urls = extract_https_urls(text);
+        assert_eq!(urls, vec!["https://secure.com"]);
+    }
+
+    #[test]
+    fn get_file_type_description_known() {
+        assert_eq!(get_file_type_description("png"), "Picture");
+        assert_eq!(get_file_type_description("PNG"), "Picture");
+        assert_eq!(get_file_type_description("pdf"), "PDF Document");
+    }
+
+    #[test]
+    fn get_file_type_description_unknown_defaults_to_file() {
+        assert_eq!(get_file_type_description("xyz"), "File");
+    }
+
+    #[test]
+    fn format_bytes_sizes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(2 * 1024 * 1024), "2.0 MB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
+    }
+
+    #[test]
+    fn bytes_to_hex_string_round_trip() {
+        let bytes = vec![0xde, 0xad, 0xbe, 0xef];
+        let hex = bytes_to_hex_string(&bytes);
+        assert_eq!(hex, "deadbeef");
+        assert_eq!(hex_string_to_bytes(&hex), bytes);
+    }
+
+    #[test]
+    fn hex_string_to_bytes_accepts_uppercase() {
+        assert_eq!(hex_string_to_bytes("DEADBEEF"), vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn hex_string_to_bytes_ignores_odd_trailing_nibble() {
+        // Current behavior drops the trailing odd digit.
+        assert_eq!(hex_string_to_bytes("abc"), vec![0xab]);
+    }
+
+    #[test]
+    fn calculate_file_hash_is_sha256_hex() {
+        let data = b"hello";
+        assert_eq!(
+            calculate_file_hash(data),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn nearest_neighbor_downsample_preserves_corners() {
+        // 2x2 image with four distinct colors.
+        let pixels = vec![
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255,
+        ];
+        let out = nearest_neighbor_downsample(&pixels, 2, 2, 1, 1);
+        assert_eq!(out, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn has_alpha_transparency_detects_alpha() {
+        let opaque = vec![255, 255, 255, 255, 0, 0, 0, 255];
+        assert!(!has_alpha_transparency(&opaque));
+        let transparent = vec![255, 255, 255, 128, 0, 0, 0, 255];
+        assert!(has_alpha_transparency(&transparent));
+    }
+
+    #[test]
+    fn mime_from_extension_normalizes() {
+        assert_eq!(mime_from_extension("png"), "image/png");
+        assert_eq!(mime_from_extension(".PNG"), "image/png");
+        assert_eq!(mime_from_extension("unknown"), "application/octet-stream");
+    }
+
+    #[test]
+    fn extension_from_mime_known_and_fallback() {
+        assert_eq!(extension_from_mime("image/png"), "png");
+        assert_eq!(extension_from_mime("application/x-foo"), "x-foo");
+        assert_eq!(extension_from_mime("malformed"), "bin");
+    }
+
+    #[test]
+    fn mime_from_extension_safe_restricts_to_images() {
+        assert_eq!(mime_from_extension_safe("png", true).unwrap(), "image/png");
+        assert_eq!(mime_from_extension_safe("png", false).unwrap(), "image/png");
+        assert!(mime_from_extension_safe("pdf", true).is_err());
+    }
+
+    #[test]
+    fn is_image_mime_check() {
+        assert!(is_image_mime("image/png"));
+        assert!(!is_image_mime("application/pdf"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `#[cfg(test)]` coverage across the Rust backend for the helpers that do not require a running Tauri or relay network.

## Changes

- Unit tests for crypto, EVM config/contract calls, storage, and squad catalog helpers.
- Minor testability adjustments in existing source files.

## Test plan

- `cd src-tauri && cargo test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
