### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
-## v0.2.0
+## v0.3.0
+
+### Highlights
+- Hardened the squad governance and launch flow: hats-first sponsor deploy paths, ala-carte Safe + governance extensions, sponsored governance writes, and an orchestrated launchpad for new squads.
+- Shipped an operable governance dashboard with a roles tree and module panels so squads can manage on-chain settings interactively.
+- Improved key security with per-device salt support and a migration to the v2 encryption scheme.
+- Kept payout addresses private by routing them through consent-based direct-message exchange instead of public metadata.
+- Added in-app "Check for Updates" with build introspection so users can verify the running release.
+
+### Reliability & Quality
+- Fixed CI landing-site deployments and release-tag resolution, and added the permissions needed for artifact uploads and Pages publishing.
+
+### Documentation
+- Added user-facing encryption architecture guidance and a macOS install quarantine note.
 
 ### Highlights
 - Delivered a full squad-centric governance experience: deploy flows, governance dashboard, squad-bot inbox join flow, polls, and sponsorship workflows.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacto",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "pacto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacto"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Tauri App"
 authors = ["daopunk"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pacto",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "io.pacto",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

This release bump prepares the v0.3.0 desktop build. It synchronizes the package, Cargo, and Tauri manifests, captures the release notes in `CHANGELOG.md`, and updates the Rust lockfile.

## What's in v0.3.0

- Squad governance and launchpad: hats-first sponsor deploy paths, ala-carte Safe + governance extensions, sponsored governance writes, and an operable governance dashboard with roles tree and module panels.
- Crypto hardening: per-device salt support and migration to the v2 encryption scheme.
- Privacy: payout addresses are now shared through consent-based DMs instead of public metadata.
- In-app "Check for Updates" with build introspection.
- CI landing-site and release-tag fixes, plus encryption/macOS install docs.

## Verification

- `pnpm check`: 0 errors
- `pnpm test`: 153 files, 1305 tests passed
- `cargo check`: clean build
- `cargo test`: 292 passed, 0 failed, 1 ignored

## Next steps

After merge, the `v0.3.0` tag pushed from this branch will remain on the release commit and trigger the Tauri release workflow on GitHub.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Moonshot K2.7 Code](https://img.shields.io/badge/Model-Moonshot_K2.7_Code-FF5E5B)
