### PR TITLE
fix(updater): clarify install/relaunch state and error messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ pnpm tauri:build
 pnpm check
 pnpm check:watch
 
+# Lint
+pnpm lint
+
 # Frontend unit tests
 pnpm test
 pnpm test:watch
@@ -173,7 +176,8 @@ cd src-tauri && cargo test
 - **Package manager:** pnpm (v9 in CI; workspace is single-root with build allowances in `pnpm-workspace.yaml`).
 - **Frontend runtime:** Node.js LTS; Vite dev server; SvelteKit static adapter SPA mode.
 - **Backend runtime:** Rust stable toolchain; Tauri v2; tokio async runtime.
-- **Type checking:** `svelte-check` via `pnpm check`. No ESLint/Prettier config is present in the repo.
+- **Linting:** `eslint .` via `pnpm lint`.
+- **Type checking:** `svelte-check` via `pnpm check`.
 - **Build orchestration:** Tauri CLI owns the loop: it runs `pnpm dev`/`pnpm build` first, then compiles the Rust backend, and the webview loads the static frontend.
 - **Environment variables:** Vite exposes only `VITE_*` and `ALCHEMY_*` to the client via `envPrefix`. The Rust backend reads `ALCHEMY_RPC_KEY` and others directly from the process environment.
 - **Platform-specific deps:** Linux needs WebKit2GTK 4.1, Vulkan, ALSA, appindicator; macOS needs Xcode CLT, cmake, llvm, openssl; Windows needs VS Build Tools, LLVM, WebView2, Vulkan. See `docs/build/{ubuntuGuide,macGuide,windowsGuide}.md`.
@@ -205,4 +209,5 @@ cd src-tauri && cargo test
 - **Before creating or updating a PR:** use the [`value-based-pr`](.agents/skills/value-based-pr/README.md) skill so the title and description explain what changed and why it matters, not just which files were touched.
 - **Greenfield posture:** do not preserve legacy layouts, old wire formats, or dual-read paths unless explicitly asked. Alpha-only repair code in `docs/legacy-fixes/` should be removed before public beta.
 - **Do not delete or narrow `.cursor/rules/`** unless the user explicitly asked to remove or replace a policy.
+- **Run lint before committing or pushing:** always run `pnpm lint` and fix all reported violations before creating a commit or pushing a branch.
 - **`install.sh` at the repo root installs an external CLI (`pacto-bot-api`)**, not the Pacto desktop app; do not use it for local desktop setup.

--- a/scripts/local-update-test.mjs
+++ b/scripts/local-update-test.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync, spawn } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, rmSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { resolve, dirname, basename } from 'node:path';
@@ -195,8 +195,8 @@ function ensureSigningKey(path) {
 
   try {
     execSync(`pnpm exec tauri signer generate -w ${path}`, { stdio: 'inherit' });
-  } catch (err) {
-    throw new Error('Failed to generate signing key. You can generate one manually with: pnpm exec tauri signer generate');
+  } catch (_err) {
+    throw new Error('Failed to generate signing key. You can generate one manually with: pnpm exec tauri signer generate', { cause: _err });
   }
 
   console.log('');

--- a/scripts/local-update-test.mjs
+++ b/scripts/local-update-test.mjs
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+import { execSync, spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const TEST_DIR = resolve(ROOT, '.local-update-test');
+const BACKUP_SUFFIX = '.local-update-test-backup';
+
+const FILES = {
+  packageJson: resolve(ROOT, 'package.json'),
+  cargoToml: resolve(ROOT, 'src-tauri', 'Cargo.toml'),
+  tauriConf: resolve(ROOT, 'src-tauri', 'tauri.conf.json'),
+};
+
+const PLATFORM_INFO = detectPlatform();
+
+function detectPlatform() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'darwin') {
+    return {
+      id: arch === 'arm64' ? 'darwin-aarch64' : 'darwin-x86_64',
+      archLabel: arch === 'arm64' ? 'aarch64' : 'x86_64',
+      productName: 'pacto',
+      dmgDir: resolve(ROOT, 'src-tauri', 'target', 'release', 'bundle', 'dmg'),
+      updaterDir: resolve(ROOT, 'src-tauri', 'target', 'release', 'bundle', 'macos'),
+      dmgExtension: '.dmg',
+      updaterExtension: '.app.tar.gz',
+    };
+  }
+
+  if (platform === 'win32') {
+    return {
+      id: 'windows-x86_64',
+      archLabel: 'x64',
+      productName: 'pacto',
+      bundleDir: resolve(ROOT, 'src-tauri', 'target', 'release', 'bundle', 'msi'),
+      extension: '.msi',
+    };
+  }
+
+  if (platform === 'linux') {
+    return {
+      id: 'linux-x86_64',
+      archLabel: 'amd64',
+      productName: 'pacto',
+      bundleDir: resolve(ROOT, 'src-tauri', 'target', 'release', 'bundle', 'appimage'),
+      extension: '.AppImage',
+    };
+  }
+
+  throw new Error(`Unsupported platform for local update testing: ${platform}`);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const options = {
+    oldVersion: '0.3.0',
+    newVersion: '0.3.1',
+    signingKey: resolve(process.env.HOME || process.env.USERPROFILE, '.tauri', 'pacto.key'),
+    signingKeyPassword: process.env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '',
+    port: 8080,
+    install: false,
+    serve: true,
+    restore: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--old-version':
+        options.oldVersion = args[++i];
+        break;
+      case '--new-version':
+        options.newVersion = args[++i];
+        break;
+      case '--signing-key':
+        options.signingKey = resolve(args[++i]);
+        break;
+      case '--signing-key-password':
+        options.signingKeyPassword = args[++i];
+        break;
+      case '--port':
+        options.port = parseInt(args[++i], 10);
+        break;
+      case '--install':
+        options.install = true;
+        break;
+      case '--no-serve':
+        options.serve = false;
+        break;
+      case '--restore':
+        options.restore = true;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.log(`
+Usage: node scripts/local-update-test.mjs [options]
+
+Build two release versions of Pacto, generate a local update manifest, and
+serve it so you can test the in-app updater end-to-end.
+
+Options:
+  --old-version <x.y.z>   Version of the installed app (default: 0.3.0)
+  --new-version <x.y.z>   Version of the update (default: 0.3.1)
+  --signing-key <path>    Path to Tauri updater private key (default: ~/.tauri/pacto.key)
+  --signing-key-password <password>
+                         Password for the private key (default: env TAURI_SIGNING_PRIVATE_KEY_PASSWORD)
+  --port <number>         Port for the local update server (default: 8080)
+  --install               Install the old version to /Applications/Pacto-Test.app
+  --no-serve              Build artifacts but do not start the local server
+  --restore               Restore backed-up files and exit
+  --help, -h              Show this help
+
+Example:
+  pnpm exec node scripts/local-update-test.mjs --old-version 0.3.0 --new-version 0.3.1 --install
+
+After the script starts the server, open the installed old app and go to:
+  Settings → App → Updates → Check for Updates
+`);
+}
+
+function backupFiles() {
+  for (const file of Object.values(FILES)) {
+    const backupPath = `${file}${BACKUP_SUFFIX}`;
+    if (!existsSync(backupPath)) {
+      copyFileSync(file, backupPath);
+    }
+  }
+}
+
+function restoreFiles() {
+  for (const file of Object.values(FILES)) {
+    const backupPath = `${file}${BACKUP_SUFFIX}`;
+    if (existsSync(backupPath)) {
+      copyFileSync(backupPath, file);
+      rmSync(backupPath);
+    }
+  }
+}
+
+function setVersion(version) {
+  // package.json
+  const pkg = JSON.parse(readFileSync(FILES.packageJson, 'utf8'));
+  pkg.version = version;
+  writeFileSync(FILES.packageJson, JSON.stringify(pkg, null, 2) + '\n');
+
+  // tauri.conf.json
+  const tauriConf = JSON.parse(readFileSync(FILES.tauriConf, 'utf8'));
+  tauriConf.version = version;
+  writeFileSync(FILES.tauriConf, JSON.stringify(tauriConf, null, 2) + '\n');
+
+  // Cargo.toml: version is inside [package]
+  const cargoToml = readFileSync(FILES.cargoToml, 'utf8');
+  const updatedCargoToml = cargoToml.replace(
+    /^(\[package\][\s\S]*?^version = ")[^"]+(")/m,
+    `$1${version}$2`
+  );
+  writeFileSync(FILES.cargoToml, updatedCargoToml);
+}
+
+function setLocalEndpoint(port) {
+  const tauriConf = JSON.parse(readFileSync(FILES.tauriConf, 'utf8'));
+  tauriConf.plugins ??= {};
+  tauriConf.plugins.updater ??= {};
+  tauriConf.plugins.updater.endpoints = [`http://localhost:${port}/latest.json`];
+  writeFileSync(FILES.tauriConf, JSON.stringify(tauriConf, null, 2) + '\n');
+}
+
+function ensureSigningKey(path) {
+  if (existsSync(path)) {
+    return;
+  }
+
+  console.log(`Signing key not found at ${path}. Generating a new one...`);
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+
+  try {
+    execSync(`pnpm exec tauri signer generate -w ${path}`, { stdio: 'inherit' });
+  } catch (err) {
+    throw new Error('Failed to generate signing key. You can generate one manually with: pnpm exec tauri signer generate');
+  }
+
+  console.log('');
+  console.log('⚠️  A new signing key was generated.');
+  console.log('You MUST update src-tauri/tauri.conf.json plugins.updater.pubkey with the public key printed above.');
+  console.log('Then re-run this script.');
+  process.exit(1);
+}
+
+function buildRelease(signingKey, signingKeyPassword, label) {
+  console.log(`\nBuilding ${label}...`);
+  const env = {
+    ...process.env,
+    TAURI_SIGNING_PRIVATE_KEY: signingKey,
+  };
+  if (signingKeyPassword) {
+    env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD = signingKeyPassword;
+  }
+  execSync('pnpm tauri:build', {
+    cwd: ROOT,
+    stdio: 'inherit',
+    env,
+  });
+}
+
+function findArtifact(bundleDir, version, extension) {
+  const candidates = [
+    resolve(bundleDir, `pacto_${version}_${PLATFORM_INFO.archLabel}${extension}`),
+    resolve(bundleDir, `Pacto_${version}_${PLATFORM_INFO.archLabel}${extension}`),
+    resolve(bundleDir, `pacto_${version}${extension}`),
+    resolve(bundleDir, `Pacto_${version}${extension}`),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Could not find built artifact for ${version} in ${bundleDir}. Searched: ${candidates.join(', ')}`);
+}
+
+function findOldInstaller(version) {
+  if (PLATFORM_INFO.dmgDir) {
+    return findArtifact(PLATFORM_INFO.dmgDir, version, PLATFORM_INFO.dmgExtension);
+  }
+  return findArtifact(PLATFORM_INFO.bundleDir, version, PLATFORM_INFO.extension);
+}
+
+function findUpdaterArtifact(version) {
+  if (PLATFORM_INFO.updaterDir) {
+    return findArtifact(PLATFORM_INFO.updaterDir, version, PLATFORM_INFO.updaterExtension);
+  }
+  return findArtifact(PLATFORM_INFO.bundleDir, version, PLATFORM_INFO.extension);
+}
+
+function findSignature(artifactPath) {
+ const sigPath = `${artifactPath}.sig`;
+  if (existsSync(sigPath)) {
+    return sigPath;
+  }
+  throw new Error(`Signature file not found: ${sigPath}`);
+}
+
+function generateManifest(newVersion, artifactPath, sigPath, port) {
+  const filename = basename(artifactPath);
+  const signature = readFileSync(sigPath, 'utf8').trim();
+
+  const manifest = {
+    version: newVersion,
+    notes: 'Local update test',
+    pub_date: new Date().toISOString(),
+    platforms: {
+      [PLATFORM_INFO.id]: {
+        signature,
+        url: `http://localhost:${port}/${filename}`,
+      },
+    },
+  };
+
+  const manifestPath = resolve(TEST_DIR, 'latest.json');
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  return manifestPath;
+}
+
+function installTestApp(dmgPath) {
+  console.log('\nInstalling test app to /Applications/Pacto-Test.app...');
+
+  // Mount the DMG
+  const mountResult = execSync(`hdiutil attach -nobrowse -readonly "${dmgPath}"`, { encoding: 'utf8' });
+  const mountLine = mountResult.split('\n').find(line => line.includes('/Volumes/'));
+  if (!mountLine) {
+    throw new Error('Failed to mount DMG');
+  }
+  const mountPoint = mountLine.split('\t').pop().trim();
+
+  try {
+    // Remove existing test app
+    execSync('rm -rf /Applications/Pacto-Test.app', { stdio: 'ignore' });
+
+    // Copy app bundle
+    execSync(`cp -R "${mountPoint}/Pacto.app" /Applications/Pacto-Test.app`, { stdio: 'inherit' });
+
+    // Remove quarantine
+    execSync('xattr -rd com.apple.quarantine /Applications/Pacto-Test.app', { stdio: 'ignore' });
+  } finally {
+    // Unmount the DMG
+    execSync(`hdiutil detach "${mountPoint}"`, { stdio: 'ignore' });
+  }
+
+  console.log('Installed /Applications/Pacto-Test.app');
+}
+
+function serveTestDir(port, oldArtifactPath) {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const urlPath = req.url === '/' ? '/index.html' : req.url;
+      const filePath = resolve(TEST_DIR, urlPath.slice(1));
+
+      if (!filePath.startsWith(TEST_DIR)) {
+        res.statusCode = 403;
+        res.end('Forbidden');
+        return;
+      }
+
+      if (!existsSync(filePath)) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+
+      const data = readFileSync(filePath);
+      res.setHeader('Content-Type', 'application/octet-stream');
+      res.end(data);
+    });
+
+    server.listen(port, '0.0.0.0', () => {
+      console.log(`\nLocal update server running at http://localhost:${port}`);
+      console.log(`Manifest: http://localhost:${port}/latest.json`);
+      console.log('');
+      console.log('Next step:');
+      if (existsSync('/Applications/Pacto-Test.app')) {
+        console.log('  open /Applications/Pacto-Test.app');
+      } else {
+        console.log(`  Open ${oldArtifactPath} and drag Pacto.app to /Applications (or re-run with --install).`);
+      }
+      console.log('  Then in the app: Settings → App → Updates → Check for Updates');
+      console.log('  Press Ctrl+C to stop the server and restore files.');
+      resolve(server);
+    });
+  });
+}
+
+async function main() {
+  const options = parseArgs();
+
+  if (options.restore) {
+    console.log('Restoring backed-up files...');
+    restoreFiles();
+    console.log('Restored.');
+    process.exit(0);
+  }
+
+  console.log('Local update test setup');
+  console.log(`  Old version: ${options.oldVersion}`);
+  console.log(`  New version: ${options.newVersion}`);
+  console.log(`  Platform: ${PLATFORM_INFO.id}`);
+  console.log(`  Signing key: ${options.signingKey}`);
+  console.log(`  Signing key password: ${options.signingKeyPassword ? 'provided' : 'not provided'}`);
+  console.log(`  Server port: ${options.port}`);
+  console.log(`  Install test app: ${options.install}`);
+
+  ensureSigningKey(options.signingKey);
+
+  // Prepare test directory
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+
+  // Backup and modify source files
+  backupFiles();
+  setLocalEndpoint(options.port);
+
+  try {
+    // Build old version
+    setVersion(options.oldVersion);
+    buildRelease(options.signingKey, options.signingKeyPassword, `old version ${options.oldVersion}`);
+    const oldArtifact = findOldInstaller(options.oldVersion);
+    const oldArtifactDest = resolve(TEST_DIR, basename(oldArtifact));
+    copyFileSync(oldArtifact, oldArtifactDest);
+    console.log(`\nOld installer: ${oldArtifactDest}`);
+
+    // Build new version
+    setVersion(options.newVersion);
+    buildRelease(options.signingKey, options.signingKeyPassword, `new version ${options.newVersion}`);
+    const newArtifact = findUpdaterArtifact(options.newVersion);
+    const newArtifactSig = findSignature(newArtifact);
+    const newArtifactDest = resolve(TEST_DIR, basename(newArtifact));
+    const newSigDest = resolve(TEST_DIR, basename(newArtifactSig));
+    copyFileSync(newArtifact, newArtifactDest);
+    copyFileSync(newArtifactSig, newSigDest);
+    console.log(`\nNew updater artifact: ${newArtifactDest}`);
+    console.log(`Signature: ${newSigDest}`);
+
+    // Generate manifest
+    const manifestPath = generateManifest(options.newVersion, newArtifactDest, newSigDest, options.port);
+    console.log(`\nManifest: ${manifestPath}`);
+
+    // Install test app if requested
+    if (options.install) {
+      installTestApp(oldArtifactDest);
+    }
+
+    // Start server
+    if (options.serve) {
+      const server = await serveTestDir(options.port, oldArtifactDest);
+
+      // Restore files on shutdown
+      process.on('SIGINT', () => {
+        console.log('\nShutting down...');
+        server.close(() => {
+          restoreFiles();
+          process.exit(0);
+        });
+      });
+    } else {
+      console.log('\nBuild complete. Files are in:', TEST_DIR);
+      restoreFiles();
+    }
+  } catch (err) {
+    console.error('\nError:', err.message);
+    restoreFiles();
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  restoreFiles();
+  process.exit(1);
+});

--- a/src/components/settings/AppSettingsSection.svelte
+++ b/src/components/settings/AppSettingsSection.svelte
@@ -23,7 +23,7 @@
     return `${version} (${buildCommitHash})`;
   }
 
-  function statusText(status: (typeof $updateStatus)['status'] | 'relaunchPending'): string {
+  function statusText(status: (typeof $updateStatus)['status']): string {
     switch (status) {
       case 'idle':
         return '';
@@ -35,10 +35,10 @@
       case 'downloading':
       case 'installing':
         return `Update ${$updateStatus.availableVersion ?? ''} available`;
+      case 'installed':
+        return 'Update installed — relaunch to apply.';
       case 'error':
         return $updateStatus.error ?? 'Update check failed.';
-      case 'relaunchPending':
-        return 'Update installed — relaunch to apply.';
       case 'dev-disabled':
         return 'Updates are only available in release builds.';
     }
@@ -140,7 +140,7 @@
         </p>
       {/if}
 
-      {#if $updateStatus.status === 'available' || $updateStatus.status === 'downloading' || $updateStatus.status === 'installing' || $updateStatus.status === 'error' || $updateStatus.relaunchPending}
+      {#if $updateStatus.status === 'available' || $updateStatus.status === 'downloading' || $updateStatus.status === 'installing' || $updateStatus.status === 'installed' || $updateStatus.status === 'error'}
         <div class="inline-update-panel">
           <UpdateAvailablePanel />
         </div>

--- a/src/components/updater/UpdateAvailableModal.svelte
+++ b/src/components/updater/UpdateAvailableModal.svelte
@@ -7,13 +7,13 @@
     $updateStatus.status === 'available' ||
     $updateStatus.status === 'downloading' ||
     $updateStatus.status === 'installing' ||
-    $updateStatus.status === 'error' ||
-    $updateStatus.relaunchPending;
+    $updateStatus.status === 'installed' ||
+    $updateStatus.status === 'error';
 
   $: title =
     $updateStatus.status === 'error'
       ? 'Update check failed'
-      : $updateStatus.relaunchPending
+      : $updateStatus.status === 'installed'
         ? 'Update installed'
         : 'Update available';
 

--- a/src/components/updater/UpdateAvailablePanel.svelte
+++ b/src/components/updater/UpdateAvailablePanel.svelte
@@ -26,6 +26,17 @@
     }
   }
 
+  function progressLabel(status: UpdateState['status']): string {
+    switch (status) {
+      case 'downloading':
+        return 'Downloading…';
+      case 'installing':
+        return 'Downloaded. Installing update…';
+      default:
+        return '';
+    }
+  }
+
   function handlePrimary(): void {
     if (state.status === 'error') {
       void checkForUpdates();
@@ -45,7 +56,7 @@
     </p>
   {:else if state.status === 'downloading' || state.status === 'installing'}
     <p class="update-version">
-      Update {state.availableVersion ?? ''} is being {state.status}.
+      Update {state.availableVersion ?? ''} is {state.status}.
       {#if state.currentVersion}
         You have {state.currentVersion}.
       {/if}
@@ -59,7 +70,26 @@
     >
       <div class="update-progress-bar" style="width: {progressPercent(state.downloadProgress)}"></div>
     </div>
-    <p class="update-progress-label">{primaryLabel(state.status)} {progressPercent(state.downloadProgress)}</p>
+    <p class="update-progress-label">
+      {#if state.status === 'downloading'}
+        {progressLabel(state.status)} {progressPercent(state.downloadProgress)}
+      {:else}
+        {progressLabel(state.status)}
+      {/if}
+    </p>
+  {:else if state.status === 'installed'}
+    <p class="update-version">
+      Update {state.availableVersion ?? ''} is installed.
+      {#if state.currentVersion}
+        You have {state.currentVersion}.
+      {/if}
+    </p>
+    <p class="update-relaunch-prompt">
+      Relaunch Pacto to start the new version.
+    </p>
+    <button type="button" class="btn-primary" on:click={() => void relaunchApp()}>
+      Relaunch now
+    </button>
   {:else if state.status === 'error'}
     <p class="update-version">
       {#if state.currentVersion}
@@ -69,17 +99,27 @@
     <p class="update-error" role="alert">{state.error ?? 'Update check failed.'}</p>
   {/if}
 
-  {#if state.relaunchPending}
-    <p class="update-relaunch-prompt">The update is installed. Relaunch to start the new version.</p>
-    <button type="button" class="btn-primary" on:click={() => void relaunchApp()}>
-      Relaunch now
-    </button>
-  {:else if state.status !== 'idle' && state.status !== 'checking' && state.status !== 'no-update' && state.status !== 'dev-disabled'}
+  {#if state.status === 'available'}
     <button
       type="button"
       class="btn-primary"
-      disabled={state.status === 'downloading' || state.status === 'installing'}
       on:click={handlePrimary}
+    >
+      {primaryLabel(state.status)}
+    </button>
+  {:else if state.status === 'error'}
+    <button
+      type="button"
+      class="btn-primary"
+      on:click={handlePrimary}
+    >
+      {primaryLabel(state.status)}
+    </button>
+  {:else if state.status === 'downloading' || state.status === 'installing'}
+    <button
+      type="button"
+      class="btn-primary"
+      disabled
     >
       {primaryLabel(state.status)}
     </button>

--- a/src/lib/updater/update-check.test.ts
+++ b/src/lib/updater/update-check.test.ts
@@ -142,7 +142,7 @@ describe('downloadAndInstallUpdate', () => {
     expectStatus('idle');
   });
 
-  it('transitions through downloading/installing and sets relaunchPending on success', async () => {
+  it('transitions through downloading/installing and sets installed status on success', async () => {
     setIsDevBuildForTest(false);
     const downloadAndInstall = vi.fn().mockImplementation((onEvent) => {
       onEvent({ event: 'Started', data: { contentLength: 100 } });
@@ -159,8 +159,7 @@ describe('downloadAndInstallUpdate', () => {
     await downloadAndInstallUpdate();
 
     const state = get(updateStatus);
-    expect(state.status).toBe('available');
-    expect(state.relaunchPending).toBe(true);
+    expect(state.status).toBe('installed');
     expect(state.downloadProgress).toBe(1);
     expect(downloadAndInstall).toHaveBeenCalled();
   });

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -37,6 +37,7 @@ export type UpdateStatus =
   | 'available'
   | 'downloading'
   | 'installing'
+  | 'installed'
   | 'error'
   | 'dev-disabled';
 
@@ -46,7 +47,6 @@ export interface UpdateState {
   availableVersion: string | null;
   downloadProgress: number;
   error: string | null;
-  relaunchPending: boolean;
 }
 
 const initialState: UpdateState = {
@@ -55,7 +55,6 @@ const initialState: UpdateState = {
   availableVersion: null,
   downloadProgress: 0,
   error: null,
-  relaunchPending: false,
 };
 
 function createUpdateStatusStore() {
@@ -87,9 +86,10 @@ export function resetUpdateStatus(): void {
 }
 
 function friendlyErrorMessage(err: unknown): string {
-  if (!(err instanceof Error)) return 'Update check failed.';
-  const msg = err.message.toLowerCase();
-  if (msg.includes('network') || msg.includes('fetch') || msg.includes('offline')) {
+  const rawMessage = err instanceof Error ? err.message : String(err ?? '');
+  const msg = rawMessage.toLowerCase();
+
+  if (msg.includes('network') || msg.includes('fetch') || msg.includes('offline') || msg.includes('connection')) {
     return 'Update check failed. Please check your internet connection and try again.';
   }
   if (msg.includes('signature') || msg.includes('verify') || msg.includes('invalid signature')) {
@@ -102,11 +102,16 @@ function friendlyErrorMessage(err: unknown): string {
     msg.includes('not found') ||
     msg.includes('404') ||
     msg.includes('latest.json') ||
-    msg.includes('no release')
+    msg.includes('no release') ||
+    msg.includes('unexpected http response')
   ) {
     return 'No published release was found. This is expected until the first release is shipped.';
   }
-  return err.message || 'Update check failed.';
+  if (msg.includes('timeout')) {
+    return 'Update check timed out. Please try again.';
+  }
+
+  return rawMessage || 'Update check failed.';
 }
 
 export async function checkForUpdates(): Promise<void> {
@@ -132,6 +137,7 @@ export async function checkForUpdates(): Promise<void> {
       downloadProgress: 0,
     });
   } catch (err) {
+    console.error('[updater] Update check failed:', err);
     const message = friendlyErrorMessage(err);
     updateStatus.setStatus('error', { error: message });
   }
@@ -177,8 +183,9 @@ export async function downloadAndInstallUpdate(): Promise<void> {
     }
 
     await update.downloadAndInstall((event) => handleDownloadEvent(event));
-    updateStatus.setStatus('available', { relaunchPending: true, downloadProgress: 1 });
+    updateStatus.setStatus('installed', { downloadProgress: 1 });
   } catch (err) {
+    console.error('[updater] Download or install failed:', err);
     const message = friendlyErrorMessage(err);
     updateStatus.setStatus('error', { error: message, availableVersion: null });
   }


### PR DESCRIPTION
## Summary

The in-app updater now signals the install/relaunch hand-off through a single `installed` status, and surfaced errors describe the actual failure instead of falling back to a generic message.

Before this change, the update UI had to check both `status` and a separate `relaunchPending` boolean, which made the modal and panel logic branchy and allowed inconsistent states. Update errors were also collapsed to "Update check failed." regardless of whether the cause was a network drop, timeout, or unexpected HTTP response.

After this change, `installed` is a first-class status, so the relaunch prompt is driven by one state value. Error handling also maps non-`Error` rejections, timeouts, and unexpected HTTP responses to actionable copy.

## Changes

- Replaced the `relaunchPending` boolean in `UpdateState` with an `installed` status value.
- Updated `UpdateAvailablePanel`, `UpdateAvailableModal`, and `AppSettingsSection` to use the new `installed` status and clearer progress labels.
- Expanded `friendlyErrorMessage` to handle non-`Error` throws, timeouts, and unexpected HTTP responses.
- Added `scripts/local-update-test.mjs` to simulate the end-to-end update flow against a local server.
- Updated `update-check.test.ts` to assert the new `installed` status.
- Added an AGENTS.md policy requiring `pnpm lint` to pass before any commit or push.
- Fixed lint errors in `scripts/local-update-test.mjs` (unused `spawn` import, missing error `cause`).

## Test plan

- `pnpm lint` passes.
- `pnpm test -- run src/lib/updater/update-check.test.ts` passes.
- Full frontend test suite: `pnpm test` passes (1336 tests).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
