### PR TITLE
feat(governance): add POA (POP) as a pluggable governance provider

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -502,6 +502,7 @@ fn normalize_infra_type(raw: &str) -> Result<String, String> {
         "squad_admin" | "squad-admin" => Ok("squad_admin".to_string()),
         "standalone_safe" | "gnosis_safe" | "gnosis-safe" | "safe" => Ok("standalone_safe".to_string()),
         "bread_coop" | "bread-coop" | "bread" => Ok("bread_coop".to_string()),
+        "poa" | "poa_gov" | "pop" => Ok("poa".to_string()),
         _ => Err(format!("unknown squad infra type: {}", raw.trim())),
     }
 }

--- a/src/components/parent/ParentDashboard.svelte
+++ b/src/components/parent/ParentDashboard.svelte
@@ -22,6 +22,7 @@
   import { parsePactoGovProviderPayload } from '../../lib/governance/pacto-gov-payload';
   import { hasSquadAdminInfra, resolveSquadAdminContext } from '../../lib/governance/squad-admin-payload';
   import { standaloneSafeInfraRows } from '../../lib/governance/standalone-safe-payload';
+  import { poaInfraRow } from '../../lib/governance/poa-payload';
   import { DEFAULT_CHAIN_ID, parseSupportedChainId, type SupportedChainId } from '../../lib/wallet/chains';
   import {
     loadSquadNetworkOverride,
@@ -118,6 +119,15 @@
         infraRowId: string;
       }) => Promise<void>)
     | undefined = undefined;
+  export let onPoaLinkComplete:
+    | ((params: {
+        parentId: string;
+        chain: string;
+        orgId: string;
+        executor?: string;
+        label?: string;
+      }) => Promise<void>)
+    | undefined = undefined;
 
   let showSetSafeModal = false;
   let showDeploySafeModal = false;
@@ -126,12 +136,20 @@
   let showSponsorDeploy = false;
   let showSquadAdminDeploy = false;
   let showSquadRolesModal = false;
+  let showSetPoaModal = false;
 
   let setSafeInput = '';
   let setSafeChain: SupportedChainId = DEFAULT_CHAIN_ID;
   let setSafeLabel = '';
   let setSafeError = '';
   let setSafeSaving = false;
+
+  let setPoaOrgId = '';
+  let setPoaChain: SupportedChainId = DEFAULT_CHAIN_ID;
+  let setPoaExecutor = '';
+  let setPoaLabel = '';
+  let setPoaError = '';
+  let setPoaSaving = false;
 
   $: parentId = parent?.id;
   $: sponsorRow = sponsorInfraRow(squadInfraRows);
@@ -143,6 +161,7 @@
   $: squadAdminCtx = resolveSquadAdminContext(squadInfraRows);
   $: hasSquadAdmin = hasSquadAdminInfra(squadInfraRows);
   $: vaultSafeCount = standaloneSafeInfraRows(squadInfraRows).length;
+  $: hasPoa = poaInfraRow(squadInfraRows) != null;
   $: pactoPayload = parsePactoGovProviderPayload(pactoGovRow?.providerPayload);
   $: pactoNetwork = parseSupportedChainId(
     pactoGovRow?.chain?.trim() || squadAdminCtx?.chain || DEFAULT_CHAIN_ID,
@@ -502,6 +521,70 @@
     setSafeError = '';
   }
 
+  /** Linking a read-only POA org does not require a squad sponsor (no gas is spent). */
+  function openImportPoa() {
+    if (hasPoa) {
+      showToast('A POA org is already linked for this squad.');
+      return;
+    }
+    showSetPoaModal = true;
+    setPoaOrgId = '';
+    setPoaChain = squadNetwork ?? DEFAULT_CHAIN_ID;
+    setPoaExecutor = '';
+    setPoaLabel = '';
+    setPoaError = '';
+  }
+
+  function closeSetPoaModal() {
+    showSetPoaModal = false;
+    setPoaOrgId = '';
+    setPoaExecutor = '';
+    setPoaLabel = '';
+    setPoaError = '';
+  }
+
+  async function confirmSetPoa() {
+    const orgId = setPoaOrgId.trim();
+    if (!orgId) {
+      setPoaError = 'Enter a POA org id';
+      return;
+    }
+    if (!/^0x[a-fA-F0-9]{64}$/.test(orgId)) {
+      setPoaError = 'Invalid org id (expected 0x + 64 hex chars)';
+      return;
+    }
+    const executor = setPoaExecutor.trim();
+    if (executor && !/^0x[a-fA-F0-9]{40}$/.test(executor)) {
+      setPoaError = 'Invalid executor address (expected 0x + 40 hex chars)';
+      return;
+    }
+    if (!onPoaLinkComplete) {
+      setPoaError = 'Link POA org is not available';
+      return;
+    }
+    if (!parentId?.trim()) {
+      setPoaError = 'Squad is not ready';
+      return;
+    }
+    setPoaSaving = true;
+    setPoaError = '';
+    try {
+      await onPoaLinkComplete({
+        parentId: parentId.trim(),
+        chain: setPoaChain,
+        orgId,
+        executor: executor || undefined,
+        label: setPoaLabel.trim() || undefined,
+      });
+      closeSetPoaModal();
+      showToast('POA org linked for this squad.');
+    } catch (e) {
+      setPoaError = e instanceof Error ? e.message : 'Failed to link POA org';
+    } finally {
+      setPoaSaving = false;
+    }
+  }
+
   async function confirmSetSafe() {
     const addr = setSafeInput.trim();
     if (!addr) {
@@ -687,6 +770,7 @@
   {hasPactoGov}
   {hasSquadAdmin}
   {vaultSafeCount}
+  {hasPoa}
   squadAdminProxy={squadAdminCtx?.proxy ?? ''}
   squadAdminNetwork={squadAdminNetwork}
   {squadNetwork}
@@ -698,11 +782,18 @@
   bind:showSquadAdminDeploy
   bind:showSquadRolesModal
   bind:showSetSafeModal
+  bind:showSetPoaModal
   bind:setSafeInput
   bind:setSafeChain
   bind:setSafeLabel
   bind:setSafeError
   bind:setSafeSaving
+  bind:setPoaOrgId
+  bind:setPoaChain
+  bind:setPoaExecutor
+  bind:setPoaLabel
+  bind:setPoaError
+  bind:setPoaSaving
   onCloseDeploySafe={() => (showDeploySafeModal = false)}
   onCloseNaveWizard={() => (showNaveWizard = false)}
   onCloseLaunchpad={() => (showLaunchpad = false)}
@@ -711,6 +802,9 @@
   onCloseSquadRolesModal={() => (showSquadRolesModal = false)}
   onCloseSetSafe={closeSetSafeModal}
   onConfirmSetSafe={confirmSetSafe}
+  onCloseSetPoa={closeSetPoaModal}
+  onConfirmSetPoa={confirmSetPoa}
+  onImportPoa={openImportPoa}
   onDeploySponsor={openSponsorDeploy}
   onDeploySquadAdmin={openSquadAdminDeploy}
   onDeployPactoGov={openPactoGovDeploy}

--- a/src/components/parent/dashboard/ParentDashboardModals.svelte
+++ b/src/components/parent/dashboard/ParentDashboardModals.svelte
@@ -19,6 +19,7 @@
   export let hasPactoGov = false;
   export let hasSquadAdmin = false;
   export let vaultSafeCount = 0;
+  export let hasPoa = false;
   export let squadAdminProxy = '';
   export let squadAdminNetwork: SupportedChainId = DEFAULT_CHAIN_ID;
   /** Established squad network; deploy modals pin to it, or prompt a pick when null. */
@@ -32,12 +33,20 @@
   export let showSquadAdminDeploy = false;
   export let showSquadRolesModal = false;
   export let showSetSafeModal = false;
+  export let showSetPoaModal = false;
 
   export let setSafeInput = '';
   export let setSafeChain: SupportedChainId = DEFAULT_CHAIN_ID;
   export let setSafeLabel = '';
   export let setSafeError = '';
   export let setSafeSaving = false;
+
+  export let setPoaOrgId = '';
+  export let setPoaChain: SupportedChainId = DEFAULT_CHAIN_ID;
+  export let setPoaExecutor = '';
+  export let setPoaLabel = '';
+  export let setPoaError = '';
+  export let setPoaSaving = false;
 
   export let onDeploySafeSuccess: (params: {
     safeAddress: string;
@@ -78,6 +87,9 @@
   export let onDeployPactoGov: () => void = () => {};
   export let onDeploySafe: () => void = () => {};
   export let onImportSafe: () => void = () => {};
+  export let onImportPoa: () => void = () => {};
+  export let onConfirmSetPoa: () => void | Promise<void> = () => {};
+  export let onCloseSetPoa: () => void = () => {};
 
   let DeploySafeModalComponent: Component | null = null;
   let DeployNaveWizardComponent: Component | null = null;
@@ -144,6 +156,7 @@
     {hasPactoGov}
     {hasSquadAdmin}
     {vaultSafeCount}
+    {hasPoa}
     hasAnnouncementsChannel={!!announcementsGroupId}
     onClose={onCloseLaunchpad}
     onDeploySponsor={onDeploySponsor}
@@ -151,6 +164,7 @@
     onDeployPactoGov={onDeployPactoGov}
     onDeploySafe={onDeploySafe}
     onImportSafe={onImportSafe}
+    onImportPoa={onImportPoa}
   />
 {/if}
 
@@ -218,6 +232,57 @@
         <button type="button" class="btn-secondary" on:click={onCloseSetSafe} disabled={setSafeSaving}>Cancel</button>
         <button type="button" class="btn-primary" on:click={onConfirmSetSafe} disabled={setSafeSaving}
           >{setSafeSaving ? 'Saving…' : 'Add to treasury'}</button
+        >
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if showSetPoaModal}
+  <div class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="set-poa-title">
+    <div class="modal-content">
+      <h3 id="set-poa-title">Link POA org</h3>
+      <p class="modal-desc">
+        Connect an existing on-chain POA (POP protocol) organization. Enter its org id; the link is
+        recorded for this squad and announced to members.
+      </p>
+      <label class="modal-field-label" for="import-poa-org">Org id (bytes32)</label>
+      <input
+        id="import-poa-org"
+        type="text"
+        class="input-address"
+        placeholder="0x… (64 hex chars)"
+        bind:value={setPoaOrgId}
+        aria-invalid={setPoaError ? 'true' : undefined}
+        aria-describedby={setPoaError ? 'set-poa-error' : undefined}
+      />
+      <label class="modal-field-label" for="import-poa-chain">Network</label>
+      <ChainIdSelect id="import-poa-chain" bind:value={setPoaChain} disabled={setPoaSaving} />
+      <label class="modal-field-label" for="import-poa-executor">Executor address (optional)</label>
+      <input
+        id="import-poa-executor"
+        type="text"
+        class="input-address"
+        placeholder="0x..."
+        bind:value={setPoaExecutor}
+      />
+      <label class="modal-field-label" for="import-poa-label">Label (optional)</label>
+      <input
+        id="import-poa-label"
+        type="text"
+        class="input-address"
+        placeholder="e.g. Main DAO"
+        bind:value={setPoaLabel}
+      />
+      {#if setPoaError}
+        <p id="set-poa-error" class="input-error" role="alert">{setPoaError}</p>
+      {/if}
+      <div class="modal-actions">
+        <button type="button" class="btn-secondary" on:click={onCloseSetPoa} disabled={setPoaSaving}
+          >Cancel</button
+        >
+        <button type="button" class="btn-primary" on:click={onConfirmSetPoa} disabled={setPoaSaving}
+          >{setPoaSaving ? 'Linking…' : 'Link POA org'}</button
         >
       </div>
     </div>

--- a/src/components/parent/governance/LaunchpadModal.svelte
+++ b/src/components/parent/governance/LaunchpadModal.svelte
@@ -5,6 +5,7 @@
   export let hasPactoGov: boolean;
   export let hasSquadAdmin: boolean;
   export let vaultSafeCount = 0;
+  export let hasPoa = false;
   export let hasAnnouncementsChannel: boolean;
   export let onClose: () => void;
   export let onDeploySponsor: () => void;
@@ -12,6 +13,7 @@
   export let onDeployPactoGov: () => void;
   export let onDeploySafe: () => void;
   export let onImportSafe: () => void;
+  export let onImportPoa: () => void = () => {};
 
   const titleId = 'launchpad-modal-title';
   const descId = 'launchpad-modal-desc';
@@ -137,6 +139,28 @@
           Import Safe
         </button>
       </div>
+    </li>
+
+    <li class="launchpad-card">
+      <h3 class="launchpad-card-title">POA (POP Governance)</h3>
+      <p class="launchpad-card-desc">
+        {#if hasPoa}
+          A POA organization is linked. Its on-chain modules are recorded for this squad.
+        {:else}
+          Link an existing on-chain POA (POP protocol) organization as a governance connector.
+        {/if}
+      </p>
+      <button
+        type="button"
+        class="btn-primary launchpad-card-btn"
+        disabled={channelBlocked || hasPoa}
+        on:click={() => {
+          onClose();
+          onImportPoa();
+        }}
+      >
+        {hasPoa ? 'POA linked' : 'Link POA org'}
+      </button>
     </li>
 
     <li class="launchpad-card launchpad-card--muted">

--- a/src/lib/governance/api.ts
+++ b/src/lib/governance/api.ts
@@ -82,6 +82,7 @@ export function infraTypeFromLegacyProvider(provider: string): string {
   if (p === 'pacto-gov') return 'pacto_gov';
   if (p === 'squad_sponsor') return 'sponsor';
   if (p === 'squad_admin' || p === 'squad-admin') return 'squad_admin';
+  if (p === 'poa' || p === 'poa_gov' || p === 'pop') return 'poa';
   return p;
 }
 
@@ -258,6 +259,36 @@ export function buildStandaloneSafeGovernanceAnnouncePayload(params: {
     parent_id: params.parentId,
     provider: 'gnosis_safe',
     canonical_ref: params.safeAddress,
+    chain: params.chain,
+    entry_id: params.entryId,
+    provider_payload: params.providerPayload,
+  };
+}
+
+/** Stable id for POA (POP protocol) governance infra row per parent. */
+export function poaInfraId(parentId: string): string {
+  return `poa-${parentId}`;
+}
+
+/** Wire payload for `governance_updated` when a POA (POP protocol) org is linked. */
+export function buildPoaGovernanceAnnouncePayload(params: {
+  parentId: string;
+  orgId: string;
+  chain: string;
+  providerPayload: string;
+  entryId: string;
+}): {
+  parent_id: string;
+  provider: 'poa';
+  canonical_ref: string;
+  chain: string;
+  entry_id: string;
+  provider_payload: string;
+} {
+  return {
+    parent_id: params.parentId,
+    provider: 'poa',
+    canonical_ref: params.orgId,
     chain: params.chain,
     entry_id: params.entryId,
     provider_payload: params.providerPayload,

--- a/src/lib/governance/poa-payload.test.ts
+++ b/src/lib/governance/poa-payload.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { buildPoaGovernanceAnnouncePayload, infraTypeFromLegacyProvider, poaInfraId } from './api';
+import {
+  buildPoaProviderPayload,
+  hasPoaInfra,
+  parsePoaProviderPayload,
+  poaInfraRow,
+} from './poa-payload';
+import type { SquadInfraDto } from './api';
+
+const PARENT = 'smoke-squad-poa';
+const ORG_ID = '0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069';
+const EXECUTOR = '0x4444444444444444444444444444444444444444';
+
+function row(overrides: Partial<SquadInfraDto>): SquadInfraDto {
+  return {
+    id: 'poa-x',
+    parentId: PARENT,
+    infraType: 'poa',
+    chain: 'gnosis',
+    canonicalRef: ORG_ID,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    ...overrides,
+  };
+}
+
+describe('poa provider payload', () => {
+  it('round-trips v1 fields', () => {
+    const raw = buildPoaProviderPayload({
+      orgId: ORG_ID,
+      executor: EXECUTOR,
+      label: 'Poa DAO',
+    });
+    const parsed = parsePoaProviderPayload(raw);
+    expect(parsed?.v).toBe(1);
+    expect(parsed?.org_id).toBe(ORG_ID);
+    expect(parsed?.executor).toBe(EXECUTOR);
+    expect(parsed?.label).toBe('Poa DAO');
+  });
+
+  it('omits empty optional fields', () => {
+    const parsed = parsePoaProviderPayload(buildPoaProviderPayload({ orgId: ORG_ID }));
+    expect(parsed?.org_id).toBe(ORG_ID);
+    expect(parsed?.executor).toBeUndefined();
+  });
+
+  it('returns null on garbage or empty input', () => {
+    expect(parsePoaProviderPayload('not json')).toBeNull();
+    expect(parsePoaProviderPayload('')).toBeNull();
+    expect(parsePoaProviderPayload(undefined)).toBeNull();
+  });
+});
+
+describe('poa infra row selectors', () => {
+  it('finds and reports the poa row', () => {
+    const rows = [row({ infraType: 'sponsor' }), row({ infraType: 'poa' })];
+    expect(poaInfraRow(rows)?.infraType).toBe('poa');
+    expect(hasPoaInfra(rows)).toBe(true);
+    expect(hasPoaInfra([row({ infraType: 'sponsor' })])).toBe(false);
+  });
+});
+
+describe('poa governance_updated announce payload (A4 wire shape)', () => {
+  it('uses orgId as canonical_ref and poa provider slug', () => {
+    const entryId = poaInfraId(PARENT);
+    const payload = buildPoaGovernanceAnnouncePayload({
+      parentId: PARENT,
+      orgId: ORG_ID,
+      chain: 'gnosis',
+      providerPayload: '{"v":1}',
+      entryId,
+    });
+    expect(payload.provider).toBe('poa');
+    expect(payload.canonical_ref).toBe(ORG_ID);
+    expect(payload.entry_id).toBe(entryId);
+    // Provider slug + aliases must map to the same infra_type the Rust allowlist canonicalizes to.
+    expect(infraTypeFromLegacyProvider(payload.provider)).toBe('poa');
+    expect(infraTypeFromLegacyProvider('poa_gov')).toBe('poa');
+    expect(infraTypeFromLegacyProvider('pop')).toBe('poa');
+  });
+});

--- a/src/lib/governance/poa-payload.ts
+++ b/src/lib/governance/poa-payload.ts
@@ -1,0 +1,72 @@
+import type { SquadInfraDto } from './api';
+
+/**
+ * Parsed `provider_payload` v1 from a POA (POP protocol) governance infra row.
+ *
+ * POA orgs are deployed by `OrgDeployer.deployFullOrg` and addressed by a native
+ * `orgId` (bytes32). The connector records the org's module addresses so the
+ * dashboard can link out / read on-chain state without re-querying the deployer.
+ */
+export interface PoaProviderPayloadV1 {
+  v?: number;
+  org_id?: string;
+  executor?: string;
+  hybrid_voting?: string;
+  direct_democracy_voting?: string;
+  participation_token?: string;
+  task_manager?: string;
+  payment_manager?: string;
+  label?: string;
+}
+
+export function parsePoaProviderPayload(
+  raw: string | null | undefined,
+): PoaProviderPayloadV1 | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as PoaProviderPayloadV1;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildPoaProviderPayload(params: {
+  orgId: string;
+  executor?: string;
+  hybridVoting?: string;
+  directDemocracyVoting?: string;
+  participationToken?: string;
+  taskManager?: string;
+  paymentManager?: string;
+  label?: string;
+}): string {
+  return JSON.stringify({
+    v: 1,
+    org_id: params.orgId.trim(),
+    ...(params.executor?.trim() ? { executor: params.executor.trim() } : {}),
+    ...(params.hybridVoting?.trim() ? { hybrid_voting: params.hybridVoting.trim() } : {}),
+    ...(params.directDemocracyVoting?.trim()
+      ? { direct_democracy_voting: params.directDemocracyVoting.trim() }
+      : {}),
+    ...(params.participationToken?.trim()
+      ? { participation_token: params.participationToken.trim() }
+      : {}),
+    ...(params.taskManager?.trim() ? { task_manager: params.taskManager.trim() } : {}),
+    ...(params.paymentManager?.trim() ? { payment_manager: params.paymentManager.trim() } : {}),
+    ...(params.label?.trim() ? { label: params.label.trim() } : {}),
+  });
+}
+
+export function poaInfraRows(rows: SquadInfraDto[] | undefined): SquadInfraDto[] {
+  return rows?.filter((r) => r.infraType === 'poa') ?? [];
+}
+
+/** POA infra row for a parent, if any. */
+export function poaInfraRow(rows: SquadInfraDto[] | undefined): SquadInfraDto | null {
+  return rows?.find((r) => r.infraType === 'poa') ?? null;
+}
+
+export function hasPoaInfra(rows: SquadInfraDto[] | undefined): boolean {
+  return poaInfraRow(rows) != null;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -130,6 +130,8 @@
     buildSquadAdminGovernanceAnnouncePayload,
     squadAdminInfraId,
     pactoGovTreasuryEntryId,
+    poaInfraId,
+    buildPoaGovernanceAnnouncePayload,
     primaryGovernanceView,
   } from '../lib/governance/api';
   import {
@@ -137,6 +139,7 @@
     isPactoGovTreasurySafe,
     pactoGovPayloadFromInfra,
   } from '../lib/governance/standalone-safe-payload';
+  import { buildPoaProviderPayload } from '../lib/governance/poa-payload';
   import { resolveAutomatedAnnounceGroupId } from '../lib/parent-navbar';
   import { resolveHubChannelNameForGroupSelection } from '../lib/mls/virtual-channel-bucket';
   import { resolveOpenHubParent, syncSquadsHubSelection, resolveEffectiveHubChannel, parentIdForChannelGroup } from '../lib/squad-hub-nav';
@@ -409,6 +412,50 @@
             sponsorAddress: params.sponsorAddress,
             chain: params.chain,
             providerPayload: params.providerPayload,
+            entryId,
+          }),
+        }),
+        '',
+        { virtualBucket: 'announcements' },
+      );
+    }
+    await mergeSquadInfraForParent(params.parentId);
+  }
+
+  /** Persist a linked POA (POP protocol) org infra row and announce it to the squad. */
+  async function finalizePoaLink(params: {
+    parentId: string;
+    chain: string;
+    orgId: string;
+    executor?: string;
+    label?: string;
+  }) {
+    const entryId = poaInfraId(params.parentId);
+    const providerPayload = buildPoaProviderPayload({
+      orgId: params.orgId,
+      executor: params.executor,
+      label: params.label,
+    });
+    await upsertSquadInfra({
+      id: entryId,
+      parentId: params.parentId,
+      infraType: 'poa',
+      chain: params.chain,
+      canonicalRef: params.orgId,
+      providerPayload,
+    });
+    const row = get(squads).find((s: Squad) => s.id === params.parentId);
+    const gid = row ? resolveAutomatedAnnounceGroupId(row) : null;
+    if (gid) {
+      await sendDmMessage(
+        gid,
+        buildAnnounceContent({
+          type: ANNOUNCE_TYPE_GOVERNANCE_UPDATED,
+          payload: buildPoaGovernanceAnnouncePayload({
+            parentId: params.parentId,
+            orgId: params.orgId,
+            chain: params.chain,
+            providerPayload,
             entryId,
           }),
         }),
@@ -1090,6 +1137,7 @@
               onPactoGovDeployComplete={finalizePactoGovDeploy}
               onSponsorDeployComplete={finalizeSponsorDeploy}
               onSquadAdminDeployComplete={finalizeSquadAdminDeploy}
+              onPoaLinkComplete={finalizePoaLink}
             />
             {/key}
           {:else if showMlsChatView}


### PR DESCRIPTION
## Summary

Pacto's ModPol design treats governance frameworks as **pluggable modules** (Nave Pirata is the in-house one; Governor Bravo / Moloch-style adapters are named as future UX connectors). This PR adds **POA (the POP protocol)** as one of those pluggable providers.

Before this change, a squad could only record in-house infra (`sponsor`, `pacto_gov`, `squad_admin`, `standalone_safe`). After it, a squad can **link an existing on-chain POA organization**: it is persisted as a `squad_infra` row keyed by the POA `orgId`, surfaced in the Deploy launchpad, and synced to peers over the `governance_updated` announce — exactly like the `standalone_safe` link/import connector.

This is a **read-only connector** (link/import), not a contract bridge. POA's `Executor` (`execute(proposalId, Call[])`, single `allowedCaller`) is not a Zodiac/Safe module, so it cannot drive a Pacto Safe; the deep integration (a POA deploy command, live proposal reads via the POA subgraph, or a Hats→SquadAdmin ACL bridge) is intentionally left as follow-up.

## Changes

- **Backend allowlist** (`src-tauri/src/db.rs`): `normalize_infra_type` accepts `poa` (aliases `poa_gov` / `pop`) so local upserts **and** peer `governance_updated` announces are not silently dropped.
- **Provider data layer** (`src/lib/governance/poa-payload.ts`): versioned `provider_payload` parse/build carrying `org_id` + module addresses, plus row selectors — mirroring `standalone-safe-payload.ts`.
- **Wire helpers** (`src/lib/governance/api.ts`): `poaInfraId`, `buildPoaGovernanceAnnouncePayload` (canonical_ref = `orgId`), and a `poa` arm in `infraTypeFromLegacyProvider` (alias set kept identical to the Rust allowlist).
- **UI**: a "Link POA org" card in `LaunchpadModal`, an import modal in `ParentDashboardModals`, `hasPoa` + handlers in `ParentDashboard`, and a `finalizePoaLink` orchestrator in `+page.svelte` (upsert → announce → sync). The link is not gated behind the squad sponsor since it spends no gas.

## Test plan

- `pnpm test` — 367 pass, including new `src/lib/governance/poa-payload.test.ts` (payload round-trip, null-on-garbage, and A4 `governance_updated` wire shape; asserts the `poa`/`poa_gov`/`pop` slugs all map to the `poa` infra_type the Rust allowlist canonicalizes to).
- `pnpm check` — 0 errors.
- `pnpm lint` — no new errors introduced (identical count to `main`).
- `cargo check` (src-tauri) — clean.

## Notes

Opened as a **draft** from a fork for maintainer review of scope/UX before merge. Happy to adjust the provider slug, canonical anchor (currently `orgId`; could be the `Executor` address), or gate the card behind the sponsor if you prefer consistency with the other providers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
