### PR TITLE
ci: include install instructions in release notes

### DIFF
--- a/.github/release-install-notes.md
+++ b/.github/release-install-notes.md
@@ -1,0 +1,54 @@
+## Install
+
+### macOS
+
+**Homebrew**
+
+```bash
+brew tap covenant-gov/pacto
+brew install --cask pacto
+```
+
+Pacto is currently unsigned. After installing, remove the quarantine attribute:
+
+```bash
+xattr -r -d com.apple.quarantine /Applications/pacto.app
+```
+
+Then launch Pacto from Applications.
+
+**Manual install**
+
+Download the DMG for your Mac and drag `pacto.app` to Applications:
+- Apple Silicon (M1/M2/M3): `pacto_{{VERSION}}_aarch64.dmg`
+- Intel: `pacto_{{VERSION}}_x64.dmg`
+
+Then run the `xattr` command above.
+
+### Linux
+
+**Debian / Ubuntu (AMD64)**
+
+```bash
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/{{TAG}}/pacto_{{VERSION}}_amd64.deb
+sudo dpkg -i pacto_{{VERSION}}_amd64.deb
+```
+
+**Fedora / RHEL / openSUSE (x86_64)**
+
+```bash
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/{{TAG}}/pacto-{{VERSION}}-1.x86_64.rpm
+sudo dnf install ./pacto-{{VERSION}}-1.x86_64.rpm
+```
+
+**AppImage**
+
+```bash
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/{{TAG}}/pacto_{{VERSION}}_amd64.AppImage
+chmod +x pacto_{{VERSION}}_amd64.AppImage
+./pacto_{{VERSION}}_amd64.AppImage
+```
+
+### Windows
+
+Download `pacto_{{VERSION}}_x64_en-US.msi` and run it. Windows Defender SmartScreen may warn that the app is unsigned; click **More info** → **Run anyway**.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,17 +25,12 @@ jobs:
         id: notes
         env:
           CHANGELOG: ${{ steps.changelog.outputs.content }}
+          TAG: ${{ github.ref_name }}
         run: |
+          VERSION="${TAG#v}"
           {
             printf '%s\n' "$CHANGELOG"
-            echo ""
-            echo "## Install"
-            echo ""
-            echo "**macOS:** Download the \`.dmg\` for your architecture, open it, and drag Pacto to Applications. For Apple Silicon (M1/M2/M3) use the \`aarch64\` DMG; for Intel Macs use the \`x64\` DMG."
-            echo ""
-            echo "**Linux:** Download the \`.AppImage\` matching your architecture (\`amd64\` or \`arm64\`), run \`chmod +x <file>.AppImage\`, then execute it. Debian/Ubuntu users can install the \`.deb\` package instead."
-            echo ""
-            echo "**Windows:** Download the \`.msi\` or \`.exe\` installer and run it."
+            sed -e "s/{{TAG}}/$TAG/g" -e "s/{{VERSION}}/$VERSION/g" .github/release-install-notes.md
           } > release-body.md
 
       - name: Upload release notes


### PR DESCRIPTION
Adds a templated install section (`.github/release-install-notes.md`) and updates the release workflow to append it to every new release, substituting `{{TAG}}` and `{{VERSION}}` automatically.