### PR TITLE
feat: add verified seed-backup gate for risky actions

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -63,6 +63,15 @@ A shared vocabulary for humans and coding agents working on Pacto. Terms are ord
 | **require_capability** | Rust ACL gate on squad-scoped writes; denies unbound roster or missing hat/role before broadcast. |
 | **Greenfield** | Repo posture: no public alpha shipped yet; prefer breaking, minimal paths over compatibility shims. |
 
+## Onboarding
+
+| Term | Definition |
+|------|------------|
+| **Verified seed-backup gate** | A first-run safety ritual where the user writes down their BIP-39 seed offline and verifies a random subset of words before accessing risky actions. See `docs/brainstorms/2026-07-18-onboarding-verified-seed-backup-requirements.md`. |
+| **Progressive gate** | Enforcement model where the main app shell is available but specific risky actions are blocked until the user completes a required step (e.g., backup verification). |
+| **Backup verified** | Per-account status indicating the user has successfully completed the verified seed-backup ritual. |
+| **Random-subset verification** | Backup verification method that asks the user to enter a random subset of words by their position numbers (e.g., words #3, #7, #12). |
+
 ## See also
 
 - `docs/README.md` — authoritative docs index

--- a/docs/brainstorms/2026-07-18-onboarding-verified-seed-backup-requirements.md
+++ b/docs/brainstorms/2026-07-18-onboarding-verified-seed-backup-requirements.md
@@ -1,0 +1,165 @@
+---
+date: 2026-07-18
+topic: onboarding-verified-seed-backup
+---
+
+# Verified seed-backup gate (first milestone)
+
+## Summary
+
+Introduce a progressive, per-account verified seed-backup gate for Pacto. Fresh accounts see it after PIN setup; existing unverified accounts see it on next unlock. DMs stay available before verification, but seed export, squad creation, squad invite acceptance, treasury interactions, and fund sends are blocked until the user writes down the seed and verifies a random subset by number. Imports with a recovery phrase skip the ritual.
+
+## Problem frame
+
+Pacto is a self-custody app: one BIP-39 seed powers both the Nostr identity and the embedded EVM wallet. If a user loses the seed, they lose messaging identity and any funds. Today there is no enforced safety ritual before risky actions; the seed can be viewed in Settings (`src/components/settings/ProfileSection.svelte`), but nothing verifies the user wrote it down. Squad invites, treasury deploys, and fund sends are reachable before any backup check. This is the single catastrophic loss point in the first-run experience.
+
+## Key decisions
+
+- **Progressive gate, not hard gate.** The main shell unlocks after PIN setup; only risky actions are blocked until backup is verified. This preserves a meaningful first action (DMs) while still protecting the surfaces that can cause irreversible loss.
+- **Random-subset verification.** After showing the seed, the user verifies a random subset of words by their position numbers. This is stronger than self-attest and less tedious than full re-entry.
+- **Three attempts, then re-show.** A failed verification re-shows the full seed so the user can re-copy and try again. No lockouts or cooldowns in the first milestone.
+- **Imports skip verification.** A user who imports with a recovery phrase is assumed to already have the phrase offline. The gate applies only to fresh accounts created inside Pacto.
+- **Per-npub persistence.** Backup-verified status is stored per account, not per install, so existing unverified accounts are covered and verification survives PIN changes or app reinstalls.
+- **All risky actions gated.** Seed export, squad creation, squad invite acceptance, treasury operations, and fund sends require verification. DMs do not.
+
+## Requirements
+
+### Backup tracking and prompt
+
+- R1. Persist a `backupVerified` boolean per npub in the per-account store (`src/stores/persistence-context.ts` or backend equivalent).
+- R2. For a fresh account, show the backup prompt after the user completes PIN setup and reaches the main shell.
+- R3. For an existing account that is not yet verified, show the backup prompt on the next unlock after this feature ships.
+- R4. The backup prompt is dismissible. A dismissed prompt returns on the next unlock or when the user attempts a gated action.
+- R5. Display a persistent but dismissible indicator (e.g., banner, badge on Settings, or alert in the squad/DM sidebars) until verification is complete.
+
+### Verification ritual
+
+- R6. The verification flow has three steps: show the full seed phrase, instruct the user to write it down offline, then ask for a random subset of words by their position numbers.
+- R7. The random subset uses at least 3 words and covers different positions across the phrase (e.g., word #3, #7, #12). The exact positions are randomized per attempt.
+- R8. If the user enters the subset correctly, mark the account as `backupVerified` and close the flow.
+- R9. If the user enters the subset incorrectly, allow up to 3 attempts on the same shown seed, then re-show the full seed and restart the ritual.
+- R10. The seed is never displayed again after successful verification except through the existing Settings export flow, which remains gated by the backup check (see R13).
+
+### Gated actions
+
+- R11. Before verification, DMs remain fully usable and Commons browsing remains available. Sending messages, receiving messages, and browsing the discovery feed are allowed.
+- R12. Before verification, the following actions are blocked and surface the backup gate:
+  - Viewing or exporting the seed phrase from any surface.
+  - Creating a new squad.
+  - Accepting a squad invite (including channel-in-squad invites).
+  - Interacting with squad treasury (Sponsor/Gov/Safe deploys, proposals, signing).
+  - Sending or moving funds from any wallet.
+- R13. The existing seed export modal in Settings (`src/components/settings/EvmAccountKeyExportModal.svelte`) must trigger the backup gate before it can reveal the seed; it becomes the post-verification view path, not the first-time backup path.
+- R14. Imports with a recovery phrase (`src/lib/api/auth.ts:loginWithRecoveryPhrase`) set `backupVerified` to true and skip the ritual.
+
+### Cross-cutting UX
+
+- R15. The backup prompt and gate use plain, non-technical language that explains why backing up matters, without mentioning `npub`, `nsec`, `MLS`, or `BIP-39` unless the user explicitly navigates to advanced surfaces.
+- R16. The flow is keyboard-navigable and accessible: the seed display is readable, word positions are announced clearly, and errors are specific (“Word #3 does not match” rather than “incorrect”).
+- R17. No network calls are required for the backup flow; it operates entirely on local state and the encrypted seed already in memory after PIN unlock.
+
+## Key flows
+
+### F1. Fresh account reaches backup prompt
+
+- **Trigger:** User creates a new account and completes PIN setup.
+- **Actors:** New Pacto user.
+- **Steps:**
+  1. `Login.svelte` finishes `pin-confirm` and unlocks the main shell.
+  2. The backup prompt appears as a modal or top banner.
+  3. User can choose “Back up now” or “Remind me later.”
+  4. If “Remind me later,” the prompt closes and the user lands on DMs.
+- **Outcome:** Account is created; `backupVerified` remains false until the user completes the ritual.
+
+### F2. Existing unverified account sees prompt on unlock
+
+- **Trigger:** User unlocks an existing account after the feature ships.
+- **Actors:** Existing Pacto user who has never verified backup.
+- **Steps:**
+  1. `checkAuthStatus` and `unlockWithPin` complete.
+  2. App checks `backupVerified` for the current npub.
+  3. If false, the backup prompt appears.
+  4. User can dismiss and continue to DMs or start the ritual.
+- **Outcome:** Existing users are pulled into the same safety net without re-creating accounts.
+
+### F3. Gated action triggers backup gate
+
+- **Trigger:** User clicks a gated action (e.g., “Accept invite” or “Send”) before verification.
+- **Actors:** Any unverified user.
+- **Steps:**
+  1. The app intercepts the action before invoking the underlying command.
+  2. A backup gate screen/modal explains the action requires a verified backup.
+  3. User can start the ritual or cancel and return to the prior screen.
+- **Outcome:** The risky action is deferred until verification completes.
+
+### F4. Successful verification
+
+- **Trigger:** User chooses “Back up now” from any prompt or gate.
+- **Actors:** Unverified user.
+- **Steps:**
+  1. App shows the full seed with clear “write this down offline” messaging.
+  2. User confirms they have written it down.
+  3. App asks for a random subset of words by position.
+  4. User enters the words correctly within 3 attempts.
+  5. App sets `backupVerified` to true, removes all indicators, and closes the flow.
+- **Outcome:** Risky actions are now unlocked for this npub on all devices.
+
+### F5. Failed verification re-shows seed
+
+- **Trigger:** User enters the wrong random-subset words three times.
+- **Actors:** Unverified user.
+- **Steps:**
+  1. App shows an error: “Those words don’t match. Here is the seed again so you can re-check.”
+  2. App returns to the seed display step.
+  3. User re-copies and starts a new verification round.
+- **Outcome:** No lockout; the loop is repeated until success or cancel.
+
+## Acceptance examples
+
+- AE1. Fresh account, user dismisses backup prompt, opens DMs, sends a message. **Covers:** R2, R4, R11.
+- AE2. Fresh account, user accepts squad invite, app shows backup gate, user completes verification, invite accept resumes. **Covers:** R12, F3, F4.
+- AE3. Existing unverified account, user unlocks, prompt appears, user dismisses, prompt does not reappear until next unlock or gated action. **Covers:** R3, R4.
+- AE4. User exports seed from Settings before verification; app shows backup gate instead of revealing seed. **Covers:** R12, R13.
+- AE5. User imports with recovery phrase, lands on main shell, no backup prompt appears, gated actions work immediately. **Covers:** R14.
+- AE6. User fails random-subset verification twice, succeeds on third attempt. **Covers:** R9.
+- AE7. User fails random-subset verification three times, app re-shows seed. **Covers:** R9, F5.
+
+## Scope boundaries
+
+### Deferred for later
+
+- The other six onboarding ideas from issue #85: intent-based first-run router, unified onboarding checklist, invite-accept guided funnel, solo sandbox squad, one-click testnet treasury sandbox, and context-aware empty-state coach cards.
+- Advanced backup forms: social recovery, encrypted cloud backup, hardware wallet integration, and multi-share schemes.
+- A hard gate that blocks the main shell until backup is verified.
+- Cooldowns, lockouts, or rate-limiting on verification attempts.
+- Backup verification for accounts imported via nsec-only unlock (`src/lib/api/auth.ts:login`). The import-with-seed path skips; nsec-only unlock is a separate advanced case and is not in this milestone.
+
+### Outside this product's identity
+
+- Centralized recovery services that hold user keys.
+- SMS/email backup reminders that depend on external identity.
+- Any form of KYC or identity verification.
+
+## Dependencies and assumptions
+
+- The seed is available in memory after PIN unlock (`get_seed` in `src/lib/api/auth.ts`), so the backup flow can run without additional decryption.
+- Per-account persistence (`src/stores/persistence-context.ts`) is the right place for the `backupVerified` flag. If backend state is preferred, it should be stored in the per-account SQLite `vector.db` and re-synced on unlock.
+- The current squad invite flow (`src/lib/app/invites/accept-invite.ts`) can be wrapped to check the backup flag before calling `acceptMlsWelcome`.
+- The current wallet/treasury commands can check the flag before signing or broadcasting.
+
+## Outstanding questions
+
+- **Resolved:** Commons browsing is available before verification, alongside DMs.
+- **Deferred to planning:** Exact UI shape of the backup prompt (modal vs banner), the random-subset size (3 vs 4 words), and whether the persistent indicator is a banner, sidebar badge, or checklist entry.
+- **Deferred to planning:** Whether the proactive prompt should be shown on every unlock until verified, or only once per session/day.
+
+## Sources
+
+- Issue #85: Onboarding: coordinated first-run experience so new users reach value before key, squad, and treasury cliffs.
+- `STRATEGY.md` — target problem, key metrics, and tracks.
+- `CONCEPTS.md` — definitions of npub, nsec, BIP-39 seed, squad, treasury, roster EVM, etc.
+- `src/components/auth/Login.svelte` — existing auth steps (`checking`, `welcome`, `pin-create`, `pin-confirm`, `pin-unlock`).
+- `src/lib/api/auth.ts` — `createAccount`, `loginWithRecoveryPhrase`, `exportRecoveryPhrase`, `get_seed`.
+- `src/components/settings/EvmAccountKeyExportModal.svelte` and `ProfileSection.svelte` — existing seed export surfaces.
+- `src/lib/app/invites/accept-invite.ts` and `src/lib/api/nostr.ts` — squad invite accept flow.
+- Grounding dossier: `/tmp/compound-engineering/ce-brainstorm/2026-07-18-onboarding-coordinated-first-run/grounding.md`.

--- a/docs/plans/2026-07-19-001-feat-verified-seed-backup-gate-plan.md
+++ b/docs/plans/2026-07-19-001-feat-verified-seed-backup-gate-plan.md
@@ -1,0 +1,325 @@
+---
+title: Verified seed-backup gate
+type: feat
+date: 2026-07-19
+origin: docs/brainstorms/2026-07-18-onboarding-verified-seed-backup-requirements.md
+---
+
+# Verified seed-backup gate
+
+## Summary
+
+Add a progressive, per-account verified seed-backup gate to Pacto. The main shell unlocks after PIN, but seed export, squad creation, squad invite acceptance, treasury operations, and fund sends are blocked until the user writes down their BIP-39 seed and verifies a random subset. DMs and Commons browsing remain available before verification.
+
+---
+
+## Problem frame
+
+Pacto is a self-custody app: one BIP-39 seed powers both the Nostr identity and the embedded EVM wallet. If a user loses the seed, they lose messaging identity and any funds. Today the seed can be exported from Settings before any backup ritual, and risky actions like squad invites, treasury deploys, and fund sends are reachable before any safety check. This is the single catastrophic loss point in the first-run experience.
+
+---
+
+## Requirements
+
+### Backup tracking and prompt
+
+- R1. Persist a `backupVerified` boolean per npub in the per-account store.
+- R2. For a fresh account, show the backup prompt after the user completes PIN setup and reaches the main shell.
+- R3. For an existing account that is not yet verified, show the backup prompt on the next unlock after this feature ships.
+- R4. The backup prompt is dismissible. A dismissed prompt returns on the next unlock or when the user attempts a gated action.
+- R5. Display a persistent but dismissible indicator until verification is complete.
+
+### Verification ritual
+
+- R6. The verification flow has three steps: show the full seed phrase, instruct the user to write it down offline, then ask for a random subset of words by their position numbers.
+- R7. The random subset uses at least 3 words and covers different positions across the phrase. The exact positions are randomized per attempt.
+- R8. If the user enters the subset correctly, mark the account as `backupVerified` and close the flow.
+- R9. If the user enters the subset incorrectly, allow up to 3 attempts on the same shown seed, then re-show the full seed and restart the ritual.
+- R10. The seed is never displayed again after successful verification except through the existing Settings export flow, which remains gated by the backup check.
+
+### Gated actions
+
+- R11. Before verification, DMs remain fully usable and Commons browsing remains available.
+- R12. Before verification, the following actions are blocked and surface the backup gate: viewing or exporting the seed phrase; creating a new squad; accepting a squad invite (including channel-in-squad invites); interacting with squad treasury; sending or moving funds from any wallet.
+- R13. The existing seed export modal in Settings must trigger the backup gate before it can reveal the seed; it becomes the post-verification view path, not the first-time backup path.
+- R14. Imports with a recovery phrase set `backupVerified` to true and skip the ritual.
+
+### Cross-cutting UX
+
+- R15. The backup prompt and gate use plain, non-technical language that explains why backing up matters, without mentioning `npub`, `nsec`, `MLS`, or `BIP-39` unless the user explicitly navigates to advanced surfaces.
+- R16. The flow is keyboard-navigable and accessible: the seed display is readable, word positions are announced clearly, and errors are specific.
+- R17. No network calls are required for the backup flow; it operates entirely on local state and the encrypted seed already in memory after PIN unlock.
+
+---
+
+## Key technical decisions
+
+1. **Store `backupVerified` in per-account SQLite via the existing `settings` table.** `src-tauri/src/db.rs` already exposes `get_sql_setting` and `set_sql_setting` commands and the `settings` table is keyed by string. A `backup_verified` key with `"true"`/`"false"` fits the existing pattern and avoids a new schema migration. This satisfies R1 and R17 (no network calls, local SQLite state) and keeps the flag tied to the account directory rather than per-install `localStorage`.
+2. **Gate risky actions at the frontend action layer, not inside Rust commands.** The UI will check the `backupVerified` flag before invoking squad, wallet, treasury, or seed-export commands. This preserves DMs and Commons as ungated (R11), avoids touching every Rust command, and matches the self-custody trust model where the app is a client, not an enforceable platform.
+3. **Wrap treasury/governance actions in the Svelte components that initiate them, not in `src/lib/governance/api.ts`.** The governance API file is a thin wrapper used by many read-only views. Gating at the button handler keeps read-only queries unaffected and avoids leaking UI concerns into the API layer.
+4. **Re-use the existing `get_seed`/`exportRecoveryPhrase` path for the ritual.** The encrypted seed is already in memory after PIN unlock. The backup flow calls the existing export helper to show the phrase, then verifies a random subset locally. No new backend crypto is needed.
+5. **Introduce a new `BackupVerificationModal` component for the ritual; keep `EvmAccountKeyExportModal` as the post-verification seed export path.** This satisfies R13: the existing export modal becomes the view users reach after verification, while the first-time ritual lives in its own component with written-confirmation and random-subset steps.
+6. **3-word random-subset verification with 3 attempts per shown seed.** This meets the R7 minimum of 3 words, is less tedious than full re-entry, and R9's 3-attempt limit before re-showing the seed gives users room to correct transcription errors without lockouts.
+7. **Show the proactive backup prompt on every unlock until verified.** This is the straightforward reading of R3 and R4: existing unverified accounts see the prompt on the next unlock, and a dismissed prompt returns on the next unlock.
+
+---
+
+## High-level technical design
+
+```mermaid
+flowchart TB
+    subgraph Auth["Auth flow"]
+        A[PIN create / unlock] --> B{backupVerified?}
+    end
+
+    B -->|false| C[Show BackupVerificationModal]
+    B -->|true| D[Main shell]
+
+    C --> E[Show seed phrase]
+    E --> F[Written confirmation]
+    F --> G[Random-subset quiz]
+    G -->|correct| H[Set backupVerified=true]
+    G -->|3 wrong| E
+
+    H --> D
+
+    D --> I[Persistent banner]
+    D --> J[Gated action]
+
+    J --> K{backupVerified?}
+    K -->|false| C
+    K -->|true| L[Execute action]
+
+    I -->|"Back up now"| C
+```
+
+- **State layer:** A frontend Svelte store (`backupVerification`) mirrors the `backup_verified` SQL setting. On login, `loadAccountState` calls `get_sql_setting` to hydrate the store; on logout/clear, the in-memory store resets.
+- **Prompt layer:** `Login.svelte` transitions to the main shell only after PIN success. `+page.svelte` checks `backupVerified` after auth becomes true and opens the modal if false. The modal is also opened from gated action handlers.
+- **Ritual layer:** `BackupVerificationModal` fetches the seed via `exportRecoveryPhrase`, displays it with a reveal mask, advances to the random-subset quiz, and calls `set_sql_setting` on success.
+- **Gate layer:** A reusable helper (`requireBackupVerified`) checks the store and opens the modal. Squad creation, invite acceptance, wallet send, treasury ops, and seed export all call this helper before their real work.
+
+---
+
+## Implementation units
+
+### U1. Backup-verified persistence and state store
+
+- **Goal:** Store `backupVerified` per account in the existing SQLite `settings` table and expose it as a frontend Svelte store.
+- **Requirements:** R1, R14, R17.
+- **Dependencies:** None.
+- **Files:**
+  - `src/lib/api/settings.ts` (new) — typed wrappers for `get_sql_setting` / `set_sql_setting`.
+  - `src/stores/backup-verification.ts` (new) — `backupVerified`, `loadBackupVerified`, `markBackupVerified`.
+  - `src/stores/persistence.ts` — call `loadBackupVerified` from `loadAccountState`.
+  - `src/lib/utils/clear-account-state.ts` — reset the `backupVerified` store.
+  - `src-tauri/src/db.rs` — no change required; commands already exist.
+- **Approach:** Add a frontend wrapper around the existing Rust `get_sql_setting` / `set_sql_setting` commands. The key is `backup_verified`. On `loadAccountState`, after `setCurrentNpubForPersistence`, read the SQL setting and initialize the store. On `clearAccountState`, reset the store to `null`/`false`. The import flow (`loginWithRecoveryPhrase`) will additionally set the flag to `true` (see U4).
+- **Patterns to follow:** `src/stores/persistence.ts` for account-state hydration; `src/lib/api/nostr.ts` for typed `invoke` wrappers.
+- **Test scenarios:**
+  - Happy path: `loadAccountState` with no `backup_verified` setting leaves the store as `false`; with `"true"` leaves it as `true`.
+  - Edge case: `clearAccountState` resets the store to `false` / `null`.
+  - Error path: missing Tauri context returns a sensible default (`false`) without crashing the auth flow.
+- **Verification:** The store reflects the SQL setting immediately after login; clearing account state resets it.
+
+### U2. Random-subset verification utility
+
+- **Goal:** Provide the logic to pick random word positions, check answers, and manage the 3-attempt loop.
+- **Requirements:** R6, R7, R8, R9.
+- **Dependencies:** U1 (stores the final result).
+- **Files:**
+  - `src/lib/utils/seed-verification.ts` (new) — pure functions for position selection and validation.
+  - `src/lib/utils/seed-verification.test.ts` (new) — unit tests.
+- **Approach:** Expose `createChallenge(seedWords: string[], count?: number): { positions: number[]; answers: string[] }` and `checkChallenge(words: string[], positions: number[], inputs: string[]): { correct: boolean; details: { position: number; expected: string; actual: string }[] }`. Keep the function deterministic enough for tests by allowing an optional RNG. The default uses `Math.random` to pick distinct positions. After 3 failed attempts, callers restart the ritual (re-create the challenge from a freshly shown seed).
+- **Patterns to follow:** Other pure utility tests under `src/lib/utils/` (e.g., `amount-input.test.ts`).
+- **Test scenarios:**
+  - Happy path: a 12-word seed produces 3 distinct positions between 1 and 12; matching inputs pass.
+  - Edge case: a 24-word seed produces positions within 1–24; all positions are distinct.
+  - Error path: one wrong input fails; after 3 wrong attempts the caller re-shows the seed (utility returns the attempt count for the UI to react).
+  - Integration scenario: function reports per-word mismatch details so the UI can show "Word #3 does not match".
+- **Verification:** Unit tests cover 12-word and 24-word seeds, position distinctness, and mismatch reporting.
+
+### U3. Backup verification modal component
+
+- **Goal:** Build the ritual UI: show seed, ask for written confirmation, quiz random words, and handle 3-attempt re-show logic.
+- **Requirements:** R6, R7, R8, R9, R10, R15, R16, R17.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `src/components/backup/BackupVerificationModal.svelte` (new).
+  - `src/components/backup/BackupVerificationModal.test.ts` (new) — optional if component testing exists; otherwise rely on store/util tests.
+- **Approach:** Use a three-phase modal: `show` (seed with reveal mask and copy warning), `confirm` (checkbox or button confirming the seed is written down), `quiz` (numbered inputs for the random subset). On success, call `markBackupVerified()` and close. On 3 failures, transition back to `show` with a new seed-derived challenge. Fetch the seed with `exportRecoveryPhrase()` (or `get_seed`) after PIN is already in memory. Use plain language: "Write these 12 words down on paper" rather than BIP-39 terminology.
+- **Patterns to follow:** `src/components/settings/EvmAccountKeyExportModal.svelte` for modal shell, reveal mask, and copy behavior; `src/components/ui/Modal.svelte` if available.
+- **Test scenarios:**
+  - Happy path: user reveals seed, confirms written, enters 3 correct words, modal closes, `backupVerified` becomes `true`.
+  - Edge case: user enters 2 wrong words, then correct words on the third attempt; success still sets the flag.
+  - Error path: 3 wrong attempts return the user to the seed display with a new challenge.
+  - Integration scenario: closing the modal mid-ritual does not change verification state; reopening starts fresh from the prompt.
+- **Verification:** Manual and/or unit-test coverage of the phase machine and success/failure transitions.
+
+### U4. Proactive prompt after account creation and unlock
+
+- **Goal:** Trigger the backup modal after fresh account creation and after every unlock for unverified accounts.
+- **Requirements:** R2, R3, R4, R14.
+- **Dependencies:** U1, U3.
+- **Files:**
+  - `src/stores/auth.ts` — after `createAccount` and `unlockWithPin`, set a flag/prompt store if `backupVerified` is `false`. Also set `backupVerified` to `true` for recovery-phrase imports.
+  - `src/components/auth/Login.svelte` — no change unless a post-login step is needed.
+  - `src/routes/+page.svelte` — observe auth + `backupVerified` and open the modal.
+- **Approach:** After successful `createAccount` or `unlockWithPin`, once the user is authenticated and `loadAccountState` has run, the main page checks `backupVerified`. If `false`, open `BackupVerificationModal`. For `importAccount`, call `markBackupVerified(true)` immediately after the account is created and skip the modal. For dismiss behavior, closing the modal simply hides it; it will reappear on the next unlock or gated action.
+- **Patterns to follow:** Existing `loadAccountState` and auth store flow; post-login toasts (`pendingReadyToast`).
+- **Test scenarios:**
+  - Happy path: fresh account reaches main shell; modal opens automatically.
+  - Happy path: recovery-phrase import reaches main shell; modal does not open and `backupVerified` is `true`.
+  - Edge case: existing unverified account unlocks; modal opens.
+  - Error path: closing the modal does not mark verified; next unlock reopens it.
+- **Verification:** Fresh account shows prompt; import skips; existing unverified account shows prompt on unlock; dismiss returns on next unlock.
+
+### U5. Gated Settings seed export
+
+- **Goal:** Block the existing seed export modal until backup is verified; after verification, the export modal works as before.
+- **Requirements:** R12, R13.
+- **Dependencies:** U1, U3.
+- **Files:**
+  - `src/components/settings/ProfileSection.svelte` — wrap the `Export seed phrase` button click.
+- **Approach:** Instead of directly setting `exportSeedModalOpen = true`, the button calls `requireBackupVerified()`. If `backupVerified` is `true`, the export modal opens. If `false`, the backup verification modal opens. After successful verification, the export modal can then open (or the user can click the button again). Do not duplicate seed export logic inside the ritual component.
+- **Patterns to follow:** Existing `exportSeedModalOpen` toggle and `EvmAccountKeyExportModal` usage.
+- **Test scenarios:**
+  - Happy path: verified account clicks Export seed phrase; export modal opens.
+  - Error path: unverified account clicks Export seed phrase; backup verification modal opens instead.
+  - Integration scenario: completing verification from the gate does not automatically open the export modal; user must click again (avoids surprising flow jumps).
+- **Verification:** Unverified users cannot see the seed without first completing the ritual.
+
+### U6. Gated squad creation and invite acceptance
+
+- **Goal:** Block new squad creation and all squad invite acceptance paths until backup is verified.
+- **Requirements:** R12.
+- **Dependencies:** U1, U3.
+- **Files:**
+  - `src/components/layout/Navbar.svelte` — gate `createSquadWithAnnouncements` / `handleCreateSquad`.
+  - `src/lib/invites/accept-invite.ts` — gate `acceptAnnouncementsInvite`, `acceptSquadOrPairInvite`, and `acceptChannelInSquadInvite`.
+- **Approach:** At the top of each handler, check `backupVerified`. If `false`, call `requireBackupVerified()` and return early. After successful verification, the user must retry the action (this avoids hanging state and partially-completed squad creation). The same helper is used for consistency with other gates.
+- **Patterns to follow:** Existing invite-accept state stores (`acceptingSquadInviteId`, `acceptingChannelInSquadId`) to prevent double-submission.
+- **Test scenarios:**
+  - Happy path: verified user creates a squad; flow succeeds.
+  - Happy path: verified user accepts a squad invite; flow succeeds.
+  - Error path: unverified user clicks Create; backup modal opens; cancelling returns to the create form without creating.
+  - Error path: unverified user clicks Accept invite; backup modal opens; cancelling leaves the invite pending.
+- **Verification:** Verified users can create/accept; unverified users are stopped before any backend call.
+
+### U7. Gated wallet sends and treasury operations
+
+- **Goal:** Block fund sends and treasury interactions until backup is verified.
+- **Requirements:** R12.
+- **Dependencies:** U1, U3.
+- **Files:**
+  - `src/components/wallet/WalletHomeSendModal.svelte` — gate `handleConfirm` before `walletBuildAndSendTransaction`.
+  - `src/components/wallet/WalletTransferStubModal.svelte` — gate its send confirm handler.
+  - `src/components/parent/dashboard/GovernanceDeployCoordinator.svelte` — gate treasury/governance deploy actions.
+  - `src/components/parent/governance/GovCrewActions.svelte` — gate mutiny and vote buttons.
+  - `src/components/parent/governance/MutinyModulePanel.svelte` — gate mutiny actions.
+  - `src/components/parent/dashboard/TreasuryPanel.svelte` or equivalent sponsor deposit/withdraw entry points.
+- **Approach:** Wrap the user-facing action handlers with `requireBackupVerified()`. If unverified, show the backup modal and do not proceed. Gate at the button handler, not inside `src/lib/governance/api.ts`, so read-only queries and dashboard rendering remain unaffected. After verification, the user retries the action.
+- **Patterns to follow:** Existing wallet send modal error handling and confirmation flow.
+- **Test scenarios:**
+  - Happy path: verified user sends funds; `walletBuildAndSendTransaction` is invoked.
+  - Happy path: verified user creates a treasury proposal; command is invoked.
+  - Error path: unverified user clicks Send confirm; backup modal opens and no backend command is called.
+  - Error path: unverified user clicks a treasury deploy/vote button; backup modal opens.
+- **Verification:** No send, deploy, vote, or execute command is invoked while `backupVerified` is `false`.
+
+### U8. Persistent banner indicator
+
+- **Goal:** Show a dismissible but recurring indicator that the account is not backed up, until verification completes.
+- **Requirements:** R5.
+- **Dependencies:** U1, U4.
+- **Files:**
+  - `src/routes/+page.svelte` — mount the banner and wire it to the backup prompt store.
+  - `src/components/backup/BackupBanner.svelte` (new) — the banner UI.
+- **Approach:** Add a banner at the top of the main shell that renders when `backupVerified === false` and the user is on a non-gated view (DMs/Commons/Squads). The banner can be dismissed per session, but reappears on the next unlock (R4). Include a "Back up now" button that opens `BackupVerificationModal`. Use a non-intrusive color that still signals caution.
+- **Patterns to follow:** Existing toast and modal patterns; keep the banner outside the main scroll area so it remains visible.
+- **Test scenarios:**
+  - Happy path: unverified account sees banner on main shell; clicking "Back up now" opens the modal.
+  - Happy path: after successful verification, the banner disappears and does not return.
+  - Edge case: dismissing the banner hides it for the current session; it returns on next unlock.
+- **Verification:** Banner is visible for unverified accounts, dismissible, and gone after verification.
+
+---
+
+## Scope boundaries
+
+### Deferred for later
+
+- The other six onboarding ideas from issue #85: intent-based first-run router, unified onboarding checklist, invite-accept guided funnel, solo sandbox squad, one-click testnet treasury sandbox, and context-aware empty-state coach cards.
+- Advanced backup forms: social recovery, encrypted cloud backup, hardware wallet integration, and multi-share schemes.
+- A hard gate that blocks the main shell until backup is verified.
+- Cooldowns, lockouts, or rate-limiting on verification attempts.
+- Backup verification for accounts imported via nsec-only unlock.
+
+### Outside this product's identity
+
+- Centralized recovery services that hold user keys.
+- SMS/email backup reminders that depend on external identity.
+- Any form of KYC or identity verification.
+
+---
+
+## System-wide impact
+
+- **Auth and persistence:** `loadAccountState` must hydrate the `backupVerified` flag from SQLite, and `clearAccountState` must reset it. This adds one async call on every login but no network traffic.
+- **Shell layout:** A persistent banner is rendered in the main shell when `backupVerified` is `false`. It must be positioned so it does not block the bottom nav, DM composer, or wallet sidebar interactions.
+- **Read-only vs. write paths:** The gate only blocks write/initiation actions. Reads such as treasury balances, governance status, and proposal lists continue to render for unverified accounts so users can browse before backing up.
+- **Retry UX:** Because gates return early and require the user to retry the action, all affected handlers must reset their loading/acting flags correctly if the backup modal is dismissed.
+- **Testing:** Every gated surface needs a test that asserts no backend command is invoked while `backupVerified` is `false`. The most brittle area is treasury governance, where many buttons dispatch to `src/lib/governance/api.ts`.
+
+---
+
+## Risks and dependencies
+
+- **Risk:** Users may confuse the new backup modal with the existing seed export modal. Mitigation: use distinct titles and language in the ritual component ("Back up your account" vs. "Export seed phrase"), and keep the export modal as the post-verification path only.
+- **Risk:** Gating at the frontend action layer is bypassable by a determined user or bug. Mitigation: this is acceptable for the first milestone because the threat is self-harm, not external attack; the app is self-custody and the user controls the device. The gate is a safety ritual, not a cryptographic boundary.
+- **Risk:** Existing unverified accounts could see the prompt at an inconvenient moment. Mitigation: the prompt is dismissible and DMs/Commons remain usable; it reappears on the next unlock or gated action rather than being modal-only.
+- **Dependency:** The existing `get_sql_setting` / `set_sql_setting` commands and `settings` table must remain stable. The commands are already registered and used elsewhere in the app.
+- **Dependency:** The seed must be available in memory after PIN unlock via `exportRecoveryPhrase` or `get_seed`. This is already true for the existing Settings export flow.
+
+---
+
+## Acceptance examples
+
+- AE1. Fresh account, user dismisses backup prompt, opens DMs, sends a message. **Covers:** R2, R4, R11.
+- AE2. Fresh account, user accepts squad invite, app shows backup gate, user completes verification, invite accept resumes. **Covers:** R12, F3, F4.
+- AE3. Existing unverified account, user unlocks, prompt appears, user dismisses, prompt does not reappear until next unlock or gated action. **Covers:** R3, R4.
+- AE4. User exports seed from Settings before verification; app shows backup gate instead of revealing seed. **Covers:** R12, R13.
+- AE5. User imports with recovery phrase, lands on main shell, no backup prompt appears, gated actions work immediately. **Covers:** R14.
+- AE6. User fails random-subset verification twice, succeeds on third attempt. **Covers:** R9.
+- AE7. User fails random-subset verification three times, app re-shows seed. **Covers:** R9, F5.
+
+---
+
+## Open questions
+
+### Resolved during planning
+
+- **Persistence backend:** Use the existing `settings` SQL table via `get_sql_setting` / `set_sql_setting`, not frontend `localStorage`. This satisfies per-account persistence while staying local and network-free.
+- **UI shape:** Modal for the first-time prompt/ritual, plus a persistent banner indicator. The modal is harder to ignore for the safety ritual; the banner provides a reminder without blocking value.
+- **Random-subset size:** 3 words per attempt.
+- **Proactive prompt frequency:** On every unlock until verified.
+
+### Deferred to implementation
+
+- Exact visual treatment of the banner (color, wording, position) once implemented in the layout.
+- Whether the banner should also appear inside the wallet view or only at the top of the main shell.
+- Exact wording for the plain-language seed-backup explanation.
+
+---
+
+## Sources and research
+
+- Origin requirements: `docs/brainstorms/2026-07-18-onboarding-verified-seed-backup-requirements.md`.
+- Domain definitions: `CONCEPTS.md` (Verified seed-backup gate, Progressive gate, Backup verified, Random-subset verification).
+- Product strategy: `STRATEGY.md` (Trust & safety track; self-custody, no KYC).
+- Existing auth flow: `src/stores/auth.ts`, `src/components/auth/Login.svelte`.
+- Existing seed export: `src/components/settings/EvmAccountKeyExportModal.svelte`, `src/components/settings/ProfileSection.svelte`.
+- Existing settings persistence: `src-tauri/src/db.rs` (`get_sql_setting`, `set_sql_setting`, `settings` table), `src-tauri/src/account_manager.rs`.
+- Existing invite flow: `src/lib/invites/accept-invite.ts`, `src/components/layout/Navbar.svelte`.
+- Existing wallet send: `src/components/wallet/WalletHomeSendModal.svelte`, `src/lib/wallet/backend-wallet.ts`.
+- Existing governance/treasury commands: `src/lib/governance/api.ts`, `src-tauri/src/evm/*`.
+- Existing state reset: `src/lib/utils/clear-account-state.ts`.

--- a/src/components/backup/BackupBanner.svelte
+++ b/src/components/backup/BackupBanner.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { isAuthenticated } from '../../stores/auth';
+  import {
+    backupVerified,
+    backupVerificationModalOpen,
+  } from '../../stores/backup-verification';
+
+  let dismissed = false;
+</script>
+
+{#if $backupVerified === false && $isAuthenticated && !dismissed}
+  <div class="backup-banner" role="status">
+    <span class="backup-banner-text">
+      Your account backup isn't verified. Back it up now so you can recover your account if you lose access.
+    </span>
+    <div class="backup-banner-actions">
+      <button
+        type="button"
+        class="backup-banner-cta"
+        on:click={() => backupVerificationModalOpen.set(true)}
+      >
+        Back up now
+      </button>
+      <button
+        type="button"
+        class="backup-banner-dismiss"
+        aria-label="Dismiss reminder"
+        title="Dismiss"
+        on:click={() => (dismissed = true)}
+      >
+        ×
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backup-banner {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 16px;
+    background-color: rgba(250, 166, 26, 0.12);
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--warning);
+    font-size: 0.875rem;
+    line-height: 1.4;
+  }
+
+  .backup-banner-text {
+    color: var(--text-primary);
+  }
+
+  .backup-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .backup-banner-cta {
+    padding: 4px 10px;
+    border: 1px solid var(--warning);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--warning);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .backup-banner-cta:hover {
+    background: rgba(250, 166, 26, 0.15);
+  }
+
+  .backup-banner-dismiss {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .backup-banner-dismiss:hover {
+    color: var(--text-primary);
+  }
+</style>

--- a/src/components/backup/BackupVerificationModal.svelte
+++ b/src/components/backup/BackupVerificationModal.svelte
@@ -1,0 +1,524 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import Modal from '../ui/Modal.svelte';
+  import { exportRecoveryPhrase } from '../../lib/api/auth';
+  import { copyTextToClipboard } from '../../lib/wallet/clipboard-copy';
+  import { getInvokeErrorMessage } from '../../lib/utils/tauri-errors';
+  import { showToast } from '../../stores/toast';
+  import { createChallenge, checkChallenge } from '../../lib/utils/seed-verification';
+  import type { SeedChallenge } from '../../lib/utils/seed-verification';
+  import { markBackupVerified, backupVerificationModalOpen } from '../../stores/backup-verification';
+
+  export let open = false;
+  export let onClose: () => void = () => {};
+
+  type Phase = 'show' | 'confirm' | 'quiz' | 'success';
+
+  const titleId = 'backup-verification-title';
+  const descId = 'backup-verification-desc';
+  const MAX_ATTEMPTS = 3;
+
+  let phase: Phase = 'show';
+  let seed = '';
+  let seedWords: string[] = [];
+  let revealed = false;
+  let copied = false;
+  let writtenDown = false;
+  let challenge: SeedChallenge = { positions: [], answers: [] };
+  let inputs: string[] = [];
+  let attempts = 0;
+  let quizError = '';
+  let busy = false;
+  let loadError = '';
+  let inputEls: HTMLInputElement[] = [];
+
+  function resetState(): void {
+    phase = 'show';
+    seed = '';
+    seedWords = [];
+    revealed = false;
+    copied = false;
+    writtenDown = false;
+    attempts = 0;
+    quizError = '';
+    loadError = '';
+    challenge = { positions: [], answers: [] };
+    inputs = [];
+  }
+
+  function handleClose(): void {
+    resetState();
+    onClose();
+  }
+
+  async function loadSeed(): Promise<void> {
+    if (seedWords.length > 0) return;
+    busy = true;
+    loadError = '';
+    try {
+      const raw = await exportRecoveryPhrase();
+      seed = raw;
+      seedWords = raw.trim().split(/\s+/);
+      if (seedWords.length !== 12 && seedWords.length !== 24) {
+        throw new Error('Seed phrase must be 12 or 24 words.');
+      }
+      challenge = seedWords.length >= 3 ? createChallenge(seedWords, 3) : { positions: [], answers: [] };
+      inputs = new Array(challenge.positions.length).fill('');
+    } catch (e) {
+      loadError = getInvokeErrorMessage(e, 'Could not load your recovery phrase.');
+    } finally {
+      busy = false;
+    }
+  }
+
+  $: {
+    if (open) {
+      void loadSeed();
+    } else if (!open) {
+      resetState();
+    }
+  }
+
+  function toggleReveal(): void {
+    revealed = !revealed;
+  }
+
+  async function copySeed(): Promise<void> {
+    if (!seed) return;
+    const ok = await copyTextToClipboard(seed);
+    if (ok) {
+      copied = true;
+      showToast('Seed phrase copied');
+      setTimeout(() => {
+        copied = false;
+      }, 2000);
+    } else {
+      showToast('Could not copy seed phrase');
+    }
+  }
+
+  function goToConfirm(): void {
+    if (!revealed) return;
+    writtenDown = false;
+    phase = 'confirm';
+  }
+
+  function goToQuiz(): void {
+    if (!writtenDown) return;
+    inputs = new Array(challenge.positions.length).fill('');
+    attempts = 0;
+    quizError = '';
+    phase = 'quiz';
+    setTimeout(() => inputEls[0]?.focus(), 0);
+  }
+
+  function goToShow(): void {
+    challenge = seedWords.length >= 3 ? createChallenge(seedWords, 3) : { positions: [], answers: [] };
+    attempts = 0;
+    quizError = '';
+    inputs = new Array(challenge.positions.length).fill('');
+    phase = 'show';
+  }
+
+  async function submitQuiz(): Promise<void> {
+    if (challenge.positions.length === 0) {
+      quizError = 'No backup challenge available. Try again.';
+      return;
+    }
+    if (inputs.some((v) => !v.trim())) {
+      quizError = 'Enter all requested words.';
+      return;
+    }
+    const result = checkChallenge(seedWords, challenge.positions, inputs);
+    if (result.correct) {
+      quizError = '';
+      try {
+        await markBackupVerified(true);
+        phase = 'success';
+        setTimeout(() => {
+          handleClose();
+          backupVerificationModalOpen.set(false);
+        }, 1200);
+      } catch (e) {
+        quizError = getInvokeErrorMessage(e, 'Could not save backup status. Try again.');
+      }
+      return;
+    }
+    attempts += 1;
+    if (attempts >= MAX_ATTEMPTS) {
+      quizError = 'Too many incorrect attempts. The seed phrase will be shown again.';
+      setTimeout(() => goToShow(), 1500);
+      return;
+    }
+    const mismatchLabels = result.details
+      .filter((d) => d.expected.trim().toLowerCase() !== d.actual.trim().toLowerCase())
+      .map((d) => `#${d.position}`)
+      .join(', ');
+    quizError = `Word ${mismatchLabels} does not match. You have ${MAX_ATTEMPTS - attempts} attempt${MAX_ATTEMPTS - attempts === 1 ? '' : 's'} left.`;
+  }
+
+  function handleInputKey(index: number, e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      if (index === inputs.length - 1) {
+        void submitQuiz();
+      } else {
+        inputEls[index + 1]?.focus();
+      }
+    }
+  }
+
+  onMount(() => {
+    return () => resetState();
+  });
+</script>
+
+{#if open}
+  <Modal {titleId} descriptionId={descId} onClose={handleClose} dismissible={!busy}>
+    <h2 id={titleId}>
+      {#if phase === 'show'}
+        Back up your account
+      {:else if phase === 'confirm'}
+        Confirm you wrote it down
+      {:else if phase === 'quiz'}
+        Verify your backup
+      {:else}
+        Backup verified
+      {/if}
+    </h2>
+
+    <p id={descId} class="backup-desc">
+      {#if phase === 'show'}
+        This recovery phrase is the only way to restore your account and funds. Write it down
+        offline and keep it safe.
+      {:else if phase === 'confirm'}
+        Make sure you have the words written in the correct order before continuing.
+      {:else if phase === 'quiz'}
+        Enter the words from your written copy.
+      {:else}
+        Your backup is verified. You can now use gated features like squads and sends.
+      {/if}
+    </p>
+
+    {#if loadError}
+      <div class="backup-error" role="alert">{loadError}</div>
+    {/if}
+
+    {#if phase === 'show'}
+      {#if seedWords.length > 0}
+        <p class="backup-warning" role="alert">
+          Never share this phrase or save it online. Anyone with these words can control your
+          account.
+        </p>
+
+        <div class="seed-grid-shell">
+          <ol class="seed-grid">
+            {#each seedWords as word, i (i)}
+              <li class="seed-word" class:seed-word--revealed={revealed}>
+                <span class="seed-index">{i + 1}</span>
+                <span class="seed-value">
+                  {#if revealed}
+                    {word}
+                  {:else}
+                    <span class="seed-mask" aria-hidden="true">{'•'.repeat(Math.max(4, word.length))}</span>
+                  {/if}
+                </span>
+              </li>
+            {/each}
+          </ol>
+        </div>
+
+        <div class="backup-toolbar">
+          <button
+            type="button"
+            class="btn-reveal"
+            on:click={toggleReveal}
+            aria-pressed={revealed}
+          >
+            {revealed ? 'Hide seed phrase' : 'Show seed phrase'}
+          </button>
+          <button
+            type="button"
+            class="btn-copy"
+            on:click={() => void copySeed()}
+            disabled={!revealed}
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      {/if}
+
+      <div class="backup-actions">
+        <button type="button" class="btn-secondary" on:click={handleClose}>Do this later</button>
+        <button
+          type="button"
+          class="btn-primary"
+          on:click={goToConfirm}
+          disabled={!revealed || seedWords.length === 0}
+        >
+          I wrote it down
+        </button>
+      </div>
+    {:else if phase === 'confirm'}
+      <div class="backup-confirm">
+        <label class="backup-checkbox-label">
+          <input type="checkbox" bind:checked={writtenDown} />
+          <span>
+            I have written down all {seedWords.length} words in the correct order on paper.
+          </span>
+        </label>
+      </div>
+
+      <div class="backup-actions">
+        <button type="button" class="btn-secondary" on:click={() => (phase = 'show')}>Back</button>
+        <button
+          type="button"
+          class="btn-primary"
+          on:click={goToQuiz}
+          disabled={!writtenDown}
+        >
+          Continue
+        </button>
+      </div>
+    {:else if phase === 'quiz'}
+      <div class="backup-quiz">
+        {#each challenge.positions as position, i (i)}
+          <label class="backup-quiz-label" for={`backup-word-${position}`}>
+            Word #{position}
+          </label>
+          <input
+            id={`backup-word-${position}`}
+            type="text"
+            class="backup-quiz-input"
+            bind:value={inputs[i]}
+            bind:this={inputEls[i]}
+            autocomplete="off"
+            spellcheck="false"
+            aria-label={`Word number ${position}`}
+            on:keydown={(e) => handleInputKey(i, e)}
+          />
+        {/each}
+      </div>
+
+      {#if quizError}
+        <div class="backup-error" role="alert">{quizError}</div>
+      {/if}
+
+      <div class="backup-actions">
+        <button type="button" class="btn-secondary" on:click={goToShow}>Show seed again</button>
+        <button type="button" class="btn-primary" on:click={() => void submitQuiz()}>
+          Verify
+        </button>
+      </div>
+    {:else}
+      <div class="backup-success" role="status">
+        <span class="backup-success-icon">✓</span>
+        <p>Your backup is verified. Closing…</p>
+      </div>
+    {/if}
+  </Modal>
+{/if}
+
+<style>
+  .backup-desc {
+    margin: 0 0 16px 0;
+    color: var(--text-muted);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .backup-warning {
+    margin: 0 0 16px 0;
+    padding: 12px 14px;
+    border-radius: 8px;
+    border-left: 3px solid var(--warning);
+    background: rgba(250, 166, 26, 0.1);
+    color: var(--warning);
+    font-size: 0.875rem;
+    line-height: 1.45;
+  }
+
+  .backup-error {
+    margin: 0 0 16px 0;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background: rgba(242, 63, 66, 0.1);
+    color: var(--danger);
+    font-size: 0.875rem;
+  }
+
+  .seed-grid-shell {
+    padding: 16px;
+    border-radius: 8px;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-panel);
+    margin-bottom: 16px;
+  }
+
+  .seed-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px 12px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  @media (min-width: 480px) {
+    .seed-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .seed-word {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: var(--bg-elevated);
+    font-family: ui-monospace, monospace;
+    font-size: 0.875rem;
+  }
+
+  .seed-word--revealed {
+    background: var(--bg-elevated);
+  }
+
+  .seed-index {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    min-width: 1.5em;
+  }
+
+  .seed-value {
+    color: var(--text-primary);
+    flex: 1;
+  }
+
+  .seed-mask {
+    color: var(--text-muted);
+    letter-spacing: 0.08em;
+    user-select: none;
+  }
+
+  .backup-toolbar {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+
+  .backup-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+
+  .backup-confirm {
+    margin-bottom: 20px;
+  }
+
+  .backup-checkbox-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    color: var(--text-primary);
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    cursor: pointer;
+  }
+
+  .backup-checkbox-label input {
+    margin-top: 3px;
+  }
+
+  .backup-quiz {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .backup-quiz-label {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .backup-quiz-input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-panel);
+    color: var(--text-primary);
+    font-size: 1rem;
+  }
+
+  .backup-quiz-input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(88, 101, 242, 0.2);
+    outline: none;
+  }
+
+  .backup-success {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 24px 0;
+    color: var(--success);
+    font-size: 1rem;
+    text-align: center;
+  }
+
+  .backup-success-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: rgba(34, 197, 94, 0.15);
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+
+  .backup-success p {
+    margin: 0;
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .btn-reveal,
+  .btn-copy {
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    transition: opacity 0.2s;
+  }
+
+  .btn-primary {
+    border: none;
+    background: var(--accent);
+    color: white;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-secondary,
+  .btn-reveal,
+  .btn-copy {
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+  }
+
+  .btn-copy:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/components/layout/Navbar.svelte
+++ b/src/components/layout/Navbar.svelte
@@ -50,6 +50,7 @@
     syncCommonsUserActiveBroadcast,
   } from '../../stores/commons-ui';
   import { getInvokeErrorMessage, friendlyMessage } from '../../lib/utils/tauri-errors';
+  import { requireBackupVerified } from '../../stores/backup-verification';
   import { persistCreatedSquad } from '../../lib/squad/squad-catalog';
   import { initSquadBot } from '../../lib/squad/squad-bot';
   import { DEFAULT_CHAIN_ID, type SupportedChainId } from '../../lib/wallet/chains';
@@ -122,6 +123,7 @@
   const squadNetworkOptions = listSquadDeployNetworkOptions();
 
   function openOrganizeSquadModal() {
+    if (!requireBackupVerified()) return;
     showOrganizeSquadModal = true;
     organizeSquadName = '';
     organizeSquadIconUrl = '';
@@ -286,6 +288,7 @@
   }
 
   function handleCreateSquad() {
+    if (!requireBackupVerified()) return;
     const name = organizeSquadName.trim();
     if (!name) return;
     organizeSquadError = '';

--- a/src/components/parent/dashboard/GovernanceDeployCoordinator.svelte
+++ b/src/components/parent/dashboard/GovernanceDeployCoordinator.svelte
@@ -2,6 +2,7 @@
   import type { SquadDashboardChannelMode } from '../../../stores/app';
   import { showToast } from '../../../stores/toast';
   import { TREASURY_SAFE_UI_CAP } from '../../../lib/treasury/treasury-safes';
+  import { requireBackupVerified } from '../../../stores/backup-verification';
   import { DEFAULT_CHAIN_ID, type SupportedChainId } from '../../../lib/wallet/chains';
   import { govAndSponsorCompletionToast } from '../../../lib/governance/deploy-completion';
   import type {
@@ -97,6 +98,7 @@
   $: existingTopHatId = hasPactoGov && !hasSponsor ? pactoGovTopHatId : '';
 
   export function openLaunchpad(): void {
+    if (!requireBackupVerified()) return;
     showLaunchpad = true;
   }
 
@@ -110,12 +112,14 @@
   }
 
   export function openDeploySafe(): void {
+    if (!requireBackupVerified()) return;
     if (parentId?.trim()) {
       showDeploySafeModal = true;
     }
   }
 
   export function openPactoGovDeploy(): void {
+    if (!requireBackupVerified()) return;
     if (hasPactoGov) {
       onNavigate('governance');
       return;
@@ -127,6 +131,7 @@
   }
 
   export function openGovAndSponsorDeploy(): void {
+    if (!requireBackupVerified()) return;
     if (hasSponsor) {
       showToast('Squad sponsor is already deployed for this parent.');
       return;
@@ -142,6 +147,7 @@
   }
 
   export function openExtSponsorDeploy(): void {
+    if (!requireBackupVerified()) return;
     if (hasSponsor) {
       showToast('Squad sponsor is already deployed for this parent.');
       return;
@@ -152,6 +158,7 @@
   }
 
   export function openSquadAdminDeploy(): void {
+    if (!requireBackupVerified()) return;
     if (hasSquadAdmin) {
       onNavigate('crew');
       showSquadRolesModal = true;
@@ -172,6 +179,7 @@
   }
 
   async function confirmSetSafe(): Promise<void> {
+    if (!requireBackupVerified()) return;
     const addr = setSafeInput.trim();
     if (!addr) {
       setSafeError = 'Enter a Safe address';

--- a/src/components/parent/governance/GovCrewActions.svelte
+++ b/src/components/parent/governance/GovCrewActions.svelte
@@ -27,6 +27,7 @@
   } from '../../../lib/governance/governance-privilege';
   import { getInvokeErrorMessage } from '../../../lib/utils/tauri-errors';
   import { showToast } from '../../../stores/toast';
+  import { requireBackupVerified } from '../../../stores/backup-verification';
 
   export let network: string;
   export let parentId: string;
@@ -124,7 +125,8 @@
               variant="primary"
               gate={crewGate}
               {acting}
-              onClick={() =>
+              onClick={() => {
+                if (!requireBackupVerified()) return;
                 void run('Crew yea', () =>
                   treasuryAuthorityCrewVote({
                     network,
@@ -133,13 +135,15 @@
                     proposalId: voteProposalId,
                     support: true,
                   }),
-                onRefreshProposals)}
+                  onRefreshProposals);
+              }}
             />
             <GovCtaButton
               label="Vote nay"
               gate={crewGate}
               {acting}
-              onClick={() =>
+              onClick={() => {
+                if (!requireBackupVerified()) return;
                 void run('Crew nay', () =>
                   treasuryAuthorityCrewVote({
                     network,
@@ -148,7 +152,8 @@
                     proposalId: voteProposalId,
                     support: false,
                   }),
-                onRefreshProposals)}
+                  onRefreshProposals);
+              }}
             />
           </div>
         {/if}
@@ -167,21 +172,23 @@
               {/each}
             </select>
           </label>
-          <GovCtaButton
-            label="Execute"
-            variant="execute"
-            gate={execGate}
-            {acting}
-            onClick={() =>
-              void run('Execute', () =>
-                treasuryAuthorityExecute({
-                  network,
-                  parentId,
-                  treasuryAuthority,
-                  proposalId: execProposalId,
-                }),
-              onRefreshProposals)}
-          />
+            <GovCtaButton
+              label="Execute"
+              variant="execute"
+              gate={execGate}
+              {acting}
+              onClick={() => {
+                if (!requireBackupVerified()) return;
+                void run('Execute', () =>
+                  treasuryAuthorityExecute({
+                    network,
+                    parentId,
+                    treasuryAuthority,
+                    proposalId: execProposalId,
+                  }),
+                  onRefreshProposals);
+              }}
+            />
         {/if}
       </div>
     </section>

--- a/src/components/parent/governance/MutinyModulePanel.svelte
+++ b/src/components/parent/governance/MutinyModulePanel.svelte
@@ -27,6 +27,7 @@
   } from '../../../lib/governance/governance-privilege';
   import { getInvokeErrorMessage } from '../../../lib/utils/tauri-errors';
   import { showToast } from '../../../stores/toast';
+  import { requireBackupVerified } from '../../../stores/backup-verification';
 
   export let network: string;
   export let parentId: string;
@@ -140,6 +141,7 @@
   }
 
   function startMutiny() {
+    if (!requireBackupVerified()) return;
     if (startKind === 'pause') {
       void run('Start pause-captain mutiny', () =>
         mutinyStartToPauseCaptain({ network, parentId, mutinyModule }),
@@ -183,29 +185,31 @@
             variant="primary"
             gate={hasVoted ? { enabled: false, reason: 'You already voted in this mutiny.' } : crewGate}
             {acting}
-            onClick={() =>
+            onClick={() => {
+              if (!requireBackupVerified()) return;
               void run('Mutiny vote', () =>
                 mutinyCastVote({
                   network,
                   parentId,
                   mutinyModule,
                   mutinyId: status!.activeMutinyId,
-                }),
-              )}
+                }));
+            }}
           />
           <GovCtaButton
             label="Execute mutiny"
             gate={execGate}
             {acting}
-            onClick={() =>
+            onClick={() => {
+              if (!requireBackupVerified()) return;
               void run('Execute mutiny', () =>
                 mutinyExecute({
                   network,
                   parentId,
                   mutinyModule,
                   mutinyId: status!.activeMutinyId,
-                }),
-              )}
+                }));
+            }}
           />
         </div>
       </div>

--- a/src/components/parent/governance/SquadSponsorTreasuryPanel.svelte
+++ b/src/components/parent/governance/SquadSponsorTreasuryPanel.svelte
@@ -34,6 +34,7 @@
   import { parseWalletOpError } from '../../../lib/wallet/backend-wallet';
   import { formatEther, parseEther } from 'viem';
   import { showToast } from '../../../stores/toast';
+  import { requireBackupVerified } from '../../../stores/backup-verification';
 
   export let parentId: string;
   export let sponsorRow: SquadInfraDto | null = null;
@@ -226,6 +227,7 @@
   }
 
   async function submitDeposit() {
+    if (!requireBackupVerified()) return;
     depositError = '';
     if (!parentId?.trim() || !sponsorRow) return;
     let amountWei: string;
@@ -434,7 +436,10 @@
         <button
           type="button"
           class="btn-secondary sponsor-withdraw-btn"
-          on:click={() => (showWithdrawModal = true)}
+          on:click={() => {
+            if (!requireBackupVerified()) return;
+            showWithdrawModal = true;
+          }}
         >
           Withdraw
         </button>

--- a/src/components/parent/governance/TreasurySafeModulePanel.svelte
+++ b/src/components/parent/governance/TreasurySafeModulePanel.svelte
@@ -23,6 +23,7 @@
   import { getEvmNativeBalance } from '../../../lib/wallet/backend-wallet';
   import { getInvokeErrorMessage } from '../../../lib/utils/tauri-errors';
   import { showToast } from '../../../stores/toast';
+  import { requireBackupVerified } from '../../../stores/backup-verification';
   import type { SupportedChainId } from '../../../lib/wallet/chains';
   import { parseSupportedChainId } from '../../../lib/wallet/chains';
   import { withReadPlaneLimit } from '../../../lib/evm/read-plane-limiter';
@@ -156,6 +157,7 @@
 
   async function addToken() {
     if (!manageGate.enabled || addBusy) return;
+    if (!requireBackupVerified()) return;
     const addr = addAddress.trim();
     if (!isAddress(addr)) {
       showToast('Paste a valid ERC-20 contract address.');
@@ -193,6 +195,7 @@
 
   async function removeToken(row: SquadTrackedTokenRow) {
     if (!manageGate.enabled) return;
+    if (!requireBackupVerified()) return;
     try {
       await removeSquadTrackedToken(parentId.trim(), row.id);
       if (announcementsGroupId.trim()) {

--- a/src/components/settings/ProfileSection.svelte
+++ b/src/components/settings/ProfileSection.svelte
@@ -12,6 +12,7 @@
   import EvmAccountKeyExportModal from './EvmAccountKeyExportModal.svelte';
   import ExportAllSecretsModal from './ExportAllSecretsModal.svelte';
   import EditIconButton from '../ui/EditIconButton.svelte';
+  import { requireBackupVerified } from '../../stores/backup-verification';
   $: userNpub = $currentUser?.npub || '';
   $: profile = userNpub ? $profiles[userNpub] : null;
   $: loading = userNpub ? ($profileLoadingStates[userNpub] || false) : false;
@@ -301,7 +302,11 @@
                 <button
                   type="button"
                   class="btn-export-seed"
-                  on:click={() => (exportSeedModalOpen = true)}
+                  on:click={() => {
+                    if (requireBackupVerified()) {
+                      exportSeedModalOpen = true;
+                    }
+                  }}
                 >
                   Export seed phrase
                 </button>

--- a/src/components/wallet/WalletHomeSendModal.svelte
+++ b/src/components/wallet/WalletHomeSendModal.svelte
@@ -32,6 +32,7 @@
   } from '../../lib/wallet';
   import { toastWalletBroadcastSubmitted } from '../../lib/wallet/wallet-dm-transfer';
   import { showToast } from '../../stores/toast';
+  import { requireBackupVerified } from '../../stores/backup-verification';
   import { normalizeLeadingDotDecimalInput } from '../../lib/wallet/amount-input';
 
   export let open: boolean;
@@ -215,6 +216,7 @@
 
   async function handleConfirm() {
     if (!canConfirm || !selectedOpt) return;
+    if (!requireBackupVerified()) return;
     const amountHuman = normalizeLeadingDotDecimalInput(amountStr.trim());
     let normalizedTo: string;
     try {

--- a/src/components/wallet/WalletTransferStubModal.svelte
+++ b/src/components/wallet/WalletTransferStubModal.svelte
@@ -31,6 +31,7 @@
   } from '../../lib/wallet';
   import { parseUnits } from 'viem';
   import { showToast } from '../../stores/toast';
+  import { requireBackupVerified } from '../../stores/backup-verification';
   import type { WalletSendPrefillPayload } from '../../stores/app';
   import { currentUser } from '../../stores/auth';
   import { formatWalletTxRequest } from '../../lib/wallet/dm-messages';
@@ -303,6 +304,7 @@
       }
       return;
     }
+    if (!requireBackupVerified()) return;
     sendError = null;
     sending = true;
     try {

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,0 +1,25 @@
+import { invoke } from '@tauri-apps/api/core';
+
+const BACKUP_VERIFIED_KEY = 'backup_verified';
+
+export async function getSqlSetting(key: string): Promise<string | null> {
+  return await invoke<string | null>('get_sql_setting', { key });
+}
+
+export async function setSqlSetting(key: string, value: string): Promise<void> {
+  await invoke('set_sql_setting', { key, value });
+}
+
+export async function getBackupVerifiedSetting(): Promise<boolean> {
+  try {
+    const value = await getSqlSetting(BACKUP_VERIFIED_KEY);
+    return value === 'true';
+  } catch {
+    // If the setting cannot be read (e.g. no current account), treat as unverified.
+    return false;
+  }
+}
+
+export async function setBackupVerifiedSetting(value: boolean): Promise<void> {
+  await setSqlSetting(BACKUP_VERIFIED_KEY, value ? 'true' : 'false');
+}

--- a/src/lib/invites/accept-invite.ts
+++ b/src/lib/invites/accept-invite.ts
@@ -27,6 +27,7 @@ import {
   type Squad,
 } from '../../stores/app';
 import { pendingReadyToast, showToast } from '../../stores/toast';
+import { requireBackupVerified } from '../../stores/backup-verification';
 
 /** Group IDs we just accepted — skip unattributed "Add to squad" modal for these. */
 const acceptedSquadInviteGroupIds = new Set<string>();
@@ -133,6 +134,7 @@ export async function acceptAnnouncementsInvite(
     );
     return;
   }
+  if (!requireBackupVerified()) return;
   const welcome = await resolvePendingWelcomeForGroup(payload.groupId);
   if (!welcome) {
     const err = new Error('No pending welcome') as Error & { noWelcome?: boolean };
@@ -203,6 +205,7 @@ export async function acceptSquadOrPairInvite(msg: DmMessage): Promise<void> {
   const payload = parseSquadInviteMessage(msg.content);
   if (!payload) return;
   if (get(acceptingSquadInviteId)) return;
+  if (!requireBackupVerified()) return;
   acceptingSquadInviteId.set(msg.id);
   try {
     await acceptAnnouncementsInvite(
@@ -261,6 +264,7 @@ export async function acceptChannelInSquadInvite(
     );
     return;
   }
+  if (!requireBackupVerified()) return;
   acceptingChannelInSquadId.set(msg.id);
   try {
     const welcomes = await listPendingMlsWelcomes();

--- a/src/lib/utils/clear-account-state.ts
+++ b/src/lib/utils/clear-account-state.ts
@@ -97,6 +97,7 @@ import { resetSquadJoinRequestStores } from '../../stores/squad-join-requests';
 import { resetSquadHubAlertStores } from '../../stores/squad-hub-alerts';
 import { resetMlsGroupMembersStores } from '../../stores/mls-group-members';
 import { STARTUP_CHECK_PREFIX } from '../../stores/startup-check';
+import { backupVerified } from '../../stores/backup-verification';
 
 /** Npub-scoped key prefixes (suffix is `_<npub>`). */
 const SCOPED_KEY_PREFIXES = [
@@ -226,4 +227,5 @@ export function clearAccountState(npub?: string): void {
 
   /** Appearance theme is device-level (`pacto_theme`); keep it across logout / new account / import. */
   recentEmojisStore.set([]);
+  backupVerified.set(null);
 }

--- a/src/lib/utils/seed-verification.test.ts
+++ b/src/lib/utils/seed-verification.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { createChallenge, checkChallenge } from './seed-verification';
+
+describe('createChallenge', () => {
+  it('picks 3 distinct 1-indexed positions from a 12-word seed', () => {
+    const words = Array.from({ length: 12 }, (_, i) => `word${i + 1}`);
+    const rng = makeRng([0.1, 0.5, 0.9, 0.2, 0.6, 0.3]);
+    const challenge = createChallenge(words, 3, rng);
+
+    expect(challenge.positions.length).toBe(3);
+    expect(new Set(challenge.positions).size).toBe(3);
+    for (const p of challenge.positions) {
+      expect(p).toBeGreaterThanOrEqual(1);
+      expect(p).toBeLessThanOrEqual(12);
+    }
+    expect(challenge.answers).toEqual(challenge.positions.map((p) => words[p - 1]));
+  });
+
+  it('works for a 24-word seed and stays within bounds', () => {
+    const words = Array.from({ length: 24 }, (_, i) => `word${i + 1}`);
+    const challenge = createChallenge(words, 3, makeRng([0.05, 0.95, 0.45, 0.12]));
+
+    for (const p of challenge.positions) {
+      expect(p).toBeGreaterThanOrEqual(1);
+      expect(p).toBeLessThanOrEqual(24);
+    }
+    expect(challenge.positions.length).toBe(3);
+  });
+
+  it('throws when count exceeds seed length', () => {
+    const words = ['one', 'two', 'three'];
+    expect(() => createChallenge(words, 4)).toThrow();
+  });
+
+  it('throws when count is zero', () => {
+    const words = ['one', 'two', 'three'];
+    expect(() => createChallenge(words, 0)).toThrow();
+  });
+
+  it('de-duplicates positions when rng picks the same index twice', () => {
+    const words = Array.from({ length: 12 }, (_, i) => `w${i + 1}`);
+    const rng = makeRng([0.2, 0.2, 0.2, 0.7, 0.8]);
+    const challenge = createChallenge(words, 3, rng);
+
+    expect(new Set(challenge.positions).size).toBe(3);
+  });
+});
+
+describe('checkChallenge', () => {
+  const words = ['abandon', 'ability', 'able', 'about', 'above', 'absent'];
+
+  it('returns correct when all inputs match', () => {
+    const result = checkChallenge(words, [1, 3, 5], ['abandon', 'able', 'above']);
+    expect(result.correct).toBe(true);
+    expect(result.details).toHaveLength(3);
+    expect(result.details.every((d) => d.expected === d.actual.trim().toLowerCase())).toBe(true);
+  });
+
+  it('returns incorrect and reports mismatching positions', () => {
+    const result = checkChallenge(words, [1, 3, 5], ['abandon', 'wrong', 'above']);
+    expect(result.correct).toBe(false);
+    expect(result.details.find((d) => d.position === 3)?.actual).toBe('wrong');
+    expect(result.details.find((d) => d.position === 3)?.expected).toBe('able');
+  });
+
+  it('ignores case and surrounding whitespace', () => {
+    const result = checkChallenge(words, [2, 4], ['  ABILITY  ', 'AbOuT']);
+    expect(result.correct).toBe(true);
+  });
+
+  it('treats missing inputs as empty', () => {
+    const result = checkChallenge(words, [1, 2], ['abandon']);
+    expect(result.correct).toBe(false);
+    expect(result.details).toHaveLength(2);
+    expect(result.details[1]?.actual).toBe('');
+  });
+});
+
+function makeRng(values: number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = values[i] ?? 0;
+    i = (i + 1) % values.length;
+    return v;
+  };
+}

--- a/src/lib/utils/seed-verification.ts
+++ b/src/lib/utils/seed-verification.ts
@@ -1,0 +1,59 @@
+export interface SeedChallenge {
+  /** 1-indexed word positions to ask the user. */
+  positions: number[];
+  /** Expected words at those positions (in matching order). */
+  answers: string[];
+}
+
+export interface ChallengeCheckResult {
+  correct: boolean;
+  /** Per-position comparison details. */
+  details: { position: number; expected: string; actual: string }[];
+}
+
+/** Pick a random subset of distinct positions from a seed phrase.
+ *  @param count - number of positions to pick (default 3)
+ *  @param rng - optional random number generator returning [0, 1); defaults to Math.random
+ */
+export function createChallenge(
+  seedWords: string[],
+  count = 3,
+  rng: () => number = Math.random,
+): SeedChallenge {
+  if (count < 1) throw new Error('Challenge count must be at least 1');
+  if (count > seedWords.length) {
+    throw new Error('Challenge count cannot exceed seed word count');
+  }
+  const positions: number[] = [];
+  const taken = new Set<number>();
+  while (positions.length < count) {
+    const index = Math.floor(rng() * seedWords.length);
+    if (!taken.has(index)) {
+      taken.add(index);
+      positions.push(index + 1); // store 1-indexed positions
+    }
+  }
+  return {
+    positions,
+    answers: positions.map((p) => seedWords[p - 1]!),
+  };
+}
+
+/** Check user-entered words against the challenge. Comparison is case-insensitive and trimmed. */
+export function checkChallenge(
+  seedWords: string[],
+  positions: number[],
+  inputs: string[],
+): ChallengeCheckResult {
+  const details: { position: number; expected: string; actual: string }[] = [];
+  let allCorrect = true;
+  for (let i = 0; i < positions.length; i++) {
+    const position = positions[i]!;
+    const expected = seedWords[position - 1] ?? '';
+    const actual = (inputs[i] ?? '').trim().toLowerCase();
+    const match = actual === expected.trim().toLowerCase();
+    if (!match) allCorrect = false;
+    details.push({ position, expected, actual: inputs[i] ?? '' });
+  }
+  return { correct: allCorrect, details };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -142,6 +142,9 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
   import { resolveOpenHubParent, syncSquadsHubSelection, resolveEffectiveHubChannel, parentIdForChannelGroup } from '../lib/squad-hub-nav';
   import { portal } from '../lib/utils/portal';
   import { subscribeAppEvents } from '../lib/app/tauri-subscriptions';
+  import { backupVerificationModalOpen } from '../stores/backup-verification';
+  import BackupVerificationModal from '../components/backup/BackupVerificationModal.svelte';
+  import BackupBanner from '../components/backup/BackupBanner.svelte';
   import {
     scheduleAllSquadsHubWarmup,
     scheduleHubParentPrefetch,
@@ -961,6 +964,7 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
   <header class="top-navbar-slot">
     <TopNavbar />
   </header>
+  <BackupBanner />
   <main class="container">
     <Navbar />
     <div class="content-wrap">
@@ -1159,6 +1163,14 @@ import MyDashboard from '../components/parent/MyDashboard.svelte';
   {#if $commonsBroadcastModalOpen}
     <div use:portal>
       <PersonalBroadcastModal />
+    </div>
+  {/if}
+  {#if $backupVerificationModalOpen}
+    <div use:portal>
+      <BackupVerificationModal
+        open={$backupVerificationModalOpen}
+        onClose={() => backupVerificationModalOpen.set(false)}
+      />
     </div>
   {/if}
   <UpdateAvailableModal />

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -43,6 +43,10 @@ import { loadAccountState } from './persistence';
 import { clearAccountState } from '../lib/utils/clear-account-state';
 import { activeTopNavTab, DEFAULT_TOP_NAV_TAB } from './navigation';
 import { setCurrentNpubForPersistence } from './persistence-context';
+import {
+  backupVerified,
+  backupVerificationModalOpen,
+} from './backup-verification';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
@@ -111,6 +115,9 @@ describe('auth', () => {
     vi.mocked(clearAccountState).mockReset();
     vi.mocked(apiCheckSession).mockReset();
     vi.mocked(apiSessionHeartbeat).mockReset();
+    vi.mocked(invoke).mockReset();
+    backupVerified.set(null);
+    backupVerificationModalOpen.set(false);
   });
 
   afterEach(() => {
@@ -292,6 +299,8 @@ describe('auth', () => {
       expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
       expect(get(activeTopNavTab)).toBe(DEFAULT_TOP_NAV_TAB);
       expect(loadAccountState).toHaveBeenCalledWith(npub);
+      expect(get(backupVerified)).toBe(null);
+      expect(get(backupVerificationModalOpen)).toBe(false);
     });
 
     it('sets auth error on failure', async () => {
@@ -313,6 +322,8 @@ describe('auth', () => {
       expect(get(isAuthenticated)).toBe(true);
       expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
       expect(runPostLoginNetworkSync).toHaveBeenCalledWith(npub);
+      expect(get(backupVerified)).toBe(true);
+      expect(get(backupVerificationModalOpen)).toBe(false);
     });
 
     it('rejects an invalid recovery phrase', async () => {
@@ -333,6 +344,8 @@ describe('auth', () => {
       expect(get(isAuthenticated)).toBe(true);
       expect(get(currentUser)).toEqual({ npub, pubkey: keys.public });
       expect(runPostLoginNetworkSync).toHaveBeenCalledWith(npub);
+      expect(get(backupVerified)).toBe(null);
+      expect(get(backupVerificationModalOpen)).toBe(false);
     });
 
     it('sets auth error on failure', async () => {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -7,6 +7,7 @@ import { runPostLoginNetworkSync } from '../lib/app/post-login-sync';
 import { activeTopNavTab, DEFAULT_TOP_NAV_TAB } from './navigation';
 import { closeWalletSidebar } from './dm';
 import { loadAccountState } from './persistence';
+import { markBackupVerified } from './backup-verification';
 import { clearAccountState } from '../lib/utils/clear-account-state';
 import { isMigrationGateError } from '../lib/utils/tauri-errors';
 
@@ -272,6 +273,7 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
       pubkey: keys.public
     });
     await maybeApplyLocalDevDefaults(npub);
+    await markBackupVerified(true);
     authLoading.set(false);
     runPostLoginNetworkSync(npub);
 

--- a/src/stores/backup-verification.test.ts
+++ b/src/stores/backup-verification.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  backupVerified,
+  backupVerificationModalOpen,
+  loadBackupVerified,
+  markBackupVerified,
+  requireBackupVerified,
+} from './backup-verification';
+
+vi.mock('../lib/api/settings', () => ({
+  getBackupVerifiedSetting: vi.fn(),
+  setBackupVerifiedSetting: vi.fn(),
+}));
+
+import {
+  getBackupVerifiedSetting,
+  setBackupVerifiedSetting,
+} from '../lib/api/settings';
+
+const mockedGet = vi.mocked(getBackupVerifiedSetting);
+const mockedSet = vi.mocked(setBackupVerifiedSetting);
+
+describe('backup-verification store', () => {
+  beforeEach(() => {
+    backupVerified.set(null);
+    backupVerificationModalOpen.set(false);
+    vi.clearAllMocks();
+  });
+
+  it('loadBackupVerified hydrates store from SQL setting', async () => {
+    mockedGet.mockResolvedValueOnce(true);
+    await loadBackupVerified();
+    expect(get(backupVerified)).toBe(true);
+  });
+
+  it('loadBackupVerified defaults to false when setting is missing', async () => {
+    mockedGet.mockResolvedValueOnce(false);
+    await loadBackupVerified();
+    expect(get(backupVerified)).toBe(false);
+  });
+
+  it('markBackupVerified persists and updates the store', async () => {
+    await markBackupVerified(true);
+    expect(mockedSet).toHaveBeenCalledWith(true);
+    expect(get(backupVerified)).toBe(true);
+  });
+
+  it('requireBackupVerified returns true when verified', () => {
+    backupVerified.set(true);
+    expect(requireBackupVerified()).toBe(true);
+    expect(get(backupVerificationModalOpen)).toBe(false);
+  });
+
+  it('requireBackupVerified opens modal and returns false when unverified', () => {
+    backupVerified.set(false);
+    expect(requireBackupVerified()).toBe(false);
+    expect(get(backupVerificationModalOpen)).toBe(true);
+  });
+});

--- a/src/stores/backup-verification.ts
+++ b/src/stores/backup-verification.ts
@@ -1,0 +1,27 @@
+import { writable, get, type Writable } from 'svelte/store';
+import { getBackupVerifiedSetting, setBackupVerifiedSetting } from '../lib/api/settings';
+
+export type BackupVerifiedState = boolean | null;
+
+export const backupVerified: Writable<BackupVerifiedState> = writable(null);
+export const backupVerificationModalOpen: Writable<boolean> = writable(false);
+
+export async function loadBackupVerified(): Promise<void> {
+  const value = await getBackupVerifiedSetting();
+  backupVerified.set(value);
+}
+
+export async function markBackupVerified(value = true): Promise<void> {
+  await setBackupVerifiedSetting(value);
+  backupVerified.set(value);
+}
+
+export function isBackupVerified(): boolean {
+  return get(backupVerified) === true;
+}
+
+export function requireBackupVerified(): boolean {
+  if (isBackupVerified()) return true;
+  backupVerificationModalOpen.set(true);
+  return false;
+}

--- a/src/stores/persistence.ts
+++ b/src/stores/persistence.ts
@@ -10,6 +10,7 @@ import { loadDeferredSquadRosterKeyParentIds } from '../lib/squad/squad-roster-k
 import { getInviteDecisionLoadEntries } from './invite-decisions';
 import type { PactoAppInboxEntry } from '../lib/pacto-app-inbox';
 import { setCurrentNpubForPersistence } from './persistence-context';
+import { loadBackupVerified } from './backup-verification';
 import {
   SQUAD_DASHBOARD_MODE_PREFIX,
   MY_DASHBOARD_MODE_PREFIX,
@@ -52,6 +53,7 @@ export {
 /** Load account-specific state from localStorage for the given npub. Call after login/create/import/unlock. */
 export function loadAccountState(npub: string): void {
   setCurrentNpubForPersistence(npub);
+  void loadBackupVerified();
   void hydrateSquadsFromDb().then(async () => {
     const { reconcileStaleInviteDecisions } = await import('../lib/invites/accept-invite');
     reconcileStaleInviteDecisions();


### PR DESCRIPTION
Closes #112

## Summary

This PR closes #112 by adding a progressive, per-account verified seed-backup gate. Users must now write down their recovery phrase and verify a random subset of words before they can perform actions that could lock them out of their identity or funds.

Before this change, anyone could create a squad, accept an invite, deploy treasury governance, send funds, or export their seed from Settings without ever proving they had backed up their phrase.

After this change, fresh accounts and existing unverified accounts see a prompt after PIN unlock, can dismiss it to keep using DMs and Commons, and are re-prompted when they try a gated action. Accounts imported with a recovery phrase skip the ritual entirely.

## Changes

- Store `backup_verified` per npub in the existing SQLite `settings` table.
- Add `BackupVerificationModal` with seed reveal, written confirmation, and a 3-word random-subset quiz.
- Add `BackupBanner` persistent indicator for unverified accounts.
- Gate seed export, squad creation, invite acceptance, treasury/governance actions, and wallet sends at the frontend handler layer.
- Add `seed-verification` utility and store tests for the random-subset logic.

## Test plan

- Create a fresh account: backup modal opens after PIN setup; dismiss it and send a DM.
- Attempt to create a squad while unverified: backup gate opens; complete verification and retry.
- Import with a recovery phrase: no backup prompt appears and gated actions work immediately.
- `pnpm test` covers seed-verification utility and backup-verification store.

---

<img width="1126" height="302" alt="Screenshot 2026-07-19 at 4 08 53 PM" src="https://github.com/user-attachments/assets/6f7ee699-2ddc-4ba5-b4fc-1f21fb15eca6" />
<img width="493" height="583" alt="Screenshot 2026-07-19 at 4 23 03 PM" src="https://github.com/user-attachments/assets/c82f414f-f55f-4a0e-985e-190e5c057886" />
<img width="501" height="498" alt="Screenshot 2026-07-19 at 4 24 28 PM" src="https://github.com/user-attachments/assets/ea466406-7f31-485b-88e4-ffcd526ccdb4" />

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
