### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,8 +187,8 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: 'Pacto ${{ github.ref_name }}'
           releaseBody: ${{ steps.notes.outputs.body }}
-          releaseDraft: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          releaseDraft: false
+          prerelease: false
           args: ${{ matrix.args }}
           uploadUpdaterJson: true
           retryAttempts: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## v0.4.0
+
+### Bug Fixes
+- Update ai.json tauri mcp command to use direct node path
+- Repair tauri-e2e job after docker image update (ci)
+- Make updater relaunch restart the updated app on macOS
+
+
+### Chores
+- Record closures for pacto-app-ayq mention feature (beads)
+- Bump version to 0.4.0 (release)
+
+
+### Documentation
+- Docs(mentions) - Add initial plan and idea files
+- Add tauri mcp integration guide and ui validation policy
+
+
+### Features
+- Add @ mentions to squad channels (mentions)
+- Add self-correcting AI testing architecture
+
+
+### Other
+- Capitalize product name
+- Bd init: initialize beads issue tracking
+- Update beads ignore file and create bead
+- Add vulkan deps and rust/pnpm caches for faster linux builds
+- Add prebuilt CI base image
+- Switch backend-tests job to pacto-ci container image
+- Switch release-symbol-check to pacto-ci container and add tauri-e2e diagnostics
+
 ## v0.3.2
 
 ### Bug Fixes
@@ -11,25 +43,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync squad MLS state across peers and stop raw JSON in UI (#111)
 
 
+### Chores
+- Bump version to 0.3.2 (#120) (release)
+
+
 ### Refactor
 - Adopt refinery for SQLite migrations (#119)
 
 ## v0.3.1
 
-### Highlights
-- Hardened account security with automatic idle lock and a verified seed-backup gate that blocks risky actions until the recovery phrase is backed up.
-- Shipped user-facing install instructions for macOS, Linux, and Windows, and included them in GitHub release notes.
+### Chores
+- Bump version to 0.3.1 (#115) (release)
+
+
+### Documentation
+- Add install instructions for macOS, Linux, and Windows (#107)
+
 
 ### Features
 - Add automatic idle lock and migration gate for sensitive operations (#96) (session)
 - Add verified seed-backup gate for risky actions (#114)
 
-### Documentation
-- Add install instructions for macOS, Linux, and Windows (#107)
 
 ### Other
 - Include install instructions in release notes (#108)
 - Docs/install instructions (#109)
+
+* docs: add install instructions for macOS, Linux, and Windows
+
+* ci: include install instructions in release notes
 
 ## v0.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacto",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "pacto"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pacto"
-version = "0.3.2"
+version = "0.4.0"
 description = "A Tauri App"
 authors = ["daopunk"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pacto",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "io.pacto",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Prepares the v0.4.0 release and changes the Tauri release workflow to publish the release directly instead of leaving it as a draft.

Before this change, the Tauri action created a draft release and set prerelease based on whether the tag contained a hyphen. This required a manual step to mark the release as latest.

After this change, pushing the v0.4.0 tag publishes a public, non-prerelease release immediately.

## Changes

- Bump package version to 0.4.0 in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
- Regenerate `CHANGELOG.md` for v0.4.0.
- Set `releaseDraft: false` and `prerelease: false` in `.github/workflows/release.yaml`.

## Test plan

- `pnpm lint` and `pnpm check` passed (0 svelte-check errors, only pre-existing warnings).
- `pnpm test` passed (163 files, 1,438 tests).
- `cargo check` and `cargo test` passed (311 Rust tests).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
