### PR TITLE
chore(release): bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## v0.3.2
+
+### Bug Fixes
+- Clarify install/relaunch state and error messages (#117) (updater)
+- Sync squad MLS state across peers and stop raw JSON in UI (#111)
+
+
+### Refactor
+- Adopt refinery for SQLite migrations (#119)
+
 ## v0.3.1
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Privacy on these blockchains is achieved through Zero-Knowledge (ZK) proving sch
 
 ## Install
 
-Download the latest release for your platform from **[covenant-gov.github.io/pacto-app/](https://covenant-gov.github.io/pacto-app/)** or use the commands below. Examples reference v0.3.1; check the [releases page](https://github.com/covenant-gov/pacto-app/releases/latest) for the current version.
+Download the latest release for your platform from **[covenant-gov.github.io/pacto-app/](https://covenant-gov.github.io/pacto-app/)** or use the commands below. Examples reference v0.3.2; check the [releases page](https://github.com/covenant-gov/pacto-app/releases/latest) for the current version.
 
 ### macOS
 
@@ -30,8 +30,8 @@ brew install --cask covenant-gov/pacto/pacto
 #### Manual install
 
 1. Download the DMG for your Mac from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest):
-   - Apple Silicon: `pacto_0.3.1_aarch64.dmg`
-   - Intel: `pacto_0.3.1_x64.dmg`
+   - Apple Silicon: `pacto_0.3.2_aarch64.dmg`
+   - Intel: `pacto_0.3.2_x64.dmg`
 2. Open the DMG and drag `pacto.app` to **Applications**.
 
 #### Unsigned app warning
@@ -53,28 +53,28 @@ Then launch Pacto from Applications.
 #### Debian / Ubuntu (AMD64)
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto_0.3.1_amd64.deb
-sudo dpkg -i pacto_0.3.1_amd64.deb
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.2/pacto_0.3.2_amd64.deb
+sudo dpkg -i pacto_0.3.2_amd64.deb
 ```
 
 #### Fedora / RHEL / openSUSE (x86_64)
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto-0.3.1-1.x86_64.rpm
-sudo dnf install ./pacto-0.3.1-1.x86_64.rpm
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.2/pacto-0.3.2-1.x86_64.rpm
+sudo dnf install ./pacto-0.3.2-1.x86_64.rpm
 ```
 
 #### AppImage
 
 ```bash
-curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.1/pacto_0.3.1_amd64.AppImage
-chmod +x pacto_0.3.1_amd64.AppImage
-./pacto_0.3.1_amd64.AppImage
+curl -LO https://github.com/covenant-gov/pacto-app/releases/download/v0.3.2/pacto_0.3.2_amd64.AppImage
+chmod +x pacto_0.3.2_amd64.AppImage
+./pacto_0.3.2_amd64.AppImage
 ```
 
 ### Windows
 
-1. Download `pacto_0.3.1_x64_en-US.msi` from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest).
+1. Download `pacto_0.3.2_x64_en-US.msi` from the [latest release](https://github.com/covenant-gov/pacto-app/releases/latest).
 2. Run the installer and follow the prompts.
 
 Windows Defender SmartScreen may warn that the app is unsigned. Click **More info** → **Run anyway**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacto",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/scripts/local-update-test.mjs
+++ b/scripts/local-update-test.mjs
@@ -60,8 +60,8 @@ function detectPlatform() {
 function parseArgs() {
   const args = process.argv.slice(2);
   const options = {
-    oldVersion: '0.3.0',
-    newVersion: '0.3.1',
+    oldVersion: '0.3.1',
+    newVersion: '0.3.2',
     signingKey: resolve(process.env.HOME || process.env.USERPROFILE, '.tauri', 'pacto.key'),
     signingKeyPassword: process.env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '',
     port: 8080,
@@ -118,8 +118,8 @@ Build two release versions of Pacto, generate a local update manifest, and
 serve it so you can test the in-app updater end-to-end.
 
 Options:
-  --old-version <x.y.z>   Version of the installed app (default: 0.3.0)
-  --new-version <x.y.z>   Version of the update (default: 0.3.1)
+  --old-version <x.y.z>   Version of the installed app (default: 0.3.1)
+  --new-version <x.y.z>   Version of the update (default: 0.3.2)
   --signing-key <path>    Path to Tauri updater private key (default: ~/.tauri/pacto.key)
   --signing-key-password <password>
                          Password for the private key (default: env TAURI_SIGNING_PRIVATE_KEY_PASSWORD)
@@ -130,7 +130,7 @@ Options:
   --help, -h              Show this help
 
 Example:
-  pnpm exec node scripts/local-update-test.mjs --old-version 0.3.0 --new-version 0.3.1 --install
+  pnpm exec node scripts/local-update-test.mjs --old-version 0.3.1 --new-version 0.3.2 --install
 
 After the script starts the server, open the installed old app and go to:
   Settings → App → Updates → Check for Updates

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "pacto"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacto"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Tauri App"
 authors = ["daopunk"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pacto",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "io.pacto",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Prepare the v0.3.2 release by bumping all package versions and updating release artifacts.

This release bundles the fixes and refactor landed on main since v0.3.1: clearer updater install/relaunch messaging, squad MLS state sync across peers, and the migration to refinery-managed SQLite migrations.

## Changes

- Bump package version to `0.3.2` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
- Update `src-tauri/Cargo.lock` for the new package version.
- Refresh `CHANGELOG.md` with the v0.3.2 entry.
- Update README install links and artifact names to v0.3.2.
- Update `scripts/local-update-test.mjs` defaults to test the 0.3.1 → 0.3.2 update path.

## Test plan

- `pnpm check` — 0 errors.
- `pnpm lint` — clean.
- `pnpm test` — 160 files / 1,383 tests passed.
- `cargo check` — built successfully.
- `cargo test` — 302 passed, 0 failed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
