### PR TITLE
fix(updater): in-app Check for Updates with build introspection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,6 +175,9 @@ jobs:
         run: echo "CARGO_TARGET_DIR=C:\cargo-target" >> $env:GITHUB_ENV
 
       - name: install frontend dependencies
+        env:
+          VITE_COMMIT_HASH: ${{ github.sha }}
+          VITE_APP_VERSION: ${{ github.ref_name }}
         run: pnpm install --frozen-lockfile
 
       - uses: tauri-apps/tauri-action@v1
@@ -182,6 +185,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          VITE_COMMIT_HASH: ${{ github.sha }}
+          VITE_APP_VERSION: ${{ github.ref_name }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Pacto ${{ github.ref_name }}'

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ dev:
 	pnpm tauri dev
 
 build:
-	pnpm tauri build
+	# Tauri CLI 2.9.x misinterprets CI=1 as --ci=1 (boolean flags only accept
+	# true/false), so unset CI and pass --ci explicitly to skip prompts.
+	env -u CI pnpm tauri build --ci
 
 preview:
 	pnpm preview

--- a/docs/brainstorms/2026-07-17-in-app-check-for-updates-requirements.md
+++ b/docs/brainstorms/2026-07-17-in-app-check-for-updates-requirements.md
@@ -1,0 +1,118 @@
+---
+date: 2026-07-17
+topic: in-app-check-for-updates
+---
+
+# In-app Check for Updates
+
+## Summary
+
+Add an Updates panel in **Settings > App** where desktop users can see the installed version, check for new releases, download/install an update, and relaunch. Include an opt-in toggle (off by default) to run one update check automatically after the app unlocks. The feature uses the existing Tauri v2 updater backend and degrades gracefully outside release builds.
+
+## Problem Frame
+
+Alpha desktop builds already ship via GitHub Releases with the Tauri updater plugin configured on the backend, but there is no Settings UI that exposes update check/install to users. Alpha testers must re-download installers manually when a new build is published. This blocks a self-serve update path and slows the alpha feedback loop.
+
+## Key Decisions
+
+- **Updates control lives inside App settings.** A dedicated subsection under the existing App settings collapsible keeps the Settings nav compact while still making the control obvious.
+- **Prompt-to-relaunch after install.** The user confirms the restart rather than the app auto-relaunching, preserving control over the interruption.
+- **Disable the update control in dev builds with explanatory copy.** The control remains visible but inactive in `tauri dev`, with copy explaining that updates are only available in release builds.
+- **Startup check is opt-in and off by default.** This respects user choice and avoids surprise download prompts on first unlock.
+
+## Requirements
+
+### Settings UI
+
+- R1. Settings shows an **Updates** control inside the **App settings** section.
+- R2. The control displays the current installed version, e.g. `Current Version: v0.1.0`.
+- R3. The control provides a primary **Check for Updates** button.
+- R4. Tapping the button triggers a Tauri updater check and shows a status line: `Checking…`, `You’re on the latest version`, or `Update vX.Y.Z available`.
+
+### Manual update flow
+
+- R5. When an update is available, the UI shows the new version and lets the user start download and install.
+- R6. Download and install show progress to the user.
+- R7. After install completes, the app prompts the user to relaunch.
+- R8. Relaunching applies the installed update and starts the new version.
+
+### Startup check
+
+- R9. Settings offers an opt-in toggle to **Check for updates on startup**.
+- R10. The startup check toggle is **off by default**.
+- R11. When enabled, the app runs one update check after the user unlocks the app.
+- R12. If the startup check finds an update, it surfaces the same available-update UX as a manual check.
+- R13. The startup check runs at most once per app session.
+
+### Build handling and errors
+
+- R14. In dev builds, the update control is disabled with copy explaining that updates are only available in release builds.
+- R15. Network failures, signature mismatch, and missing platform assets surface via user-readable toasts rather than silent failures.
+
+### Operator docs
+
+- R16. Operator steps for publishing `latest.json` and configuring signing env vars are documented in `docs/`.
+
+## Key Flows
+
+### F1. Manual check
+
+- **Trigger:** User opens **Settings > App > Updates** and taps **Check for Updates**.
+- **Actors:** User, Tauri updater plugin.
+- **Steps:**
+  1. Read installed version from app metadata.
+  2. Call updater `check()`.
+  3. If no update: show `You’re on the latest version`.
+  4. If update available: show version and offer **Download & Install**.
+  5. On confirm: download and install with progress events.
+  6. On completion: prompt user to relaunch.
+  7. On relaunch confirm: call `relaunch()`.
+- **Outcome:** App restarts on the new version, or the user is confirmed as current.
+
+### F2. Startup check
+
+- **Trigger:** App unlocks and the user has enabled **Check for updates on startup**.
+- **Actors:** User, app lifecycle, Tauri updater plugin.
+- **Steps:**
+  1. After PIN unlock, run one updater check for the session.
+  2. If no update: do nothing (no toast).
+  3. If update available: present the same available-update UX as F1.
+- **Outcome:** User is notified of an update only when one exists.
+
+## Acceptance Examples
+
+- **AE1. No update available.** Given the user is on the latest release, when the user taps **Check for Updates**, then the status shows `You’re on the latest version` and no install prompt appears.
+- **AE2. Update available.** Given a newer release is published, when the user taps **Check for Updates**, then the available version is shown, the user can download/install with progress, and a relaunch prompt appears after install.
+- **AE3. Dev build.** Given the app is running in `tauri dev`, when the user opens **Settings > App > Updates**, then the update control is disabled and explains that updates are only available in release builds.
+- **AE4. Startup check off by default.** Given a fresh install or account, when the app unlocks, then no automatic update check occurs.
+- **AE5. Startup check opted in.** Given the user enabled **Check for updates on startup**, when the app unlocks, then one updater check runs and, if an update exists, the available-update UX appears.
+
+## Success Criteria
+
+- Manual smoke test passes: install build N, publish build N+1 to the release channel, and verify in-app update on macOS and one other desktop platform.
+- Settings shows version and update controls in an obvious location.
+- Release builds only; dev/web builds degrade gracefully without confusing testers.
+- Operator documentation is in `docs/`.
+
+## Scope Boundaries
+
+- **Deferred for later:**
+  - Android/iOS updater.
+  - Auto-check on startup without an explicit opt-in.
+  - Rich in-app release notes rendering beyond the metadata the updater already carries.
+
+## Dependencies / Assumptions
+
+- The Tauri updater plugin is already registered and configured in `src-tauri/src/lib.rs` and `src-tauri/tauri.conf.json`.
+- The desktop capability already grants `updater:default` in `src-tauri/capabilities/desktop.json`.
+- The frontend packages `@tauri-apps/plugin-updater` and `@tauri-apps/plugin-process` are already installed.
+- The updater manifest endpoint is `https://github.com/covenant-gov/pacto-app/releases/latest/download/latest.json` and release artifacts are signed with the configured pubkey.
+- The app has an unlock lifecycle event or equivalent hook on which to run the startup check.
+
+## Sources / Research
+
+- GitHub issue #70: `feat(settings): in-app Check for Updates for alpha desktop builds`
+- Tauri v2 Updater plugin documentation: https://v2.tauri.app/plugin/updater/
+- Tauri Updater JS API: https://v2.tauri.app/reference/javascript/updater/
+- Existing backend configuration: `src-tauri/tauri.conf.json`, `src-tauri/capabilities/desktop.json`, `src-tauri/src/lib.rs`
+- Existing Settings shell: `src/components/settings/AppSettingsSection.svelte`, `src/components/settings/SettingsPage.svelte`

--- a/docs/build/OPERATOR_UPDATES.md
+++ b/docs/build/OPERATOR_UPDATES.md
@@ -1,0 +1,69 @@
+# Operator Guide: In-App Updates
+
+The Pacto desktop app uses the Tauri v2 updater plugin. This document covers how release operators publish signed updates so the in-app **Check for Updates** flow can discover and install them.
+
+## What gets published
+
+The Tauri GitHub Action uploads platform installers and a `latest.json` manifest to the GitHub release. The app reads `latest.json` from:
+
+```
+https://github.com/covenant-gov/pacto-app/releases/latest/download/latest.json
+```
+
+That URL is configured in `src-tauri/tauri.conf.json` under `plugins.updater.endpoints`.
+
+## Release workflow
+
+1. Tag a release in the form `vX.Y.Z`, e.g. `v0.2.1`.
+2. Push the tag: `git push origin v0.2.1`.
+3. `.github/workflows/release.yaml` runs the `publish-tauri` job for:
+   - macOS (`aarch64-apple-darwin`, `x86_64-apple-darwin`)
+   - Linux (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`)
+   - Windows (`x86_64-pc-windows-msvc`)
+4. The workflow uploads installers and `latest.json` to the GitHub release.
+   - `uploadUpdaterJson: true` tells the Tauri action to generate and attach `latest.json`.
+
+## Signing key
+
+The updater requires an Ed25519 key pair. The public key is embedded in `src-tauri/tauri.conf.json` at `plugins.updater.pubkey`. The private key is used at build time to sign the update bundles.
+
+Set the private key as a repository secret **and never commit it to source control or expose it in the frontend bundle**:
+
+- **Secret name:** `TAURI_SIGNING_PRIVATE_KEY`
+- **Optional password secret:** `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+
+The release job reads these secrets in the `tauri-apps/tauri-action` step:
+
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+```
+
+### Generating the key pair
+
+If you need to rotate or create the updater signing key:
+
+```bash
+tauri signer generate
+```
+
+Save the public key for `tauri.conf.json` and store the private key in the repository secret.
+
+## Manual smoke test
+
+1. Build and install a signed release for the current platform, e.g. `v0.2.0`.
+2. Push a new tag `v0.2.1` and wait for the release workflow to complete.
+3. Open the installed `v0.2.0` app, go to **Settings > App > Updates**, and click **Check for Updates**.
+4. Confirm the app reports `Update 0.2.1 available`.
+5. Click **Download and install**, wait for the progress bar to complete, and click **Relaunch now**.
+6. After restart, verify the app is running the new version (shown in the same Updates section).
+
+Repeat on at least one additional desktop platform before promoting a release broadly.
+
+## Troubleshooting
+
+- **No update found when one exists:** verify the tag, the release workflow completion, and that `latest.json` is attached to the release.
+- **Signature mismatch:** confirm the public key in `tauri.conf.json` matches the private key used to sign the release.
+- **Missing platform asset:** the workflow must produce an installer for the running platform. Check the release assets and platform matrix in `.github/workflows/release.yaml`.

--- a/docs/plans/2026-07-17-001-feat-in-app-check-for-updates-plan.md
+++ b/docs/plans/2026-07-17-001-feat-in-app-check-for-updates-plan.md
@@ -1,0 +1,222 @@
+---
+title: feat: in-app Check for Updates
+type: feat
+date: 2026-07-17
+origin: docs/brainstorms/2026-07-17-in-app-check-for-updates-requirements.md
+---
+
+# In-app Check for Updates
+
+## Summary
+
+Add a frontend-only updater layer on top of the already-wired Tauri v2 updater plugin. The work introduces an updater service, an npub-scoped opt-in startup-check preference, shared update UI components, and an Updates subsection inside **Settings > App**. No Rust backend changes are needed.
+
+## Problem Frame
+
+Alpha desktop builds ship via GitHub Releases with the Tauri updater already configured, but testers have no in-app way to discover or install updates. They must re-download installers manually, which blocks a self-serve update path.
+
+## Requirements
+
+Carried forward from the origin doc. R-IDs are stable.
+
+### Settings UI
+
+- R1. Settings shows an **Updates** control inside the **App settings** section.
+- R2. The control displays the current installed version.
+- R3. The control provides a primary **Check for Updates** button.
+- R4. Tapping the button triggers a Tauri updater check and shows a status line: `Checking…`, `You’re on the latest version`, or `Update vX.Y.Z available`.
+
+### Manual update flow
+
+- R5. When an update is available, the UI shows the new version and lets the user start download and install.
+- R6. Download and install show progress to the user.
+- R7. After install completes, the app prompts the user to relaunch.
+- R8. Relaunching applies the installed update and starts the new version.
+
+### Startup check
+
+- R9. Settings offers an opt-in toggle to **Check for updates on startup**.
+- R10. The startup check toggle is **off by default**.
+- R11. When enabled, the app runs one update check after the user unlocks the app.
+- R12. If the startup check finds an update, it surfaces the same available-update UX as a manual check.
+- R13. The startup check runs at most once per app session.
+
+### Build handling and errors
+
+- R14. In dev builds, the update control is disabled with copy explaining that updates are only available in release builds.
+- R15. Network failures, signature mismatch, and missing platform assets surface via user-readable toasts rather than silent failures.
+
+### Operator docs
+
+- R16. Operator steps for publishing `latest.json` and configuring signing env vars are documented in `docs/`.
+
+## Key Technical Decisions
+
+- **Frontend-only updater service.** The Tauri v2 updater plugin is already registered and the desktop capability already grants `updater:default`, so the feature calls `@tauri-apps/plugin-updater` and `@tauri-apps/plugin-process` directly from the frontend. No new Rust command is needed.
+- **Shared update state in a Svelte store.** Both the Settings panel and the startup-check modal subscribe to the same `updateStatus` store so the available-update UX, progress, and errors are consistent wherever they appear.
+- **Startup check fires from `src/lib/app/post-login-sync.ts`.** This reuses the existing non-blocking post-unlock hook and runs after `loadAccountState` has set the npub-scoped persistence context.
+- **Startup-check opt-in is npub-scoped localStorage.** Follows the existing `persistenceKey(prefix)` pattern so the preference is tied to the account and cleared on logout.
+- **Dev builds degrade via `import.meta.env.DEV`.** The service short-circuits to a disabled state with user-facing copy; no runtime backend detection is required.
+- **Startup-found updates surface in a global modal.** This gives the user an immediate action surface without requiring navigation to Settings first.
+
+## Implementation Units
+
+### U1. Create updater service module
+
+- **Goal:** Wrap Tauri plugin-updater `check()` and `downloadAndInstall()`, plus plugin-process `relaunch()`, and expose a shared `updateStatus` store.
+- **Requirements:** R4, R5, R6, R7, R8, R14, R15.
+- **Dependencies:** None.
+- **Files:**
+  - `src/lib/updater/update-check.ts` (new)
+  - `src/lib/updater/update-check.test.ts` (new)
+- **Approach:**
+  - Define a status store with states: `idle`, `checking`, `no-update`, `available`, `downloading`, `installing`, `error`, `dev-disabled`.
+  - `checkForUpdates()` guards on `import.meta.env.DEV` and sets `dev-disabled` in dev. In release builds it calls `check()` from `@tauri-apps/plugin-updater`, reads the installed version via `getVersion()` from `@tauri-apps/api/app`, and transitions the store to `no-update` or `available`.
+  - `downloadAndInstallUpdate()` calls `downloadAndInstall()` on the returned update with a progress callback that updates the store. On completion it raises a relaunch prompt by setting a separate `relaunchPending` flag in the store.
+  - `relaunchApp()` calls `relaunch()` from `@tauri-apps/plugin-process`.
+  - Errors are caught, mapped to user-facing messages, stored in the status, and surfaced via `showToast` so startup-check failures are not silent.
+- **Patterns to follow:** Existing wrapper modules in `src/lib/api/*` for typed Tauri command patterns; `src/stores/toast.ts` for error surfacing.
+- **Test scenarios:**
+  - Covers AE3. Dev build: `checkForUpdates` sets `dev-disabled` and never calls the plugin.
+  - Covers AE1. No update available: mocked `check()` returns no update; status becomes `no-update`.
+  - Covers AE2. Update available: mocked `check()` returns an update; status becomes `available` with the target version.
+  - Download/install progress: mocked `downloadAndInstall()` emits progress events; status transitions through `downloading`/`installing`.
+  - Error paths: network failure, signature mismatch, and missing platform asset each set `error` status and call `showToast`.
+  - Relaunch: `relaunchApp` invokes the process plugin relaunch function.
+- **Verification:** Unit tests pass and the service exposes a clean public API with no leaked plugin internals.
+
+### U2. Create startup-check preference store
+
+- **Goal:** Persist the opt-in startup-check toggle per account and track whether the check has already run this session.
+- **Requirements:** R9, R10, R11, R13.
+- **Dependencies:** None.
+- **Files:**
+  - `src/stores/startup-check.ts` (new)
+  - `src/stores/startup-check.test.ts` (new)
+  - `src/lib/utils/clear-account-state.ts` (add prefix)
+  - `src/stores/persistence.ts` (read preference on account load)
+- **Approach:**
+  - Writable store `startupCheckEnabled` defaults to `false`.
+  - On `loadAccountState(npub)`, read `persistenceKey(STARTUP_CHECK_PREFIX)` and seed the store.
+  - Subscribe to the store and persist changes to the npub-scoped key.
+  - Add `STARTUP_CHECK_PREFIX` to `SCOPED_KEY_PREFIXES` in `clear-account-state.ts` so logout clears it.
+  - Keep a module-level `hasRunStartupCheckThisSession` flag that resets on app restart (no persistence).
+- **Patterns to follow:** `src/stores/theme.ts` for localStorage persistence; `src/stores/navigation.ts` for `persistenceKey` usage; `src/stores/dm.ts` for npub-scoped read on load.
+- **Test scenarios:**
+  - Default off when no persisted value exists.
+  - Persists `enabled` state per npub and clears it on logout.
+  - `hasRunStartupCheckThisSession` is false at import time, true after `markStartupCheckRun()`, and only resets on app restart.
+  - Subscription writes only when persistence context is set.
+- **Verification:** Unit tests pass; `clearAccountState` removes the startup-check key for the logged-out npub.
+
+### U3. Wire startup check trigger
+
+- **Goal:** Run one update check after unlock when the user has opted in.
+- **Requirements:** R11, R12, R13.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `src/lib/app/post-login-sync.ts` (modify)
+- **Approach:**
+  - After the existing post-login sync tasks, check `startupCheckEnabled` and `hasRunStartupCheckThisSession`.
+  - If enabled, not yet run, and not in dev, call `checkForUpdates()` from U1 and mark the session as checked.
+  - Do not block on the result; failures are already surfaced as toasts by U1.
+  - If an update is found, the global modal from U4 appears automatically because it subscribes to the shared store.
+- **Patterns to follow:** Existing async fire-and-forget shape inside `runPostLoginNetworkSync`.
+- **Test scenarios:**
+  - Does not run when the preference is disabled.
+  - Does not run when the session has already been checked.
+  - Does not run in dev builds.
+  - Runs exactly once when enabled in a release build.
+  - When an update is found, the shared status store becomes `available` (modal handled in U4).
+- **Verification:** Manual smoke test confirms a startup check runs once after PIN unlock when the toggle is on.
+
+### U4. Create shared update-available UI components
+
+- **Goal:** Provide a reusable panel and modal so the available-update UX is the same in Settings and after a startup check.
+- **Requirements:** R5, R6, R7, R12.
+- **Dependencies:** U1.
+- **Files:**
+  - `src/components/updater/UpdateAvailablePanel.svelte` (new)
+  - `src/components/updater/UpdateAvailableModal.svelte` (new)
+  - `src/routes/+page.svelte` (mount modal)
+- **Approach:**
+  - `UpdateAvailablePanel` reads `updateStatus` and renders the available version, install button, progress, and any error. It calls `downloadAndInstallUpdate()` and `relaunchApp()` from U1.
+  - `UpdateAvailableModal` wraps the panel in `src/components/ui/Modal.svelte` and opens when `updateStatus` is `available` or `relaunchPending`.
+  - Mount `UpdateAvailableModal` in `src/routes/+page.svelte` next to the existing toast portal and global modals so it can appear regardless of the active view.
+- **Patterns to follow:** `src/components/ui/Modal.svelte` usage in `src/components/commons/BroadcastSquadModal.svelte`.
+- **Test scenarios:**
+  - Panel renders version and an enabled install button when status is `available`.
+  - Panel disables the install button and shows progress when status is `downloading` or `installing`.
+  - Panel shows the error state when status is `error`.
+  - Modal opens when status becomes `available` and closes on dismiss.
+  - Modal remains open during download/install so progress is visible.
+- **Verification:** UI review confirms the modal and panel render consistently and the install/relaunch flow works end to end.
+
+### U5. Add Updates UI to App settings
+
+- **Goal:** Add the version display, manual check button, status line, startup toggle, and dev-build disabled copy inside **Settings > App**.
+- **Requirements:** R1, R2, R3, R4, R9, R14.
+- **Dependencies:** U1, U2, U4.
+- **Files:**
+  - `src/components/settings/AppSettingsSection.svelte` (modify)
+- **Approach:**
+  - Add a new subsection under the existing Appearance section in `AppSettingsSection`.
+  - Display the installed version from U1.
+  - Render a primary **Check for Updates** button that calls `checkForUpdates()`.
+  - Show the status line based on `updateStatus`.
+  - Render `UpdateAvailablePanel` inline when status is `available`.
+  - Add a checkbox toggle bound to `startupCheckEnabled`.
+  - In dev builds, disable the check button and show copy explaining updates are release-only.
+- **Patterns to follow:** Existing `AppSettingsSection` radio-group layout; `src/components/ui/Modal.svelte` for modal usage; `src/stores/toast.ts` for transient status.
+- **Test scenarios:**
+  - Renders the current installed version.
+  - Clicking **Check for Updates** transitions status to `checking`.
+  - Toggling startup check persists the preference.
+  - Dev build disables the button and shows explanatory copy.
+  - When an update is available, the inline panel appears with install action.
+- **Verification:** Manual review in dev and release builds confirms the control behaves as specified.
+
+### U6. Document operator steps
+
+- **Goal:** Provide runbook for publishing the updater manifest and configuring signing.
+- **Requirements:** R16.
+- **Dependencies:** None.
+- **Files:**
+  - `docs/build/OPERATOR_UPDATES.md` (new)
+- **Approach:**
+  - Explain how `latest.json` is produced by the release workflow.
+  - Document the `TAURI_SIGNING_PRIVATE_KEY` environment variable and how it is used.
+  - Include manual smoke-test steps: install build N, publish build N+1, verify in-app update on macOS and one other desktop platform.
+- **Test expectation:** none — documentation-only unit.
+- **Verification:** Doc is present in `docs/build/` and contains enough detail for a release operator to produce a signed update.
+
+## Scope Boundaries
+
+- **Deferred for later:**
+  - Android/iOS updater.
+  - Auto-check on startup without an explicit opt-in.
+  - Rich in-app release notes rendering beyond the metadata the updater already carries.
+- **Deferred to follow-up work:**
+  - Add a global "check for updates on launch" option before PIN unlock.
+  - Show detailed per-platform asset status in the UI.
+
+## Risks & Dependencies
+
+- **Signing key handling.** The release workflow already consumes `TAURI_SIGNING_PRIVATE_KEY`; the operator doc must make it clear this key must stay out of source control and out of the frontend bundle.
+- **Dev vs release behavior mismatch.** Because dev builds short-circuit, the real update flow can only be verified in a release build. The smoke test in the success criteria is required.
+- **Updater plugin API churn.** The feature is the first frontend caller of `@tauri-apps/plugin-updater`. If the plugin API changes in a future Tauri update, the service module is the single place to adapt.
+- **Startup check timing.** The check must run only after `loadAccountState` sets the persistence context. The chosen hook (`post-login-sync`) already runs after that point.
+
+## Sources & Research
+
+- Origin requirements: `docs/brainstorms/2026-07-17-in-app-check-for-updates-requirements.md`
+- Tauri v2 updater plugin docs: https://v2.tauri.app/plugin/updater/
+- Tauri updater JS API: https://v2.tauri.app/reference/javascript/updater/
+- Existing Tauri config: `src-tauri/tauri.conf.json`
+- Updater plugin registration: `src-tauri/src/lib.rs`
+- Desktop capability: `src-tauri/capabilities/desktop.json`
+- Settings shell: `src/components/settings/AppSettingsSection.svelte`, `src/components/settings/SettingsPage.svelte`
+- Persistence pattern: `src/stores/persistence-context.ts`, `src/stores/persistence.ts`, `src/lib/utils/clear-account-state.ts`
+- Post-unlock hook: `src/lib/app/post-login-sync.ts`
+- Toast primitive: `src/stores/toast.ts`
+- Modal primitive: `src/components/ui/Modal.svelte`

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/components/settings/AppSettingsSection.svelte
+++ b/src/components/settings/AppSettingsSection.svelte
@@ -5,6 +5,7 @@
     checkForUpdates,
     updateStatus,
     buildCommitHash,
+    buildVersion,
   } from '../../lib/updater/update-check';
   import UpdateAvailablePanel from '../updater/UpdateAvailablePanel.svelte';
   import SettingsCollapsibleSection from './SettingsCollapsibleSection.svelte';
@@ -13,7 +14,7 @@
   $: isChecking = $updateStatus.status === 'checking';
 
   function versionLabel(): string {
-    const version = $updateStatus.currentVersion || 'v0.0.0';
+    const version = $updateStatus.currentVersion || buildVersion;
     if (import.meta.env.DEV) {
       return `${version} (dev ${buildCommitHash})`;
     }
@@ -31,9 +32,11 @@
       case 'available':
       case 'downloading':
       case 'installing':
-      case 'error':
-      case 'relaunchPending':
         return `Update ${$updateStatus.availableVersion ?? ''} available`;
+      case 'error':
+        return $updateStatus.error ?? 'Update check failed.';
+      case 'relaunchPending':
+        return 'Update installed — relaunch to apply.';
       case 'dev-disabled':
         return 'Updates are only available in release builds.';
     }

--- a/src/components/settings/AppSettingsSection.svelte
+++ b/src/components/settings/AppSettingsSection.svelte
@@ -1,30 +1,131 @@
 <script lang="ts">
   import { theme, setTheme, THEME_OPTIONS } from '../../stores/theme';
+  import { startupCheckEnabled } from '../../stores/startup-check';
+  import {
+    checkForUpdates,
+    updateStatus,
+    buildCommitHash,
+  } from '../../lib/updater/update-check';
+  import UpdateAvailablePanel from '../updater/UpdateAvailablePanel.svelte';
   import SettingsCollapsibleSection from './SettingsCollapsibleSection.svelte';
+
+  $: isDev = $updateStatus.status === 'dev-disabled';
+  $: isChecking = $updateStatus.status === 'checking';
+
+  function versionLabel(): string {
+    const version = $updateStatus.currentVersion || 'v0.0.0';
+    if (import.meta.env.DEV) {
+      return `${version} (dev ${buildCommitHash})`;
+    }
+    return `${version} (${buildCommitHash})`;
+  }
+
+  function statusText(status: (typeof $updateStatus)['status'] | 'relaunchPending'): string {
+    switch (status) {
+      case 'idle':
+        return '';
+      case 'checking':
+        return 'Checking…';
+      case 'no-update':
+        return 'You’re on the latest version.';
+      case 'available':
+      case 'downloading':
+      case 'installing':
+      case 'error':
+      case 'relaunchPending':
+        return `Update ${$updateStatus.availableVersion ?? ''} available`;
+      case 'dev-disabled':
+        return 'Updates are only available in release builds.';
+    }
+    return '';
+  }
+
+  function handleCheck(): void {
+    void checkForUpdates();
+  }
+
+  function handleToggleStartupCheck(e: Event): void {
+    const target = e.currentTarget as HTMLInputElement;
+    startupCheckEnabled.set(target.checked);
+  }
 </script>
 
 <SettingsCollapsibleSection sectionId="settings-app" title="App settings">
-  <div class="theme-section" aria-labelledby="theme-heading">
-    <h3 id="theme-heading" class="theme-subheading">Appearance</h3>
-    <span class="theme-label">Theme</span>
-    <div class="theme-options" role="radiogroup" aria-label="App theme">
-      {#each THEME_OPTIONS as opt (opt.value)}
-        <label class="theme-option">
-          <input
-            type="radio"
-            name="theme"
-            value={opt.value}
-            checked={$theme === opt.value}
-            on:change={() => setTheme(opt.value)}
-          />
-          <span class="theme-option-label">{opt.label}</span>
-        </label>
-      {/each}
+  <div class="app-settings">
+    <div class="theme-section" aria-labelledby="theme-heading">
+      <h3 id="theme-heading" class="theme-subheading">Appearance</h3>
+      <span class="theme-label">Theme</span>
+      <div class="theme-options" role="radiogroup" aria-label="App theme">
+        {#each THEME_OPTIONS as opt (opt.value)}
+          <label class="theme-option">
+            <input
+              type="radio"
+              name="theme"
+              value={opt.value}
+              checked={$theme === opt.value}
+              on:change={() => setTheme(opt.value)}
+            />
+            <span class="theme-option-label">{opt.label}</span>
+          </label>
+        {/each}
+      </div>
+    </div>
+
+    <hr class="app-settings-divider" />
+
+    <div class="updates-section" aria-labelledby="updates-heading">
+      <h3 id="updates-heading" class="theme-subheading">Updates</h3>
+
+      <p class="update-current-version">
+        Current version: {versionLabel()}
+      </p>
+
+      <button
+        type="button"
+        class="btn-primary check-for-updates-btn"
+        disabled={isChecking}
+        on:click={handleCheck}
+      >
+        {isChecking ? 'Checking…' : (isDev ? 'Release-build only' : 'Check for Updates')}
+      </button>
+
+      {#if $updateStatus.status !== 'idle'}
+        <p class="update-status-line" class:update-status-line--error={$updateStatus.status === 'error'}>
+          {statusText($updateStatus.status)}
+        </p>
+      {/if}
+
+      {#if $updateStatus.status === 'available' || $updateStatus.status === 'downloading' || $updateStatus.status === 'installing' || $updateStatus.status === 'error' || $updateStatus.relaunchPending}
+        <div class="inline-update-panel">
+          <UpdateAvailablePanel />
+        </div>
+      {/if}
+
+      <label class="startup-check-toggle">
+        <input
+          type="checkbox"
+          checked={$startupCheckEnabled}
+          on:change={handleToggleStartupCheck}
+        />
+        <span>Check for updates on startup</span>
+      </label>
+
+      {#if isDev}
+        <p class="dev-build-note">
+          The in-app updater is disabled in dev builds. Use a release build to check for and install published updates.
+        </p>
+      {/if}
     </div>
   </div>
 </SettingsCollapsibleSection>
 
 <style>
+  .app-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
   .theme-section {
     margin: 0;
   }
@@ -64,5 +165,83 @@
 
   .theme-option-label {
     user-select: none;
+  }
+
+  .app-settings-divider {
+    width: 100%;
+    border: 0;
+    border-top: 1px solid var(--border-subtle);
+    margin: 0;
+  }
+
+  .updates-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .update-current-version {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+  }
+
+  .check-for-updates-btn {
+    align-self: flex-start;
+  }
+
+  .update-status-line {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    min-height: 1.2em;
+  }
+
+  .update-status-line--error {
+    color: var(--danger, #e53e3e);
+  }
+
+  .inline-update-panel {
+    margin-top: 4px;
+  }
+
+  .startup-check-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .startup-check-toggle input {
+    accent-color: var(--accent);
+  }
+
+  .dev-build-note {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+  }
+
+  .btn-primary {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent);
+    color: #ffffff;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
   }
 </style>

--- a/src/components/updater/UpdateAvailableModal.svelte
+++ b/src/components/updater/UpdateAvailableModal.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import Modal from '../ui/Modal.svelte';
+  import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
+  import { updateStatus } from '../../lib/updater/update-check';
+
+  $: open = $updateStatus.status === 'available' || $updateStatus.status === 'downloading' || $updateStatus.status === 'installing' || $updateStatus.status === 'error' || $updateStatus.relaunchPending;
+
+  function closeModal(): void {
+    // Only allow closing while idle; progress and errors keep the modal open.
+    const status = $updateStatus.status;
+    if (status === 'downloading' || status === 'installing') return;
+    updateStatus.reset();
+  }
+</script>
+
+{#if open}
+  <Modal titleId="update-available-title" onClose={closeModal} dismissible={$updateStatus.status !== 'downloading' && $updateStatus.status !== 'installing'}>
+    <div class="update-modal">
+      <h2 id="update-available-title">Update available</h2>
+      <UpdateAvailablePanel />
+    </div>
+  </Modal>
+{/if}
+
+<style>
+  .update-modal {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .update-modal h2 {
+    margin: 0;
+  }
+</style>

--- a/src/components/updater/UpdateAvailableModal.svelte
+++ b/src/components/updater/UpdateAvailableModal.svelte
@@ -3,10 +3,21 @@
   import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
   import { updateStatus } from '../../lib/updater/update-check';
 
-  $: open = $updateStatus.status === 'available' || $updateStatus.status === 'downloading' || $updateStatus.status === 'installing' || $updateStatus.status === 'error' || $updateStatus.relaunchPending;
+  $: open =
+    $updateStatus.status === 'available' ||
+    $updateStatus.status === 'downloading' ||
+    $updateStatus.status === 'installing' ||
+    $updateStatus.status === 'error' ||
+    $updateStatus.relaunchPending;
+
+  $: title =
+    $updateStatus.status === 'error'
+      ? 'Update check failed'
+      : $updateStatus.relaunchPending
+        ? 'Update installed'
+        : 'Update available';
 
   function closeModal(): void {
-    // Only allow closing while idle; progress and errors keep the modal open.
     const status = $updateStatus.status;
     if (status === 'downloading' || status === 'installing') return;
     updateStatus.reset();
@@ -14,9 +25,13 @@
 </script>
 
 {#if open}
-  <Modal titleId="update-available-title" onClose={closeModal} dismissible={$updateStatus.status !== 'downloading' && $updateStatus.status !== 'installing'}>
+  <Modal
+    titleId="update-available-title"
+    onClose={closeModal}
+    dismissible={$updateStatus.status !== 'downloading' && $updateStatus.status !== 'installing'}
+  >
     <div class="update-modal">
-      <h2 id="update-available-title">Update available</h2>
+      <h2 id="update-available-title">{title}</h2>
       <UpdateAvailablePanel />
     </div>
   </Modal>

--- a/src/components/updater/UpdateAvailablePanel.svelte
+++ b/src/components/updater/UpdateAvailablePanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    checkForUpdates,
     updateStatus,
     downloadAndInstallUpdate,
     relaunchApp,
@@ -8,59 +9,80 @@
 
   $: state = $updateStatus;
 
-  function installLabel(status: UpdateState['status']): string {
+  function progressPercent(progress: number): string {
+    return `${Math.round(progress * 100)}%`;
+  }
+
+  function primaryLabel(status: UpdateState['status']): string {
     switch (status) {
       case 'downloading':
         return 'Downloading…';
       case 'installing':
         return 'Installing…';
       case 'error':
-        return 'Retry install';
+        return 'Retry';
       default:
         return 'Download and install';
     }
   }
 
-  function progressPercent(progress: number): string {
-    return `${Math.round(progress * 100)}%`;
+  function handlePrimary(): void {
+    if (state.status === 'error') {
+      void checkForUpdates();
+      return;
+    }
+    void downloadAndInstallUpdate();
   }
 </script>
 
 <div class="update-panel">
-  {#if state.status === 'available' || state.status === 'downloading' || state.status === 'installing' || state.status === 'error'}
+  {#if state.status === 'available'}
     <p class="update-version">
       Update {state.availableVersion ?? ''} is available.
       {#if state.currentVersion}
         You have {state.currentVersion}.
       {/if}
     </p>
+  {:else if state.status === 'downloading' || state.status === 'installing'}
+    <p class="update-version">
+      Update {state.availableVersion ?? ''} is being {state.status}.
+      {#if state.currentVersion}
+        You have {state.currentVersion}.
+      {/if}
+    </p>
+    <div
+      class="update-progress"
+      role="progressbar"
+      aria-valuenow={state.downloadProgress}
+      aria-valuemin={0}
+      aria-valuemax={1}
+    >
+      <div class="update-progress-bar" style="width: {progressPercent(state.downloadProgress)}"></div>
+    </div>
+    <p class="update-progress-label">{primaryLabel(state.status)} {progressPercent(state.downloadProgress)}</p>
+  {:else if state.status === 'error'}
+    <p class="update-version">
+      {#if state.currentVersion}
+        You have {state.currentVersion}.
+      {/if}
+    </p>
+    <p class="update-error" role="alert">{state.error ?? 'Update check failed.'}</p>
+  {/if}
 
-    {#if state.status === 'downloading' || state.status === 'installing'}
-      <div class="update-progress" role="progressbar" aria-valuenow={state.downloadProgress} aria-valuemin={0} aria-valuemax={1}>
-        <div class="update-progress-bar" style="width: {progressPercent(state.downloadProgress)}"></div>
-      </div>
-      <p class="update-progress-label">{installLabel(state.status)} {progressPercent(state.downloadProgress)}</p>
-    {/if}
-
-    {#if state.status === 'error'}
-      <p class="update-error" role="alert">{state.error ?? 'Update failed.'}</p>
-    {/if}
-
-    {#if !state.relaunchPending}
-      <button
-        type="button"
-        class="btn-primary"
-        disabled={state.status === 'downloading' || state.status === 'installing'}
-        on:click={() => void downloadAndInstallUpdate()}
-      >
-        {installLabel(state.status)}
-      </button>
-    {:else}
-      <p class="update-relaunch-prompt">The update is installed. Relaunch to start the new version.</p>
-      <button type="button" class="btn-primary" on:click={() => void relaunchApp()}>
-        Relaunch now
-      </button>
-    {/if}
+  {#if state.relaunchPending}
+    <p class="update-relaunch-prompt">The update is installed. Relaunch to start the new version.</p>
+    <button type="button" class="btn-primary" on:click={() => void relaunchApp()}>
+      Relaunch now
+    </button>
+  {:else if state.status !== 'idle' && state.status !== 'checking' && state.status !== 'no-update' && state.status !== 'dev-disabled'}
+    <button
+      type="button"
+      class="btn-primary"
+      disabled={state.status === 'downloading' || state.status === 'installing'}
+      on:click={handlePrimary}
+    >
+      {primaryLabel(state.status)}
+    </button>
   {/if}
 </div>
 
@@ -80,15 +102,15 @@
 
   .update-progress {
     width: 100%;
-    height: 6px;
-    background: var(--border);
-    border-radius: 3px;
+    height: 8px;
+    background-color: var(--bg-tertiary);
+    border-radius: 4px;
     overflow: hidden;
   }
 
   .update-progress-bar {
     height: 100%;
-    background: var(--accent);
+    background-color: var(--accent-primary);
     transition: width 0.2s ease;
   }
 
@@ -100,34 +122,13 @@
 
   .update-error {
     margin: 0;
-    color: var(--danger, #e53e3e);
-    font-size: 0.875rem;
+    color: var(--danger);
+    font-size: 0.9375rem;
   }
 
   .update-relaunch-prompt {
     margin: 0;
     color: var(--text-secondary);
-    font-size: 0.875rem;
-  }
-
-  .btn-primary {
-    align-self: flex-start;
-    padding: 8px 16px;
-    border: none;
-    border-radius: 8px;
-    background: var(--accent);
-    color: #ffffff;
-    font-size: 0.875rem;
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    background: var(--accent-hover);
+    font-size: 0.9375rem;
   }
 </style>

--- a/src/components/updater/UpdateAvailablePanel.svelte
+++ b/src/components/updater/UpdateAvailablePanel.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import {
+    updateStatus,
+    downloadAndInstallUpdate,
+    relaunchApp,
+    type UpdateState,
+  } from '../../lib/updater/update-check';
+
+  $: state = $updateStatus;
+
+  function installLabel(status: UpdateState['status']): string {
+    switch (status) {
+      case 'downloading':
+        return 'Downloading…';
+      case 'installing':
+        return 'Installing…';
+      case 'error':
+        return 'Retry install';
+      default:
+        return 'Download and install';
+    }
+  }
+
+  function progressPercent(progress: number): string {
+    return `${Math.round(progress * 100)}%`;
+  }
+</script>
+
+<div class="update-panel">
+  {#if state.status === 'available' || state.status === 'downloading' || state.status === 'installing' || state.status === 'error'}
+    <p class="update-version">
+      Update {state.availableVersion ?? ''} is available.
+      {#if state.currentVersion}
+        You have {state.currentVersion}.
+      {/if}
+    </p>
+
+    {#if state.status === 'downloading' || state.status === 'installing'}
+      <div class="update-progress" role="progressbar" aria-valuenow={state.downloadProgress} aria-valuemin={0} aria-valuemax={1}>
+        <div class="update-progress-bar" style="width: {progressPercent(state.downloadProgress)}"></div>
+      </div>
+      <p class="update-progress-label">{installLabel(state.status)} {progressPercent(state.downloadProgress)}</p>
+    {/if}
+
+    {#if state.status === 'error'}
+      <p class="update-error" role="alert">{state.error ?? 'Update failed.'}</p>
+    {/if}
+
+    {#if !state.relaunchPending}
+      <button
+        type="button"
+        class="btn-primary"
+        disabled={state.status === 'downloading' || state.status === 'installing'}
+        on:click={() => void downloadAndInstallUpdate()}
+      >
+        {installLabel(state.status)}
+      </button>
+    {:else}
+      <p class="update-relaunch-prompt">The update is installed. Relaunch to start the new version.</p>
+      <button type="button" class="btn-primary" on:click={() => void relaunchApp()}>
+        Relaunch now
+      </button>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .update-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .update-version {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.9375rem;
+    line-height: 1.4;
+  }
+
+  .update-progress {
+    width: 100%;
+    height: 6px;
+    background: var(--border);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .update-progress-bar {
+    height: 100%;
+    background: var(--accent);
+    transition: width 0.2s ease;
+  }
+
+  .update-progress-label {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+  }
+
+  .update-error {
+    margin: 0;
+    color: var(--danger, #e53e3e);
+    font-size: 0.875rem;
+  }
+
+  .update-relaunch-prompt {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+  }
+
+  .btn-primary {
+    align-self: flex-start;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent);
+    color: #ffffff;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+</style>

--- a/src/lib/app/post-login-sync.test.ts
+++ b/src/lib/app/post-login-sync.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runPostLoginNetworkSync } from './post-login-sync';
+import * as updateCheck from '../updater/update-check';
+import {
+  startupCheckEnabled,
+  markStartupCheckRun,
+  resetStartupCheckSession,
+  getHasRunStartupCheckThisSession,
+} from '../../stores/startup-check';
 
 const scheduleCommonsStartupPrefetch = vi.fn();
 const apiConnect = vi.fn();
@@ -33,16 +40,28 @@ vi.mock('../commons/commons-prefetch', () => ({
     scheduleCommonsStartupPrefetch(...args),
 }));
 
+vi.mock('../updater/update-check', () => ({
+  checkForUpdates: vi.fn().mockResolvedValue(undefined),
+  isDevBuild: vi.fn().mockReturnValue(false),
+  updateStatus: { setStatus: vi.fn() },
+  resetUpdateStatus: vi.fn(),
+  setIsDevBuildForTest: vi.fn(),
+}));
+
 describe('runPostLoginNetworkSync', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
+    resetStartupCheckSession();
+    startupCheckEnabled.set(false);
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     consoleError.mockClear();
+    resetStartupCheckSession();
+    startupCheckEnabled.set(false);
   });
 
   async function flushAsync(): Promise<void> {
@@ -137,5 +156,64 @@ describe('runPostLoginNetworkSync', () => {
     await flushAsync();
 
     expect(console.error).toHaveBeenCalledWith('syncMlsGroupsNow after login failed:', err);
+  });
+
+  describe('startup update check', () => {
+    beforeEach(() => {
+      vi.spyOn(updateCheck, 'isDevBuild').mockReturnValue(false);
+      vi.spyOn(updateCheck, 'checkForUpdates').mockResolvedValue(undefined);
+    });
+
+    it('does not check when the preference is disabled', async () => {
+      startupCheckEnabled.set(false);
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it('does not check when the session has already been checked', async () => {
+      startupCheckEnabled.set(true);
+      markStartupCheckRun();
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.checkForUpdates).not.toHaveBeenCalled();
+      expect(getHasRunStartupCheckThisSession()).toBe(true);
+    });
+
+    it('does not check in dev builds', async () => {
+      vi.spyOn(updateCheck, 'isDevBuild').mockReturnValue(true);
+      startupCheckEnabled.set(true);
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it('runs exactly once when enabled in a release build', async () => {
+      startupCheckEnabled.set(true);
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(getHasRunStartupCheckThisSession()).toBe(true);
+
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.checkForUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls updateStatus.setStatus when an update is found', async () => {
+      startupCheckEnabled.set(true);
+      vi.spyOn(updateCheck, 'checkForUpdates').mockImplementation(async () => {
+        updateCheck.updateStatus.setStatus('available', {
+          currentVersion: '0.2.0',
+          availableVersion: '0.3.0',
+        });
+      });
+      runPostLoginNetworkSync('npub1');
+      await flushAsync();
+      expect(updateCheck.updateStatus.setStatus).toHaveBeenCalledWith('available', {
+        currentVersion: '0.2.0',
+        availableVersion: '0.3.0',
+      });
+    });
   });
 });

--- a/src/lib/app/post-login-sync.ts
+++ b/src/lib/app/post-login-sync.ts
@@ -3,11 +3,19 @@
  * Must not block PIN UI.
  */
 
+import { get } from 'svelte/store';
 import { connect as apiConnect } from '../api/auth';
 import { fetchMessages, refreshProfileNow, syncMlsGroupsNow } from '../api/nostr';
 import { dmLog } from '../utils/dm-debug';
 import { dmSyncStatus } from '../../stores/dm';
 import { scheduleCommonsStartupPrefetch } from '../commons/commons-prefetch';
+import { checkForUpdates } from '../updater/update-check';
+import {
+  startupCheckEnabled,
+  markStartupCheckRun,
+  getHasRunStartupCheckThisSession,
+} from '../../stores/startup-check';
+import { isDevBuild } from '../updater/update-check';
 
 export function runPostLoginNetworkSync(npub: string): void {
   scheduleCommonsStartupPrefetch();
@@ -32,5 +40,16 @@ export function runPostLoginNetworkSync(npub: string): void {
 
     syncMlsGroupsNow(null).catch((e) => console.error('syncMlsGroupsNow after login failed:', e));
     dmLog('post-login: network sync done');
+
+    runStartupUpdateCheckIfEnabled();
   })();
+}
+
+function runStartupUpdateCheckIfEnabled(): void {
+  if (isDevBuild()) return;
+  if (getHasRunStartupCheckThisSession()) return;
+  if (!get(startupCheckEnabled)) return;
+
+  markStartupCheckRun();
+  void checkForUpdates();
 }

--- a/src/lib/updater/update-check.test.ts
+++ b/src/lib/updater/update-check.test.ts
@@ -88,7 +88,7 @@ describe('checkForUpdates', () => {
     expectStatus('available', { currentVersion: '0.2.0', availableVersion: '0.3.0' });
   });
 
-  it('sets error and shows a toast on network failures', async () => {
+  it('sets error on network failures', async () => {
     setIsDevBuildForTest(false);
     mockedGetVersion.mockResolvedValue('0.2.0');
     mockedCheck.mockRejectedValue(new Error('Network request failed'));
@@ -96,11 +96,10 @@ describe('checkForUpdates', () => {
     const state = get(updateStatus);
     expect(state.status).toBe('error');
     expect(state.error).toContain('internet connection');
-    expect(mockedShowToast).toHaveBeenCalledTimes(1);
-    expect(mockedShowToast.mock.calls[0][0]).toContain('internet connection');
+    expect(mockedShowToast).not.toHaveBeenCalled();
   });
 
-  it('sets error and shows a toast on signature mismatch', async () => {
+  it('sets error on signature mismatch', async () => {
     setIsDevBuildForTest(false);
     mockedGetVersion.mockResolvedValue('0.2.0');
     mockedCheck.mockRejectedValue(new Error('invalid signature'));
@@ -108,10 +107,10 @@ describe('checkForUpdates', () => {
     const state = get(updateStatus);
     expect(state.status).toBe('error');
     expect(state.error).toContain('signature');
-    expect(mockedShowToast).toHaveBeenCalled();
+    expect(mockedShowToast).not.toHaveBeenCalled();
   });
 
-  it('sets error and shows a toast on missing platform assets', async () => {
+  it('sets error on missing platform assets', async () => {
     setIsDevBuildForTest(false);
     mockedGetVersion.mockResolvedValue('0.2.0');
     mockedCheck.mockRejectedValue(new Error('no asset found for platform'));
@@ -119,7 +118,18 @@ describe('checkForUpdates', () => {
     const state = get(updateStatus);
     expect(state.status).toBe('error');
     expect(state.error).toContain('platform');
-    expect(mockedShowToast).toHaveBeenCalled();
+    expect(mockedShowToast).not.toHaveBeenCalled();
+  });
+
+  it('sets a clear error when the release endpoint is not found', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockRejectedValue(new Error('404 Not Found: latest.json'));
+    await checkForUpdates();
+    const state = get(updateStatus);
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('No published release');
+    expect(mockedShowToast).not.toHaveBeenCalled();
   });
 });
 
@@ -155,7 +165,7 @@ describe('downloadAndInstallUpdate', () => {
     expect(downloadAndInstall).toHaveBeenCalled();
   });
 
-  it('sets error and shows a toast when install fails', async () => {
+  it('sets error when install fails', async () => {
     setIsDevBuildForTest(false);
     const downloadAndInstall = vi.fn().mockRejectedValue(new Error('network error'));
     mockedCheck.mockResolvedValue({ version: '0.3.0', downloadAndInstall } as unknown as UpdaterUpdate);
@@ -166,7 +176,7 @@ describe('downloadAndInstallUpdate', () => {
     const state = get(updateStatus);
     expect(state.status).toBe('error');
     expect(state.error).toContain('internet connection');
-    expect(mockedShowToast).toHaveBeenCalled();
+    expect(mockedShowToast).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/updater/update-check.test.ts
+++ b/src/lib/updater/update-check.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { check } from '@tauri-apps/plugin-updater';
+import { getVersion } from '@tauri-apps/api/app';
+import { relaunch } from '@tauri-apps/plugin-process';
+import {
+  checkForUpdates,
+  downloadAndInstallUpdate,
+  relaunchApp,
+  updateStatus,
+  resetUpdateStatus,
+  setIsDevBuildForTest,
+  buildCommitHash,
+  buildVersion,
+  type UpdateState,
+  type UpdaterUpdate,
+} from './update-check';
+
+import { showToast } from '../../stores/toast';
+
+
+vi.mock('@tauri-apps/plugin-updater');
+vi.mock('@tauri-apps/api/app');
+vi.mock('@tauri-apps/plugin-process');
+vi.mock('../../stores/toast', () => ({
+  showToast: vi.fn(),
+  toastMessage: { set: vi.fn(), subscribe: vi.fn() },
+  clearToast: vi.fn(),
+  runToastRetryAction: vi.fn(),
+  pendingReadyToast: { set: vi.fn(), subscribe: vi.fn() },
+}));
+
+const mockedCheck = vi.mocked(check);
+const mockedGetVersion = vi.mocked(getVersion);
+const mockedRelaunch = vi.mocked(relaunch);
+const mockedShowToast = vi.mocked(showToast);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  resetUpdateStatus();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function expectStatus(status: UpdateState['status'], extra?: Partial<UpdateState>) {
+  const state = get(updateStatus);
+  expect(state.status).toBe(status);
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      expect(state[key as keyof UpdateState]).toEqual(value);
+    }
+  }
+}
+
+describe('checkForUpdates', () => {
+  it('falls back to the build version when getVersion() returns 0.0.0', async () => {
+    setIsDevBuildForTest(true);
+    mockedGetVersion.mockResolvedValue('0.0.0');
+    await checkForUpdates();
+    expect(mockedGetVersion).toHaveBeenCalled();
+    expectStatus('dev-disabled', { currentVersion: buildVersion });
+  });
+
+  it('falls back to the build version when getVersion() returns empty', async () => {
+    setIsDevBuildForTest(true);
+    mockedGetVersion.mockResolvedValue('');
+    await checkForUpdates();
+    expect(mockedGetVersion).toHaveBeenCalled();
+    expectStatus('dev-disabled', { currentVersion: buildVersion });
+  });
+
+  it('transitions to no-update when no update is available', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockResolvedValue(null);
+    await checkForUpdates();
+    expect(mockedCheck).toHaveBeenCalledTimes(1);
+    expectStatus('no-update', { currentVersion: '0.2.0', availableVersion: null });
+  });
+
+  it('transitions to available when an update is returned', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockResolvedValue({ version: '0.3.0' } as UpdaterUpdate);
+    await checkForUpdates();
+    expectStatus('available', { currentVersion: '0.2.0', availableVersion: '0.3.0' });
+  });
+
+  it('sets error and shows a toast on network failures', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockRejectedValue(new Error('Network request failed'));
+    await checkForUpdates();
+    const state = get(updateStatus);
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('internet connection');
+    expect(mockedShowToast).toHaveBeenCalledTimes(1);
+    expect(mockedShowToast.mock.calls[0][0]).toContain('internet connection');
+  });
+
+  it('sets error and shows a toast on signature mismatch', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockRejectedValue(new Error('invalid signature'));
+    await checkForUpdates();
+    const state = get(updateStatus);
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('signature');
+    expect(mockedShowToast).toHaveBeenCalled();
+  });
+
+  it('sets error and shows a toast on missing platform assets', async () => {
+    setIsDevBuildForTest(false);
+    mockedGetVersion.mockResolvedValue('0.2.0');
+    mockedCheck.mockRejectedValue(new Error('no asset found for platform'));
+    await checkForUpdates();
+    const state = get(updateStatus);
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('platform');
+    expect(mockedShowToast).toHaveBeenCalled();
+  });
+});
+
+describe('downloadAndInstallUpdate', () => {
+  it('does nothing when status is not available', async () => {
+    setIsDevBuildForTest(false);
+    updateStatus.setStatus('idle');
+    await downloadAndInstallUpdate();
+    expect(mockedCheck).not.toHaveBeenCalled();
+    expectStatus('idle');
+  });
+
+  it('transitions through downloading/installing and sets relaunchPending on success', async () => {
+    setIsDevBuildForTest(false);
+    const downloadAndInstall = vi.fn().mockImplementation((onEvent) => {
+      onEvent({ event: 'Started', data: { contentLength: 100 } });
+      onEvent({ event: 'Progress', data: { chunkLength: 25 } });
+      onEvent({ event: 'Progress', data: { chunkLength: 25 } });
+      onEvent({ event: 'Progress', data: { chunkLength: 25 } });
+      onEvent({ event: 'Progress', data: { chunkLength: 25 } });
+      onEvent({ event: 'Finished' });
+      return Promise.resolve();
+    });
+    mockedCheck.mockResolvedValue({ version: '0.3.0', downloadAndInstall } as unknown as UpdaterUpdate);
+
+    updateStatus.setStatus('available', { availableVersion: '0.3.0' });
+    await downloadAndInstallUpdate();
+
+    const state = get(updateStatus);
+    expect(state.status).toBe('available');
+    expect(state.relaunchPending).toBe(true);
+    expect(state.downloadProgress).toBe(1);
+    expect(downloadAndInstall).toHaveBeenCalled();
+  });
+
+  it('sets error and shows a toast when install fails', async () => {
+    setIsDevBuildForTest(false);
+    const downloadAndInstall = vi.fn().mockRejectedValue(new Error('network error'));
+    mockedCheck.mockResolvedValue({ version: '0.3.0', downloadAndInstall } as unknown as UpdaterUpdate);
+
+    updateStatus.setStatus('available', { availableVersion: '0.3.0' });
+    await downloadAndInstallUpdate();
+
+    const state = get(updateStatus);
+    expect(state.status).toBe('error');
+    expect(state.error).toContain('internet connection');
+    expect(mockedShowToast).toHaveBeenCalled();
+  });
+});
+
+describe('relaunchApp', () => {
+  it('calls the process plugin relaunch function', async () => {
+    mockedRelaunch.mockResolvedValue(undefined);
+    await relaunchApp();
+    expect(mockedRelaunch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('build metadata', () => {
+  it('exposes a build commit hash', () => {
+    expect(typeof buildCommitHash).toBe('string');
+    expect(buildCommitHash.length).toBeGreaterThan(0);
+  });
+
+  it('exposes a build version starting with v', () => {
+    expect(typeof buildVersion).toBe('string');
+    expect(buildVersion.startsWith('v')).toBe(true);
+  });
+});

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -1,0 +1,186 @@
+import { check, type DownloadEvent } from '@tauri-apps/plugin-updater';
+import { getVersion } from '@tauri-apps/api/app';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { writable, get, type Readable } from 'svelte/store';
+
+import { showToast } from '../../stores/toast';
+
+declare const __APP_COMMIT_HASH__: string | undefined;
+declare const __APP_VERSION__: string | undefined;
+
+export let isDevBuild = (): boolean => import.meta.env.DEV;
+
+/** Git commit hash the bundle was built from, or 'unknown'. */
+export const buildCommitHash: string = typeof __APP_COMMIT_HASH__ === 'string' ? __APP_COMMIT_HASH__ : 'unknown';
+
+/** Package version the bundle was built from (e.g. v0.2.0), or 'v0.0.0'. */
+export const buildVersion: string = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'v0.0.0';
+
+/** Resolve the installed version, falling back to the package version. */
+export async function resolveInstalledVersion(): Promise<string> {
+  const installed = await getVersion().catch(() => '');
+  // Tauri returns '0.0.0' when it cannot read a real bundle version.
+  return installed && installed !== '0.0.0' ? installed : buildVersion;
+}
+
+/** Test-only hook to override the dev-build detector. */
+export function setIsDevBuildForTest(value: boolean): void {
+  isDevBuild = () => value;
+}
+
+export type UpdaterUpdate = Awaited<ReturnType<typeof check>>;
+
+export type UpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'no-update'
+  | 'available'
+  | 'downloading'
+  | 'installing'
+  | 'error'
+  | 'dev-disabled';
+
+export interface UpdateState {
+  status: UpdateStatus;
+  currentVersion: string;
+  availableVersion: string | null;
+  downloadProgress: number;
+  error: string | null;
+  relaunchPending: boolean;
+}
+
+const initialState: UpdateState = {
+  status: 'idle',
+  currentVersion: '',
+  availableVersion: null,
+  downloadProgress: 0,
+  error: null,
+  relaunchPending: false,
+};
+
+function createUpdateStatusStore() {
+  const { subscribe, set, update } = writable<UpdateState>(initialState);
+
+  return {
+    subscribe,
+    set,
+    update,
+    reset: () => set(initialState),
+    setStatus: (status: UpdateStatus, patch: Partial<UpdateState> = {}) =>
+      set({
+        ...get(updateStatus),
+        status,
+        error: status === 'error' ? get(updateStatus).error : null,
+        // Clear stale download state when leaving download/install phases.
+        downloadProgress: status === 'downloading' || status === 'installing'
+          ? get(updateStatus).downloadProgress
+          : 0,
+        ...patch,
+      }),
+  };
+}
+
+export const updateStatus = createUpdateStatusStore();
+
+export function resetUpdateStatus(): void {
+  updateStatus.reset();
+}
+
+function friendlyErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return 'Update check failed.';
+  const msg = err.message.toLowerCase();
+  if (msg.includes('network') || msg.includes('fetch') || msg.includes('offline')) {
+    return 'Update check failed. Please check your internet connection and try again.';
+  }
+  if (msg.includes('signature') || msg.includes('verify') || msg.includes('invalid signature')) {
+    return 'Update signature mismatch. The update package could not be verified.';
+  }
+  if (msg.includes('platform') || msg.includes('asset') || msg.includes('no asset')) {
+    return 'No update is available for this platform yet.';
+  }
+  return err.message || 'Update check failed.';
+}
+
+export async function checkForUpdates(): Promise<void> {
+  const currentVersion = await resolveInstalledVersion();
+
+  if (isDevBuild()) {
+    updateStatus.setStatus('dev-disabled', { currentVersion });
+    return;
+  }
+
+  updateStatus.setStatus('checking', { currentVersion, availableVersion: null, error: null });
+
+  try {
+    const update = await check();
+    if (!update) {
+      updateStatus.setStatus('no-update', { currentVersion });
+      return;
+    }
+
+    updateStatus.setStatus('available', {
+      currentVersion,
+      availableVersion: update.version,
+      downloadProgress: 0,
+    });
+  } catch (err) {
+    const message = friendlyErrorMessage(err);
+    updateStatus.setStatus('error', { error: message });
+    showToast(message, undefined, undefined, { error: true });
+  }
+}
+
+let downloadTotalBytes = 0;
+let downloadedBytes = 0;
+
+function resetDownloadProgress(): void {
+  downloadTotalBytes = 0;
+  downloadedBytes = 0;
+}
+
+function getDownloadProgress(): number {
+  if (!downloadTotalBytes) return 0;
+  return Math.min(1, downloadedBytes / downloadTotalBytes);
+}
+
+function handleDownloadEvent(event: DownloadEvent): void {
+  if (event.event === 'Started') {
+    resetDownloadProgress();
+    downloadTotalBytes = event.data.contentLength ?? 0;
+    updateStatus.setStatus('downloading', { downloadProgress: 0 });
+  } else if (event.event === 'Progress') {
+    downloadedBytes += event.data.chunkLength;
+    updateStatus.setStatus('downloading', { downloadProgress: getDownloadProgress() });
+  } else if (event.event === 'Finished') {
+    updateStatus.setStatus('installing', { downloadProgress: 1 });
+  }
+}
+
+export async function downloadAndInstallUpdate(): Promise<void> {
+  const state = get(updateStatus);
+  if (state.status !== 'available') return;
+
+  resetDownloadProgress();
+
+  try {
+    const update = await check();
+    if (!update) {
+      updateStatus.setStatus('no-update');
+      return;
+    }
+
+    await update.downloadAndInstall((event) => handleDownloadEvent(event));
+    updateStatus.setStatus('available', { relaunchPending: true, downloadProgress: 1 });
+  } catch (err) {
+    const message = friendlyErrorMessage(err);
+    updateStatus.setStatus('error', { error: message, availableVersion: null });
+    showToast(message, undefined, undefined, { error: true });
+  }
+}
+
+export async function relaunchApp(): Promise<void> {
+  await relaunch();
+}
+
+/** Readable alias for components that only need to subscribe. */
+export const updateStatusReadable: Readable<UpdateState> = updateStatus;

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -3,7 +3,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { writable, get, type Readable } from 'svelte/store';
 
-import { showToast } from '../../stores/toast';
+
 
 declare const __APP_COMMIT_HASH__: string | undefined;
 declare const __APP_VERSION__: string | undefined;
@@ -51,7 +51,7 @@ export interface UpdateState {
 
 const initialState: UpdateState = {
   status: 'idle',
-  currentVersion: '',
+  currentVersion: buildVersion,
   availableVersion: null,
   downloadProgress: 0,
   error: null,
@@ -98,6 +98,14 @@ function friendlyErrorMessage(err: unknown): string {
   if (msg.includes('platform') || msg.includes('asset') || msg.includes('no asset')) {
     return 'No update is available for this platform yet.';
   }
+  if (
+    msg.includes('not found') ||
+    msg.includes('404') ||
+    msg.includes('latest.json') ||
+    msg.includes('no release')
+  ) {
+    return 'No published release was found. This is expected until the first release is shipped.';
+  }
   return err.message || 'Update check failed.';
 }
 
@@ -126,7 +134,6 @@ export async function checkForUpdates(): Promise<void> {
   } catch (err) {
     const message = friendlyErrorMessage(err);
     updateStatus.setStatus('error', { error: message });
-    showToast(message, undefined, undefined, { error: true });
   }
 }
 
@@ -174,7 +181,6 @@ export async function downloadAndInstallUpdate(): Promise<void> {
   } catch (err) {
     const message = friendlyErrorMessage(err);
     updateStatus.setStatus('error', { error: message, availableVersion: null });
-    showToast(message, undefined, undefined, { error: true });
   }
 }
 

--- a/src/lib/utils/clear-account-state.ts
+++ b/src/lib/utils/clear-account-state.ts
@@ -96,6 +96,7 @@ import { SQUAD_NETWORK_PREFIX } from '../squad/squad-network';
 import { resetSquadJoinRequestStores } from '../../stores/squad-join-requests';
 import { resetSquadHubAlertStores } from '../../stores/squad-hub-alerts';
 import { resetMlsGroupMembersStores } from '../../stores/mls-group-members';
+import { STARTUP_CHECK_PREFIX } from '../../stores/startup-check';
 
 /** Npub-scoped key prefixes (suffix is `_<npub>`). */
 const SCOPED_KEY_PREFIXES = [
@@ -124,6 +125,7 @@ const SCOPED_KEY_PREFIXES = [
   PACTO_SQUAD_JOIN_MUTED_PREFIX,
   'pacto_local_dev_defaults_applied_v1',
   ...INVITE_DECISION_SCOPED_PREFIXES,
+  STARTUP_CHECK_PREFIX,
 ] as const;
 
 function clearAccountLocalStorage(npub?: string): void {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import TopNavbar from '../components/layout/TopNavbar.svelte';
   import CommonsView from '../components/commons/CommonsView.svelte';
   import PersonalBroadcastModal from '../components/commons/PersonalBroadcastModal.svelte';
+  import UpdateAvailableModal from '../components/updater/UpdateAvailableModal.svelte';
   import ParentNavbar from '../components/layout/ParentNavbar.svelte';
   import ParentDashboard from '../components/parent/ParentDashboard.svelte';
 import MyDashboard from '../components/parent/MyDashboard.svelte';
@@ -1109,6 +1110,7 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
       <PersonalBroadcastModal />
     </div>
   {/if}
+  <UpdateAvailableModal />
 </div>
 
 <style>

--- a/src/stores/persistence.ts
+++ b/src/stores/persistence.ts
@@ -37,6 +37,7 @@ import {
 import { pactoAppInboxLastReadId, PACTO_APP_INBOX_LAST_READ_PREFIX } from './dm-unread';
 import { hydrateSquadsFromDb } from '../lib/squad/squad-catalog';
 import { normalizeHubChannelName } from './squads';
+import { loadStartupCheckPreference } from './startup-check';
 
 export {
   currentNpubForPersistence,
@@ -123,6 +124,7 @@ export function loadAccountState(npub: string): void {
     squadDashboardChannelMode.set(parseSquadDashboardChannelMode(rawSquadDashboardMode));
     const rawMyDashboardMode = localStorage.getItem(`${MY_DASHBOARD_MODE_PREFIX}_${npub}`);
     myDashboardChannelMode.set(parseMyDashboardChannelMode(rawMyDashboardMode));
+    loadStartupCheckPreference(npub);
   } catch {
     // ignore parse errors
   }

--- a/src/stores/startup-check.test.ts
+++ b/src/stores/startup-check.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  startupCheckEnabled,
+  loadStartupCheckPreference,
+  markStartupCheckRun,
+  resetStartupCheckSession,
+  getHasRunStartupCheckThisSession,
+  STARTUP_CHECK_PREFIX,
+} from './startup-check';
+import { setCurrentNpubForPersistence } from './persistence-context';
+
+beforeEach(() => {
+  const storage: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem(key: string): string | null {
+      return storage[key] ?? null;
+    },
+    setItem(key: string, value: string): void {
+      storage[key] = value;
+    },
+    removeItem(key: string): void {
+      delete storage[key];
+    },
+  });
+  setCurrentNpubForPersistence(null);
+  startupCheckEnabled.set(false);
+  resetStartupCheckSession();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setCurrentNpubForPersistence(null);
+  startupCheckEnabled.set(false);
+  resetStartupCheckSession();
+});
+
+const NPUB = 'npub1test';
+
+function expectedKey(npub: string = NPUB): string {
+  return `${STARTUP_CHECK_PREFIX}_${npub}`;
+}
+
+describe('startupCheckEnabled', () => {
+  it('defaults to false when no persisted value exists', () => {
+    loadStartupCheckPreference(NPUB);
+    expect(get(startupCheckEnabled)).toBe(false);
+  });
+
+  it('reads true from localStorage when previously enabled', () => {
+    localStorage.setItem(expectedKey(), JSON.stringify(true));
+    loadStartupCheckPreference(NPUB);
+    expect(get(startupCheckEnabled)).toBe(true);
+  });
+
+  it('reads false from localStorage when previously disabled', () => {
+    localStorage.setItem(expectedKey(), JSON.stringify(false));
+    loadStartupCheckPreference(NPUB);
+    expect(get(startupCheckEnabled)).toBe(false);
+  });
+
+  it('treats corrupt values as false', () => {
+    localStorage.setItem(expectedKey(), 'not-json');
+    loadStartupCheckPreference(NPUB);
+    expect(get(startupCheckEnabled)).toBe(false);
+  });
+
+  it('persists true per npub', async () => {
+    loadStartupCheckPreference(NPUB);
+    startupCheckEnabled.set(true);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(localStorage.getItem(expectedKey())).toBe('true');
+  });
+
+  it('persists false per npub when toggled off from true', async () => {
+    loadStartupCheckPreference(NPUB);
+    startupCheckEnabled.set(true);
+    await new Promise((r) => setTimeout(r, 10));
+    startupCheckEnabled.set(false);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(localStorage.getItem(expectedKey())).toBe('false');
+  });
+
+  it('scopes storage to the current npub', async () => {
+    loadStartupCheckPreference(NPUB);
+    startupCheckEnabled.set(true);
+    await new Promise((r) => setTimeout(r, 10));
+    const otherNpub = 'npub1other';
+    loadStartupCheckPreference(otherNpub);
+    startupCheckEnabled.set(true);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(localStorage.getItem(expectedKey(NPUB))).toBe('true');
+    expect(localStorage.getItem(expectedKey(otherNpub))).toBe('true');
+  });
+
+  it('does not write when no persistence context is set', () => {
+    const isolatedStorage: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem(key: string): string | null { return isolatedStorage[key] ?? null; },
+      setItem(key: string, value: string): void { isolatedStorage[key] = value; },
+      removeItem(key: string): void { delete isolatedStorage[key]; },
+    });
+    setCurrentNpubForPersistence(null);
+    startupCheckEnabled.set(true);
+    expect(Object.keys(isolatedStorage)).toHaveLength(0);
+  });
+});
+
+describe('session guard', () => {
+  it('starts false at import time', () => {
+    expect(getHasRunStartupCheckThisSession()).toBe(false);
+  });
+
+  it('becomes true after markStartupCheckRun', () => {
+    markStartupCheckRun();
+    expect(getHasRunStartupCheckThisSession()).toBe(true);
+  });
+
+  it('resets only via resetStartupCheckSession', () => {
+    markStartupCheckRun();
+    resetStartupCheckSession();
+    expect(getHasRunStartupCheckThisSession()).toBe(false);
+  });
+});

--- a/src/stores/startup-check.ts
+++ b/src/stores/startup-check.ts
@@ -1,0 +1,60 @@
+import { writable } from 'svelte/store';
+import { persistenceKey, setCurrentNpubForPersistence } from './persistence-context';
+
+export const STARTUP_CHECK_PREFIX = 'pacto_startup_check_enabled_v1';
+
+export const startupCheckEnabled = writable<boolean>(false);
+
+let hasRunStartupCheckThisSession = false;
+
+export function markStartupCheckRun(): void {
+  hasRunStartupCheckThisSession = true;
+}
+
+export function getHasRunStartupCheckThisSession(): boolean {
+  return hasRunStartupCheckThisSession;
+}
+
+/** Reset the per-session guard. Used by tests; app restart naturally resets it. */
+export function resetStartupCheckSession(): void {
+  hasRunStartupCheckThisSession = false;
+}
+
+function persistStartupCheckEnabled(value: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  const key = persistenceKey(STARTUP_CHECK_PREFIX);
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}
+
+export function loadStartupCheckPreference(npub: string): void {
+  setCurrentNpubForPersistence(npub);
+  if (typeof localStorage === 'undefined') {
+    startupCheckEnabled.set(false);
+    return;
+  }
+  const key = persistenceKey(STARTUP_CHECK_PREFIX);
+  if (!key) {
+    startupCheckEnabled.set(false);
+    return;
+  }
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) {
+      startupCheckEnabled.set(false);
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    startupCheckEnabled.set(typeof parsed === 'boolean' ? parsed : false);
+  } catch {
+    startupCheckEnabled.set(false);
+  }
+}
+
+startupCheckEnabled.subscribe((value) => {
+  persistStartupCheckEnabled(value);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import packageJson from './package.json' with { type: 'json' };
 
 const host = process.env.TAURI_DEV_HOST;
 
 const plugins = await sveltekit();
+
+const tauriConf = JSON.parse(fs.readFileSync('./src-tauri/tauri.conf.json', 'utf8'));
 
 function getCommitHash(): string {
   if (process.env.VITE_COMMIT_HASH) {
@@ -19,8 +22,19 @@ function getCommitHash(): string {
 }
 
 function getAppVersion(): string {
-  const version = process.env.VITE_APP_VERSION ?? packageJson.version;
-  return version.startsWith('v') ? version : `v${version}`;
+  // Prefer the explicit build-time override, then the Tauri app version (the
+  // source of truth for the bundle), then package.json as a last resort.
+  const raw = process.env.VITE_APP_VERSION ?? tauriConf.version ?? packageJson.version;
+  const version = raw.startsWith('v') ? raw : `v${raw}`;
+
+  if (!/^v\d+\.\d+\.\d+/.test(version)) {
+    throw new Error(
+      `Invalid app version "${version}". Expected a semver like "v0.2.0". ` +
+        `Check VITE_APP_VERSION, src-tauri/tauri.conf.json, and package.json.`
+    );
+  }
+
+  return version;
 }
 
 // https://vite.dev/config/ — Vitest uses the same file (see `test` below).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,27 @@
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { execSync } from 'node:child_process';
+import packageJson from './package.json' with { type: 'json' };
 
 const host = process.env.TAURI_DEV_HOST;
 
 const plugins = await sveltekit();
+
+function getCommitHash(): string {
+  if (process.env.VITE_COMMIT_HASH) {
+    return process.env.VITE_COMMIT_HASH.trim();
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getAppVersion(): string {
+  const version = process.env.VITE_APP_VERSION ?? packageJson.version;
+  return version.startsWith('v') ? version : `v${version}`;
+}
 
 // https://vite.dev/config/ — Vitest uses the same file (see `test` below).
 export default defineConfig({
@@ -11,6 +29,11 @@ export default defineConfig({
 
   /** Expose `ALCHEMY_RPC_KEY` to the client (same var the Tauri backend reads). */
   envPrefix: ['VITE_', 'ALCHEMY_'],
+
+  define: {
+    __APP_COMMIT_HASH__: JSON.stringify(getCommitHash()),
+    __APP_VERSION__: JSON.stringify(getAppVersion()),
+  },
 
   clearScreen: false,
 


### PR DESCRIPTION
## Summary

Adds an in-app **Check for Updates** flow to the Pacto desktop app, including release-asset download/install, relaunch, a startup opt-in toggle, and build/version introspection so users (and devs) know exactly what they are running.

## What changed

- **Updater service** (`src/lib/updater/update-check.ts`) wraps the Tauri updater plugin.
  - States: `idle`, `checking`, `no-update`, `available`, `downloading`, `installing`, `relaunchPending`, `error`, `dev-disabled`.
  - Maps plugin/network/signature errors to user-facing toast messages.
  - Short-circuits in dev builds so the button stays usable and explains that updates are release-build only.
- **Startup check** (`src/stores/startup-check.ts`) is an npub-scoped localStorage toggle loaded on account login and cleared on logout. When enabled, `runPostLoginNetworkSync` fires a non-blocking update check after login sync completes.
- **Shared UI components**
  - `UpdateAvailablePanel.svelte` + `UpdateAvailableModal.svelte`: show available version, download progress, and install/relaunch actions.
  - `AppSettingsSection.svelte`: new Updates section with version label, check button, and startup toggle.
- **Build metadata wiring**
  - `vite.config.ts` injects `__APP_COMMIT_HASH__` and `__APP_VERSION__`.
  - Dev builds show `v0.2.0 (dev 93163db)`; release builds show `v0.2.0 (93163db)`.
  - `.github/workflows/release.yaml` passes `VITE_COMMIT_HASH` and `VITE_APP_VERSION` to release builds.
- **Operator docs** (`docs/build/OPERATOR_UPDATES.md`) document how signed updates are published and what assets the updater needs.

Fixes #70


<img width="534" height="237" alt="Screenshot 2026-07-17 at 6 40 12 PM" src="https://github.com/user-attachments/assets/78f56d7b-49be-4ca9-b073-85fac3a95ed4" />
<img width="714" height="370" alt="Screenshot 2026-07-17 at 6 37 18 PM" src="https://github.com/user-attachments/assets/4c60b1a3-0cc0-49a5-87a8-61639e84a9e0" />
