### PR TITLE
fix(lint): resolve behavioral ESLint fixes for error handling and typing

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,43 +38,5 @@ export default [
 			'svelte/no-immutable-reactive-statements': 'off',
 			'svelte/no-reactive-literals': 'off'
 		}
-	},
-	// Temporary suppressions for files whose remaining lint errors require
-	// behavioral fixes. These are being addressed in the parent lint PR and
-	// will be removed once the risky changes land.
-	{
-		files: ['src/components/auth/Login.svelte', 'src/components/settings/ProfileSection.svelte'],
-		rules: {
-			'@typescript-eslint/no-explicit-any': 'off'
-		}
-	},
-	{
-		files: [
-			'src/components/parent/DashboardPollsPanel.svelte',
-			'src/lib/api/encryption.ts',
-			'src/routes/+page.svelte'
-		],
-		rules: {
-			'preserve-caught-error': 'off'
-		}
-	},
-	{
-		files: ['src/lib/api/encryption.ts'],
-		rules: {
-			'@typescript-eslint/no-unused-vars': 'off'
-		}
-	},
-	{
-		files: ['src/lib/utils/message-formatting.ts'],
-		rules: {
-			'no-useless-escape': 'off'
-		}
-	},
-	{
-		files: ['src/stores/auth.ts', 'src/stores/profiles.ts'],
-		rules: {
-			'@typescript-eslint/no-explicit-any': 'off',
-			'@typescript-eslint/no-unused-vars': 'off'
-		}
 	}
 ];

--- a/src/components/auth/Login.svelte
+++ b/src/components/auth/Login.svelte
@@ -86,8 +86,8 @@
         await createAccount(pin);
       }
       // On success, auth store will handle state and user will see app
-    } catch (e: any) {
-      error = e.message || 'Failed to create account';
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to create account';
       currentStep = 'pin-create';
       firstPin = '';
     }
@@ -99,8 +99,8 @@
     try {
       await unlockWithPin(pin);
       // On success, auth store will handle state and user will see app
-    } catch (e: any) {
-      error = e.message || 'Incorrect PIN';
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Incorrect PIN';
       // Stay on unlock screen for retry
     } finally {
       unlockInFlight = false;

--- a/src/components/parent/DashboardPollsPanel.svelte
+++ b/src/components/parent/DashboardPollsPanel.svelte
@@ -139,7 +139,7 @@
     } catch (e) {
       const msg = getInvokeErrorMessage(e, 'Failed to publish poll.');
       showToast(msg);
-      throw new Error(msg);
+      throw new Error(msg, { cause: e });
     }
   }
 

--- a/src/components/settings/ProfileSection.svelte
+++ b/src/components/settings/ProfileSection.svelte
@@ -45,8 +45,8 @@
     try {
       error = null;
       await loadProfile(npub);
-    } catch (e: any) {
-      error = e.message || 'Failed to load profile';
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load profile';
       console.error('Profile load error:', e);
     }
   }
@@ -85,9 +85,9 @@
       saveError = null;
       const url = await uploadAvatar(selected, 'avatar');
       editAvatarUrl = url;
-    } catch (e: any) {
+    } catch (e) {
       console.error('Upload avatar failed:', e);
-      saveError = e?.message || 'Failed to upload avatar';
+      saveError = e instanceof Error ? e.message : 'Failed to upload avatar';
     } finally {
       uploadingAvatar = false;
     }
@@ -263,7 +263,8 @@
                     } catch (_) {
                       // clipboard write may fail silently
                     }
-                  }}>
+                  }}
+                >
                   <svg
                     class="btn-copy-account-id-icon"
                     width="18"

--- a/src/lib/api/encryption.ts
+++ b/src/lib/api/encryption.ts
@@ -68,7 +68,7 @@ export async function loadAndDecryptKey(pin: string): Promise<string> {
     });
     return decryptedKey;
   } catch (error) {
-    throw new Error('Incorrect PIN');
+    throw new Error('Incorrect PIN', { cause: error });
   }
 }
 

--- a/src/lib/utils/message-formatting.ts
+++ b/src/lib/utils/message-formatting.ts
@@ -188,7 +188,7 @@ function sanitizeWithEmoji(html: string): string {
   }
 }
 
-const URL_REGEX = /(https?:\/\/[^\s<>"']+?)([.,;:!?)\]\']*)(?=\s|$|<|>)/g;
+const URL_REGEX = /(https?:\/\/[^\s<>"']+?)([.,;:!?)\]'"]*)(?=\s|$|<|>)/g;
 
 function isSafeUrl(url: string): boolean {
   const t = url.toLowerCase().trim();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -962,7 +962,7 @@
                   try {
                     await setNickname(id, value);
                   } catch (e) {
-                    throw new Error(getInvokeErrorMessage(e, 'Failed to set nickname'));
+                    throw new Error(getInvokeErrorMessage(e, 'Failed to set nickname'), { cause: e });
                   }
                 }}
                 onDeleteChat={isPactoAppThreadId($activeDmId)

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -89,9 +89,9 @@ export async function checkAuthStatus(): Promise<'needs-auth' | 'needs-pin' | 'a
     }
 
     return 'needs-pin';
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Auth check failed:', error);
-    authError.set(error.message || 'Failed to check auth status');
+    authError.set(error instanceof Error ? error.message : 'Failed to check auth status');
     return 'needs-auth';
   } finally {
     authLoading.set(false);
@@ -136,9 +136,9 @@ export async function createAccount(pin: string): Promise<void> {
 
     dmLog('createAccount: done (fetchMessages will run from +page onMount)');
     authLoading.set(false);
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Create account failed:', error);
-    authError.set(error.message || 'Failed to create account');
+    authError.set(error instanceof Error ? error.message : 'Failed to create account');
     authLoading.set(false);
     throw error;
   }
@@ -187,9 +187,9 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
     runPostLoginNetworkSync(npub);
 
     dmLog('importAccount: done');
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Import account failed:', error);
-    authError.set(error.message || 'Failed to import account');
+    authError.set(error instanceof Error ? error.message : 'Failed to import account');
     authLoading.set(false);
     throw error;
   }
@@ -221,9 +221,9 @@ export async function unlockWithPin(pin: string): Promise<void> {
     await maybeApplyLocalDevDefaults(npub);
 
     dmLog('unlockWithPin: done');
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Unlock failed:', error);
-    authError.set(error.message || 'Incorrect PIN or failed to decrypt');
+    authError.set(error instanceof Error ? error.message : 'Incorrect PIN or failed to decrypt');
     throw error;
   } finally {
     authLoading.set(false);
@@ -246,9 +246,9 @@ export async function logout(): Promise<void> {
     clearSessionUnlocked();
     clearAccountState(npub);
     await invoke('logout');
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Logout failed:', error);
-    authError.set(error.message || 'Failed to logout');
+    authError.set(error instanceof Error ? error.message : 'Failed to logout');
     isAuthenticated.set(false);
     currentUser.set(null);
     throw error;

--- a/src/stores/profiles.ts
+++ b/src/stores/profiles.ts
@@ -10,6 +10,18 @@ import { hydrateDmUnreadFromInitChats } from './dm-unread';
 import { currentUser } from './auth';
 import { showToast } from './toast';
 
+type InitFinishedPayload = {
+  profiles?: NostrProfile[];
+  chats?: Array<{
+    id?: string;
+    chat_type?: string;
+    messages?: Array<{ at: number; mine?: boolean }>;
+    last_read?: string;
+    created_at?: number;
+  }>;
+  dm_flags?: Record<string, { has_from_me?: boolean; has_from_them?: boolean }>;
+};
+
 const LAST_DM_NPUB_PREFIX = 'pacto_last_dm_npub';
 let lastOpenChatRestored = false;
 
@@ -27,14 +39,14 @@ const INIT_LISTENER_KEY = '__pacto_init_finished_unlisten';
     const prev = typeof window !== 'undefined' ? (window as unknown as { [key: string]: (() => void) | undefined })[INIT_LISTENER_KEY] : undefined;
     if (prev) prev();
 
-    const unlisten = await listen('init_finished', (event: any) => {
+    const unlisten = await listen<InitFinishedPayload>('init_finished', (event) => {
       const payload = event.payload;
       dmLog('init_finished received', {
         profilesCount: payload?.profiles?.length ?? 0,
         chatsCount: payload?.chats?.length ?? 0,
       });
       // [Squad/Invite] debug: which chats (npubs) we got so we can see if inviter DM exists
-      const chats = (payload?.chats && Array.isArray(payload.chats)) ? (payload.chats as { id?: string; chat_type?: string }[]) : [];
+      const chats = (payload?.chats && Array.isArray(payload.chats)) ? payload.chats : [];
       const dmNpubs = chats.filter((c) => typeof c.id === 'string' && (c.id.startsWith('npub1') || c.chat_type === 'DirectMessage')).map((c) => c.id as string);
       console.log('[Squad/Invite] init_finished: chats total=', chats.length, 'dm npubs=', dmNpubs.length, 'ids (first 5)=', dmNpubs.slice(0, 5).map((id) => id.slice(0, 24) + '…'));
       if (!payload) return;
@@ -60,29 +72,25 @@ const INIT_LISTENER_KEY = '__pacto_init_finished_unlisten';
         const profilesMap = payload.profiles
           ? Object.fromEntries(payload.profiles.map((p: NostrProfile) => [p.id, p]))
           : {};
-        type ChatPayload = {
-          id: string;
-          chat_type?: string;
-          messages?: Array<{ at: number; mine?: boolean }>;
-          created_at?: number;
-        };
-        const dmChats = (payload.chats as ChatPayload[]).filter(
+      const dmChats = payload.chats.filter(
           (c) =>
             typeof c.id === 'string' &&
             (c.id.startsWith('npub1') || c.chat_type === 'DirectMessage')
         );
-        const dmFlags = (payload as { dm_flags?: Record<string, { has_from_me?: boolean; has_from_them?: boolean }> }).dm_flags;
+        const dmFlags = payload.dm_flags;
         const map: Record<string, DmChatState> = {};
         for (const c of dmChats) {
+          const id = c.id;
+          if (typeof id !== 'string') continue;
           const ms = c.messages ?? [];
           // Prefer backend dm_flags (from full DB) so Friends vs Requests vs Pending is correct when init only loads 1 message per chat
-          const flags = dmFlags?.[c.id];
+          const flags = dmFlags?.[id];
           const hasFromMe = flags ? flags.has_from_me ?? false : ms.some((m: { mine?: boolean }) => m.mine === true);
           const hasFromThem = flags ? flags.has_from_them ?? false : ms.some((m: { mine?: boolean }) => m.mine === false);
           const lastAt = ms.length > 0 ? Math.max(...ms.map((m: { at?: number }) => m.at ?? 0)) : (c.created_at ?? 0);
-          const profile = profilesMap[c.id];
-          map[c.id] = {
-            npub: c.id,
+          const profile = profilesMap[id];
+          map[id] = {
+            npub: id,
             name: getProfileDisplayName(profile ?? undefined),
             avatar: profile?.avatar_cached || profile?.avatar,
             hasFromMe,
@@ -140,7 +148,7 @@ const INIT_LISTENER_KEY = '__pacto_init_finished_unlisten';
     await listen('kind0_profile_published', () => {
       showToast('Profile metadata (Kind 0) published to the network.');
     });
-    await listen('kind0_profile_publish_failed', (event: any) => {
+    await listen<string>('kind0_profile_publish_failed', (event) => {
       const p = event.payload;
       const msg = typeof p === 'string' && p.trim() ? p : 'Could not publish profile metadata.';
       showToast(msg);
@@ -153,8 +161,8 @@ const INIT_LISTENER_KEY = '__pacto_init_finished_unlisten';
 // Listen for profile updates from backend
 (async () => {
   try {
-    await listen('profile_update', (event: any) => {
-      const profile = event.payload as NostrProfile;
+    await listen<NostrProfile>('profile_update', (event) => {
+      const profile = event.payload;
       if (profile?.id) {
         dmLog('profile_update', { npub: profile.id.slice(0, 20) + '…', name: profile.display_name || profile.name });
         profiles.update((p) => {
@@ -174,8 +182,8 @@ const INIT_LISTENER_KEY = '__pacto_init_finished_unlisten';
 // Listen for nickname changes
 (async () => {
   try {
-    await listen('profile_nick_changed', (event: any) => {
-      const payload = event.payload as { profile_id?: string; value?: string };
+    await listen<{ profile_id?: string; value?: string }>('profile_nick_changed', (event) => {
+      const payload = event.payload;
       const { profile_id, value } = payload;
       if (!profile_id || value === undefined) return;
       dmLog('profile_nick_changed', { npub: profile_id.slice(0, 20) + '…', nickname: value });
@@ -219,7 +227,7 @@ export async function loadProfile(npub: string): Promise<NostrProfile> {
       const profile = await fetchNostrProfile(npub);
       profiles.update(p => ({ ...p, [npub]: profile }));
       return profile;
-    } catch (fetchError) {
+    } catch {
       // Not in cache, trigger background fetch
       await loadNostrProfile(npub);
       


### PR DESCRIPTION
## Why
PR #67 was originally a mixed bag of mechanical lint cleanup and behavioral fixes. The mechanical fixes are now in #71 so they can merge quickly. This PR keeps only the changes that affect runtime behavior or need focused review, so they get the attention they deserve without blocking the rest.

## What changed
- `catch` error handling in `Login.svelte`, `ProfileSection.svelte`, and `auth.ts` (replace `e: any` with safe extraction).
- Adds `{ cause: error }` to re-thrown errors in `encryption.ts`, `DashboardPollsPanel.svelte`, and `+page.svelte`.
- Fixes `no-useless-escape` in `message-formatting.ts` URL regex (slightly changes trailing-punctuation stripping).
- Refactors `profiles.ts` listener typing and adds a runtime guard for chat IDs.
- Keeps the `eslint.config.js` legacy-Svelte rule adjustments.
- Drops the committed `lint-verify.txt` artifact.

## Dependency
This branch is based on #71. Merge #71 first, then this PR can be retargeted to `main` and merged.

## Test plan
- With #71 merged, `pnpm lint` passes.
- Review the behavioral changes carefully since they touch error handling and profile init.