### PR TITLE
fix: persist peer roster EVM shares from announcements

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -2783,8 +2783,9 @@ pub async fn replay_automation_side_effects_for_chat<R: Runtime>(
 }
 
 /// Applies treasury (`squad_safe_updated`), governance (`governance_updated`), and roster EVM (`squad_member_evm_share`)
-/// side effects when the MLS chat row is classified into the **inbox** virtual bucket (routing ADR).
+/// side effects when the MLS chat row is classified into virtual buckets (routing ADR).
 /// Squad sponsor `governance_updated` announces also ingest from **announcements** so all members sync infra.
+/// Roster EVM shares are routed to **announcements** (ADR rule 6) and must upsert here — not only under `inbox`.
 /// `chat_id` is the MLS group id (squad announcements id); payload parent ids must match it.
 pub fn apply_inbox_virtual_bucket_side_effects<R: Runtime>(
     handle: &AppHandle<R>,
@@ -2807,12 +2808,19 @@ pub fn apply_inbox_virtual_bucket_side_effects<R: Runtime>(
         maybe_upsert_governance_from_announce(handle, content, chat_id, author_npub);
     }
 
+    // `squad_member_evm_share` is announcements-bucket traffic; apply regardless of inbox gate.
+    if effective_bucket == Some("announcements")
+        || effective_bucket == Some("inbox")
+        || effective_bucket.is_none()
+    {
+        try_apply_squad_member_evm_share(handle, content, chat_id, author_npub);
+    }
+
     if effective_bucket == Some("announcements") || effective_bucket.is_none() {
         try_apply_squad_bot_meta(handle, content, chat_id);
     }
 
     if effective_bucket == Some("inbox") {
-        try_apply_squad_member_evm_share(handle, content, chat_id, author_npub);
         apply_parent_safe_announce(handle, content, chat_id, author_npub);
         maybe_upsert_governance_from_announce(handle, content, chat_id, author_npub);
         try_apply_squad_contract_allowlist_announce(handle, content, chat_id, author_npub);

--- a/src/lib/app/tauri-subscriptions.test.ts
+++ b/src/lib/app/tauri-subscriptions.test.ts
@@ -90,6 +90,7 @@ vi.mock('../api/nostr', () => ({
 vi.mock('../announcements', () => ({
   parseAnnouncement: (...args: unknown[]) => mocks.mockFunctions.parseAnnouncement(...args),
   ANNOUNCE_TYPE_GOVERNANCE_UPDATED: 'governance_updated',
+  ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE: 'squad_member_evm_share',
 }));
 
 vi.mock('../wallet/dm-messages', () => ({
@@ -169,6 +170,7 @@ function dmMessage(overrides: Partial<DmMessage> = {}) {
 const handlers: AppEventHandlers = {
   mergeTreasurySafesForParent: vi.fn(),
   mergeSquadInfraForParent: vi.fn(),
+  mergeSquadMemberEvmForAnnouncementsGroup: vi.fn(),
 };
 
 describe('subscribeAppEvents', () => {
@@ -451,6 +453,18 @@ describe('subscribeAppEvents', () => {
       unsubscribe = subscribeAppEvents(handlers);
       emit('mls_message_new', { group_id: 'g1', message: dmMessage() });
       expect(handlers.mergeSquadInfraForParent).toHaveBeenCalledWith('p1');
+    });
+
+    it('merges roster EVM on squad_member_evm_share', () => {
+      mocks.mockFunctions.parseAnnouncement.mockReturnValue({
+        type: 'squad_member_evm_share',
+        payload: { parent_id: 'announcements-mls', evm_address: '0xabc' },
+      });
+      unsubscribe = subscribeAppEvents(handlers);
+      emit('mls_message_new', { group_id: 'announcements-mls', message: dmMessage() });
+      expect(handlers.mergeSquadMemberEvmForAnnouncementsGroup).toHaveBeenCalledWith(
+        'announcements-mls',
+      );
     });
 
     it('updates channel name when group_name provided', () => {

--- a/src/lib/app/tauri-subscriptions.ts
+++ b/src/lib/app/tauri-subscriptions.ts
@@ -1,6 +1,6 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { listPendingMlsWelcomes, fetchMessages, parseSquadInviteMessage, syncMlsGroupsNow } from '../api/nostr';
-import { parseAnnouncement, ANNOUNCE_TYPE_GOVERNANCE_UPDATED } from '../announcements';
+import { parseAnnouncement, ANNOUNCE_TYPE_GOVERNANCE_UPDATED, ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE } from '../announcements';
 import { parseWalletTxAnnouncement, walletTxAnnouncementHash } from '../wallet/dm-messages';
 import {
   isPactoAppRoutableInviteContent,
@@ -33,6 +33,8 @@ const TYPING_EXPIRY_SEC = 15;
 export interface AppEventHandlers {
   mergeTreasurySafesForParent: (parentId: string) => void;
   mergeSquadInfraForParent: (parentId: string) => void;
+  /** Refresh Crew roster EVM maps after a peer `squad_member_evm_share` (announcements MLS group id). */
+  mergeSquadMemberEvmForAnnouncementsGroup: (announcementsGroupId: string) => void;
 }
 
 function normalizeDmPayload(message: DmMessage): DmMessage {
@@ -202,6 +204,11 @@ export function subscribeAppEvents(handlers: AppEventHandlers): () => void {
       if (announce?.type === ANNOUNCE_TYPE_GOVERNANCE_UPDATED) {
         handlers.mergeSquadInfraForParent(announce.payload.parent_id);
       }
+      if (announce?.type === ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE) {
+        handlers.mergeSquadMemberEvmForAnnouncementsGroup(
+          announce.payload.parent_id || chat_id,
+        );
+      }
     }
   });
 
@@ -272,6 +279,11 @@ export function subscribeAppEvents(handlers: AppEventHandlers): () => void {
     }
     if (announce?.type === ANNOUNCE_TYPE_GOVERNANCE_UPDATED) {
       handlers.mergeSquadInfraForParent(announce.payload.parent_id);
+    }
+    if (announce?.type === ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE) {
+      handlers.mergeSquadMemberEvmForAnnouncementsGroup(
+        announce.payload.parent_id || group_id,
+      );
     }
     if (group_name) updateChannelNameIfPlaceholder(group_id, group_name);
   });

--- a/src/lib/dashboard/dashboard-data-sync.test.ts
+++ b/src/lib/dashboard/dashboard-data-sync.test.ts
@@ -5,7 +5,9 @@ import {
   squadMemberEvmByParentId,
   treasurySafesByParentId,
   squadInfraByParentId,
+  squads,
   type TreasurySafeEntry,
+  type Squad,
 } from '../../stores/squads';
 import {
   treasurySafesFetchMetaByParentId,
@@ -19,6 +21,7 @@ import {
   syncTreasurySafesForParent,
   syncSquadInfraForParent,
   syncSquadMemberEvmForParent,
+  syncSquadMemberEvmForAnnouncementsGroup,
   resetDashboardDataSyncInflight,
 } from './dashboard-data-sync';
 import { TREASURY_SAFES_CACHE_PREFIX } from './treasury-safes-cache';
@@ -29,6 +32,12 @@ import type { SquadInfraDto } from '../governance/api';
 vi.mock('../api/nostr');
 vi.mock('../governance/api');
 vi.mock('./parent-dashboard-loaders');
+vi.mock('../parent-navbar', () => ({
+  resolveAutomatedAnnounceGroupId: (parent: { id: string; channels?: { name: string; groupId: string }[] }) =>
+    parent.channels?.find((c) => c.name === 'announcements')?.groupId ??
+    parent.channels?.[0]?.groupId ??
+    null,
+}));
 
 const mockedListParentTreasurySafes = vi.mocked(listParentTreasurySafes);
 const mockedListSquadInfra = vi.mocked(listSquadInfra);
@@ -68,6 +77,7 @@ afterEach(() => {
   treasurySafesByParentId.set({});
   squadInfraByParentId.set({});
   squadMemberEvmByParentId.set({});
+  squads.set([]);
   clearDashboardFetchMetaStores();
   vi.unstubAllGlobals();
 });
@@ -299,6 +309,35 @@ describe('syncSquadMemberEvmForParent', () => {
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
     expect(parsed.byParentId[parentId]).toEqual([evmMap]);
+  });
+});
+
+describe('syncSquadMemberEvmForAnnouncementsGroup', () => {
+  it('refreshes matching squad parents keyed by catalog id', async () => {
+    mockedFetchSquadMemberEvmByNpub.mockResolvedValue(evmMap);
+    squads.set([
+      {
+        id: 'squad-catalog-id',
+        channels: [{ name: 'announcements', groupId: 'mls-announcements' }],
+      } as Squad,
+    ]);
+
+    await syncSquadMemberEvmForAnnouncementsGroup('mls-announcements');
+
+    expect(mockedFetchSquadMemberEvmByNpub).toHaveBeenCalledWith(
+      'squad-catalog-id',
+      'mls-announcements',
+    );
+    expect(get(squadMemberEvmByParentId)['squad-catalog-id']).toEqual(evmMap);
+  });
+
+  it('falls back to the group id when no squad matches', async () => {
+    mockedFetchSquadMemberEvmByNpub.mockResolvedValueOnce(evmMap);
+    squads.set([]);
+
+    await syncSquadMemberEvmForAnnouncementsGroup('orphan-group');
+
+    expect(mockedFetchSquadMemberEvmByNpub).toHaveBeenCalledWith('orphan-group', 'orphan-group');
   });
 });
 

--- a/src/lib/dashboard/dashboard-data-sync.ts
+++ b/src/lib/dashboard/dashboard-data-sync.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { currentUser } from '../../stores/auth';
-import { squadMemberEvmByParentId, treasurySafesByParentId, squadInfraByParentId } from '../../stores/squads';
+import { squads, squadMemberEvmByParentId, treasurySafesByParentId, squadInfraByParentId } from '../../stores/squads';
 import { listParentTreasurySafes } from '../api/nostr';
 import { listSquadInfra } from '../governance/api';
 import { fetchSquadMemberEvmByNpub } from './parent-dashboard-loaders';
@@ -8,6 +8,7 @@ import { persistTreasurySafesForParent, treasurySafesFetchedAtMs } from './treas
 import { persistSquadInfraForParent, squadInfraFetchedAtMs } from './squad-infra-cache';
 import { persistSquadMemberEvmForParent } from './squad-member-evm-cache';
 import { setSquadInfraFetchMeta, setTreasurySafesFetchMeta } from './dashboard-fetch-meta';
+import { resolveAutomatedAnnounceGroupId } from '../parent-navbar';
 
 const treasuryInflight = new Map<string, Promise<void>>();
 const infraInflight = new Map<string, Promise<void>>();
@@ -108,6 +109,21 @@ export async function syncSquadMemberEvmForParent(
 
   memberEvmInflight.set(parentId, p);
   return p;
+}
+
+/**
+ * Refresh roster EVM maps for every local squad/network whose #announcements MLS group is `groupId`.
+ * Wire `squad_member_evm_share.parent_id` is the announcements group id.
+ */
+export async function syncSquadMemberEvmForAnnouncementsGroup(groupId: string): Promise<void> {
+  const gid = groupId.trim();
+  if (!gid) return;
+  const parents = get(squads).filter((p) => resolveAutomatedAnnounceGroupId(p) === gid);
+  if (parents.length === 0) {
+    await syncSquadMemberEvmForParent(gid, gid);
+    return;
+  }
+  await Promise.all(parents.map((p) => syncSquadMemberEvmForParent(p.id, gid)));
 }
 
 /** Clears in-flight dedupe maps (e.g. on logout). */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -150,6 +150,7 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
   import {
     syncSquadInfraForParent as mergeSquadInfraForParent,
     syncTreasurySafesForParent as mergeTreasurySafesForParent,
+    syncSquadMemberEvmForAnnouncementsGroup as mergeSquadMemberEvmForAnnouncementsGroup,
   } from '../lib/dashboard/dashboard-data-sync';
   import {
     acceptSquadOrPairInvite,
@@ -901,6 +902,7 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
     return subscribeAppEvents({
       mergeTreasurySafesForParent,
       mergeSquadInfraForParent,
+      mergeSquadMemberEvmForAnnouncementsGroup,
     });
   });
 </script>


### PR DESCRIPTION
## Summary

Before: when a member shared their squad EVM key, only their own Crew tab updated. Peers kept showing **Not shared**, even though the share appeared in #announcements chat.

After: peers persist `squad_member_evm_share` into SQLite on MLS ingest and refresh Crew maps live.

Root cause: shares are routed to the **announcements** virtual bucket, but the upsert only ran under the **inbox** side-effect gate.

## Changes

- Apply `try_apply_squad_member_evm_share` for announcements (and missing-bucket) ingest.
- On `mls_message_new` / message update, refresh roster EVM maps for parents whose #announcements group matches.
- Unit coverage for the subscription + sync helpers.

Follow-up for the broader Nostr/MLS dashboard gossip audit: #102

## Test plan

- [x] `pnpm exec vitest run src/lib/app/tauri-subscriptions.test.ts src/lib/dashboard/dashboard-data-sync.test.ts`
- [ ] Two clients: A shares EVM → B’s Crew shows A’s address without restart (and vice versa)
- [ ] Optional: open #announcements and confirm share card still appears

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Made with [Cursor](https://cursor.com)