### PR TITLE
fix(ci): make landing deployment workflow deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-landing.yaml
+++ b/.github/workflows/deploy-landing.yaml
@@ -44,10 +44,12 @@ jobs:
         run: node scripts/generate-release-manifest.mjs
 
       - name: Build Astro landing site
-        uses: withastro/action@v6
+        run: pnpm --filter pacto-landing build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: landing
-          package-manager: pnpm@11.7.0
+          path: landing/dist
 
   deploy:
     needs: build


### PR DESCRIPTION
Fixes the Deploy landing site workflow so the Astro landing site builds and deploys to GitHub Pages.

Changes:
- Grant the build job `pages: write` and `id-token: write` so it can upload the Pages artifact.
- Replace `withastro/action` with explicit `pnpm --filter pacto-landing build` and `actions/upload-pages-artifact@v3` steps. The convenience action's post-build cache cleanup repeatedly failed in our pnpm workspace setup because `landing/node_modules/.astro` does not exist.
- The release manifest generator was already fixed on `main` to fall back to the latest release when run from a branch dispatch.

Verification:
- Build job now completes and uploads the `github-pages` artifact.
- Deploy job requires the `github-pages` environment; after this merges to `main` the environment protection rules will allow the deployment.