### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,42 +4,346 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## Unreleased
+## v0.3.1
+
+### Highlights
+- Hardened account security with automatic idle lock and a verified seed-backup gate that blocks risky actions until the recovery phrase is backed up.
+- Shipped user-facing install instructions for macOS, Linux, and Windows, and included them in GitHub release notes.
+
+### Features
+- Add automatic idle lock and migration gate for sensitive operations (#96) (session)
+- Add verified seed-backup gate for risky actions (#114)
+
+### Documentation
+- Add install instructions for macOS, Linux, and Windows (#107)
+
+### Other
+- Include install instructions in release notes (#108)
+- Docs/install instructions (#109)
 
 ## v0.3.0
 
-### Highlights
-- Hardened the squad governance and launch flow: hats-first sponsor deploy paths, ala-carte Safe + governance extensions, sponsored governance writes, and an orchestrated launchpad for new squads.
-- Shipped an operable governance dashboard with a roles tree and module panels so squads can manage on-chain settings interactively.
-- Improved key security with per-device salt support and a migration to the v2 encryption scheme.
-- Kept payout addresses private by routing them through consent-based direct-message exchange instead of public metadata.
-- Added in-app "Check for Updates" with build introspection so users can verify the running release.
+### Bug Fixes
+- Grant build job artifact write permission for landing deploy (ci)
+- Resolve release tag from GITHUB_REF only for tag refs (ci)
+- Add pages and id-token permissions to landing build job (ci)
+- Replace withastro/action with explicit build/upload steps (#79) (ci)
+- Keep payout addresses private to consent-based DM exchange
+- In-app Check for Updates with build introspection (#104) (updater)
 
-### Reliability & Quality
-- Fixed CI landing-site deployments and release-tag resolution, and added the permissions needed for artifact uploads and Pages publishing.
 
-### Documentation
-- Added user-facing encryption architecture guidance and a macOS install quarantine note.
+### Chores
+- Bump version to 0.3.0 (#106) (release)
 
-### Highlights
-- Delivered a full squad-centric governance experience: deploy flows, governance dashboard, squad-bot inbox join flow, polls, and sponsorship workflows.
-- Significantly upgraded wallet capabilities: embedded/advanced wallet UX, signer flows, seed/export actions, Safe deployment paths, and better transaction visibility.
-- Expanded communication features: stronger DM/squad inbox behavior, unread notifications, pinned inbox patterns, and improved message reliability/sorting.
-- Improved multi-network support: better network selection/reads, relay compatibility for local development, and broader chain contract coverage.
-- Released public distribution improvements, including architecture-aware downloads and native ARM64 CI support.
-
-### Reliability & Quality
-- Fixed key bugs across encryption, MLS membership/channel lifecycle, dashboard hydration, local storage/session recovery, and relay validation.
-- Addressed major review findings (P1/P2/P3) and multiple PR follow-ups, including race/use-after-move fixes and stability hardening.
-- Reduced frontend and Rust type/check noise by resolving svelte-check, ESLint, and cargo diagnostics issues.
-
-### Developer Experience
-- Improved local-dev workflow with Local Anvil support, dockerized dev wiring, safer defaults, and tighter dev/test gating.
-- Strengthened CI quality gates (typecheck, lint, unit tests), split CI jobs for clearer failures, and expanded backend/frontend test coverage.
-- Streamlined release/process tooling with changelog automation, version bump validation/shortcuts, submodule build handling, and dependency/action updates.
 
 ### Documentation
-- Consolidated and expanded setup/architecture guidance (including local wallet/dev flows and agent-facing docs) for easier onboarding and maintenance.
+- Add macOS install quarantine note (#80) (readme)
+- Document encryption architecture and user-facing cryptography guidance (#99)
+
+
+### Features
+- Operable governance UI with roles tree and module panels (#83) (squad)
+- Per-device salt and migration to v2 (#95) (crypto)
+- Hats-first sponsor deploy with ext ala carte and ungated safe (#86) (squad)
+- Hats-first sponsor deploy, sponsored gov writes, and orchestrated launchpad (#100) (squad)
+
+## v0.2.0
+
+### Bug Fixes
+- Pin encryption decryption
+- Rm channel modal
+- Logout restart
+- Squad channel filter
+- Track mls group membership across devices
+- Path name correction
+- Release workflow
+- Workflow
+- Workflow windows + delete android
+- No key-package for member bug
+- Poll rumor
+- Add missing resetDashboardPrefetchSession import
+- Balance read bug
+- Allow-build
+- Harden local-dev defaults and fix relay/env issues (review)
+- Resolve P1/P2/P3 local-dev review findings (review)
+- Restore missing lastDm localStorage read (persistence)
+- Gate local Anvil to dev/test builds and tighten tests (dev)
+- Squad-dashboard hydratation on-start
+- Mls exit channel asymmetry
+- Address Copilot PR review (PinInput, hub replay race, wallet dedupe)
+- Backfill reply context for bot replies that beat original message persistence (dm)
+- Clean up cargo check diagnostics (rust)
+- Resolve svelte-check errors (frontend)
+- Finish resolving svelte-check errors (frontend)
+- Source testability tweaks for new frontend test coverage
+- Resolve svelte-check type errors (frontend)
+- Resolve ESLint errors and align config with legacy Svelte patterns (#67) (lint)
+- Install xdg-utils for Ubuntu AppImage bundling (ci)
+
+
+### Chores
+- Init
+- Remove mock data
+- Change argon-2-id salt
+- Update package
+- Update lockfile
+- Lock file update
+- Delete docs from gitignore
+- Add release workflow
+- Rules
+- Cleanup
+- Add @vitest/coverage-v8@3.2.4 for test coverage reports (dev)
+- Add coverage npm scripts (dev)
+- Restore missing android module stubs (android)
+- Land safe mechanical lint fixes so lint stays green (#71) (lint)
+- Add changelog automation and align package version (#75) (release)
+- V0.2.0 changelog and ARM64 CI fix (#76) (release)
+
+
+### Documentation
+- Update README
+- Add all OS guides
+- Add sub-folder
+- Rename windows guide
+- Agent docs
+- Edit
+- Update
+- Consolidate
+- Update squads
+- Mark P1/P2/P3 findings as resolved (review)
+- Document Local Anvil dev setup (wallet)
+- Rename local setup doc and consolidate dev guidance (wallet)
+- Add AGENTS.md repository guidelines and Tauri v2 agent skills (agents)
+- Add strategy, concepts, and architecture docs for humans and agents
+- Update
+- Add value-based-pr skill and reference in AGENTS.md
+- Split out documentation and skills from PR #59
+- Correct NIP-17 terminology, read-plane split, storage nuance, and remove Aztec (ARCHITECTURE)
+
+
+### Features
+- Add vector backend logic
+- Nav/tab button
+- Icons
+- Community channels
+- Messages and input
+- Message channel filter
+- Profile page
+- Key encryption and retrieval
+- New cp
+- Create and export keys
+- Avatar pull and offline logic
+- Profile fetching from relays
+- Auto profile pull on start
+- Direct messenger UX
+- Message to relay
+- Message fetching
+- Fetch msgs w/ notifs
+- Message sorting
+- Pfp and nostr account network changes from app
+- Mls channel creation
+- Invite to squad modal
+- Exit squad
+- Pin dms
+- Emoji library
+- Storage wipe on logout
+- Mls group invite card
+- Network invite card
+- Network & channel handling & storage
+- Break network into squad
+- Exit modal
+- Evm key derivation
+- Add viem
+- Squad dashboard
+- Embedded evm wallet and viem read functions
+- Backend evm signatures
+- Wallet sidebar
+- Etherscan tx hash tracking
+- Private key exchange
+- Multisig-safe deployment
+- Themes
+- Seed-phrase-based accounts
+- Block user
+- Resizable wallet bar
+- Safe deployer
+- Deployer modal
+- Backend and nostr rumors for poll voting
+- Governance launch pad
+- Mod squad infra
+- Contract api
+- Squad-sponsor flow
+- Generic chain reads
+- Hat tree
+- Dm deployment update
+- Gov modal deployment flow
+- Deploy stand-alone safes
+- Advanced wallet
+- Signer for advanced wallet
+- Chat date-n-time
+- Network selector
+- Rpc setup
+- Pinned internal app inbox
+- Commons
+- Common card
+- Common filter
+- Commons modal
+- Commons ux
+- Export nsec button
+- Export seed button
+- Sponsor-contract deploy modal
+- Optimistic payment request
+- Unread notifications
+- Add Local Anvil chain (31337) for dockerized dev stack (wallet)
+- Auto-wire local Docker dev stack in dev mode
+- Add commons categories
+- Mls squad-inbox gossip
+- Backend network snapshot extraction
+- Add gnosis-safe contracts on arbitrum
+- Squad-wide network selection
+- Allow ws:// localhost/127.0.0.1 dev relay URLs (relays)
+- Pacto Gov deploy flow, squad-bot join inbox, and governance dashboard (#68) (governance)
+- Public download site with arch-aware downloads and native ARM64 CI (#74)
+
+
+### Other
+- Edit capabilities and config
+- Rm template code
+- Vector backend pull
+- Vector mini-apps pull
+- Cargo toml
+- Vector sound pull
+- Packages
+- Add init-finished logic
+- Error handling
+- Communities => squads
+- Add dm error handling
+- Message pagination
+- Typing notif & fetching notif
+- Persistent last message
+- Sort dms into friends, requests, & pending
+- Icon update
+- Squad & default channel creation
+- Allow 1-member mls groups on squad creation
+- Optional themes
+- Typing improvement
+- Typing improvement
+- Flow
+- Improvements
+- Mls groups from friends & pinned
+- Fix
+- Fix
+- Mls invites
+- Comments
+- Sync channel names
+- Notifications
+- Improvements
+- State persistance from settings view
+- Enhance README with platform details and features
+
+Expanded the README to include detailed platform features, architecture, and technology stack.
+- Simplify Pacto description in README
+
+Removed redundant mention of cryptographic and database management logic in the Pacto description.
+- Sidebar wallet
+- Clear sessions on logout-in
+- Comments
+- Aztec theme
+- Dms
+- Tx notifications
+- Safe-deploy modal
+- Dm wallet exchange
+- Poll voting
+- Add pacto-gov as pinned submodule under third_party/pacto-gov
+
+Document clone/init and bump policy in docs/wallet/PACTO_GOV_SUBMODULE.md;
+link from root README and wallet docs index.
+
+Co-authored-by: Cursor <cursoragent@cursor.com>
+- Checkout pacto-gov submodule recursively before Tauri build
+- Hydration standardization
+- Commons mode
+- Key mgmt
+- View squad signer
+- Upgrade pnpm to 11.7.0 and update action versions
+- Add typecheck, lint, and unit test quality gate
+- Squad dashboard & polls
+- Potential fix for pull request finding
+
+Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+- Potential fix for pull request finding
+
+Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+- Potential fix for pull request finding
+
+Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+- Potential fix for pull request finding
+
+Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+- Address PR review feedback (#54)
+
+- Fix use-after-move in message.rs backfill emit loop by cloning reply.id
+- Fix use-after-move and remove stderr spam in lib.rs backfill emit loop
+- Allow ws://127.0.0.1 without port in relay validation to match error message
+- Update relay validation tests for loopback without port
+
+Note: pre-existing failure in npm run check (unrelated TypeScript/vite errors) not addressed by this PR.
+- Add Makefile for app lifecycle commands
+- Address PR review feedback (#58)
+
+- Reorder import type before export re-exports in src/lib/commons/types.ts to match codebase convention.
+- Fix indentation of parseSupportedChainId import in src/routes/+page.svelte to align with surrounding imports.
+- Split CI into frontend and backend jobs and remove ignore-failure gates (ci)
+
+
+### Refactor
+- Reduce aargon2id iterations for faster decryption
+- Rm pivx payments
+- Cache trusted relays
+- Simplify code
+- Rm PROFILE_CACHE_DEBUG.md
+- Enforce >1 mls group creation
+- Rm packages in favor of minified files
+- Separate squad invite from channel invite
+- Networks functionality
+- Remove bloat
+- Modular re-usable approach to squads and networks
+- Ux components to match backend refactor
+- Reveal evm address in update account creation
+- Virtual channel buckets
+- Governance modes
+- Evm alloy
+- Dashboard tabs
+- Monitor to inbox
+- User settings
+- Cleanup
+- Reduce loc
+- Dashboard onchain fetching
+- Chain refreshing
+- Settings
+- Hydrate
+- Squad channel life-cycle
+- Optimistic dm-wallet announcements
+- Add timeout guard to local-dev relay setup
+- Chain network optionality
+- Replace anvil term with local
+
+
+### Revert
+- Mls proposal handling
+
+
+### Styling
+- Collaspable settings sections
+- Chains selector
+- Ux
+
+
+### Testing
+- Scaffold smoke
+- Add coverage for Local Anvil chain (31337) (wallet)
+- Add backend unit tests for crypto, EVM, storage, and catalog helpers (rust)
+- Add frontend unit tests for stores, utils, API, app, dashboard, governance, and parent flows (#65) (frontend)
+
 
 
 ## v0.1.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Privacy on these blockchains is achieved through Zero-Knowledge (ZK) proving sch
 
 ## Install
 
-Download the latest release for your platform from **[covenant-gov.github.io/pacto-app/](https://covenant-gov.github.io/pacto-app/)** or use the commands below. Examples reference v0.3.0; check the [releases page](https://github.com/covenant-gov/pacto-app/releases/latest) for the current version.
+Download the latest release for your platform from **[covenant-gov.github.io/pacto-app/](https://covenant-gov.github.io/pacto-app/)** or use the commands below. Examples reference v0.3.1; check the [releases page](https://github.com/covenant-gov/pacto-app/releases/latest) for the current version.
 
 ### macOS
 
@@ -30,8 +30,8 @@ brew install --cask covenant-gov/pacto/pacto
 #### Manual install
 
 1. Download the DMG for your Mac from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest):
-   - Apple Silicon: `pacto_0.3.0_aarch64.dmg`
-   - Intel: `pacto_0.3.0_x64.dmg`
+   - Apple Silicon: `pacto_0.3.1_aarch64.dmg`
+   - Intel: `pacto_0.3.1_x64.dmg`
 2. Open the DMG and drag `pacto.app` to **Applications**.
 
 #### Unsigned app warning
@@ -53,28 +53,28 @@ Then launch Pacto from Applications.
 #### Debian / Ubuntu (AMD64)
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.0/pacto_0.3.0_amd64.deb
-sudo dpkg -i pacto_0.3.0_amd64.deb
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto_0.3.1_amd64.deb
+sudo dpkg -i pacto_0.3.1_amd64.deb
 ```
 
 #### Fedora / RHEL / openSUSE (x86_64)
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.0/pacto-0.3.0-1.x86_64.rpm
-sudo dnf install ./pacto-0.3.0-1.x86_64.rpm
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto-0.3.1-1.x86_64.rpm
+sudo dnf install ./pacto-0.3.1-1.x86_64.rpm
 ```
 
 #### AppImage
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.0/pacto_0.3.0_amd64.AppImage
-chmod +x pacto_0.3.0_amd64.AppImage
-./pacto_0.3.0_amd64.AppImage
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto_0.3.1_amd64.AppImage
+chmod +x pacto_0.3.1_amd64.AppImage
+./pacto_0.3.1_amd64.AppImage
 ```
 
 ### Windows
 
-1. Download `pacto_0.3.0_x64_en-US.msi` from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest).
+1. Download `pacto_0.3.1_x64_en-US.msi` from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest).
 2. Run the installer and follow the prompts.
 
 Windows Defender SmartScreen may warn that the app is unsigned. Click **More info** → **Run anyway**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacto",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "pacto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacto"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Tauri App"
 authors = ["daopunk"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pacto",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "io.pacto",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps the Pacto desktop app version to 0.3.1 across all versioned files and refreshes release-facing docs.

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`: update to 0.3.1
- `CHANGELOG.md`: regenerate with a new `v0.3.1` section and highlights for the idle lock, seed-backup gate, and install-instruction work
- `README.md`: update install example URLs and artifact filenames to v0.3.1

No application behavior changes; this is release bookkeeping only.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![kimi_for_coding](https://img.shields.io/badge/kimi_for_coding-D97757?logo=claude&logoColor=white)
