### PR TITLE
fix: capitalize product name in desktop app config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "pacto",
+  "productName": "Pacto",
   "version": "0.3.2",
   "identifier": "io.pacto",
   "build": {
@@ -13,7 +13,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "pacto",
+        "title": "Pacto",
         "minWidth": 400,
         "width": 1000,
         "minHeight": 400,


### PR DESCRIPTION
## Summary

The desktop app window title and bundle product name were lowercase `pacto`. This PR capitalizes both to `Pacto` for consistent branding across the desktop shell.

## Changes

- Capitalize `productName` in `src-tauri/tauri.conf.json`.
- Capitalize the main window `title` in the same file.

## Test plan

- `pnpm tauri:build` validates the config and produces a bundle with the corrected product name.
- The main window title reads `Pacto` on launch.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
