### PR TITLE
feat: add backend-owned app-config with frontend validation and enforcement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ These docs are **tracked in git** and are the primary map for humans and coding 
 | **[wallet/](./wallet/)** | Embedded EVM wallet, RPC, chain config, DM payment messages ([on-chain read pattern](./wallet/ONCHAIN_READ_PATTERN.md)) |
 | **[governance/ACCESS_CONTROL.md](./governance/ACCESS_CONTROL.md)** | Nostr↔EVM roster **ACL** (access control): Hats / Squad Admin capabilities, fail-closed signing preflight |
 | **[CHAIN_TERMINOLOGY.md](./CHAIN_TERMINOLOGY.md)** | Canonical network keys (`local`, not `anvil`); one spelling per chain |
+| **[RUNTIME_CONFIG.md](./RUNTIME_CONFIG.md)** | Backend-owned `AppConfig` limits/flags over Tauri IPC: source of truth, Zod validation, fallback behavior, how to add a new limit |
 | **[audits/](./audits/)** | **Alpha / no external audit:** wallet and key-handling assurance posture ([README](./audits/README.md)) |
 | **[build/](./build/)** | Desktop build guides (macOS, Windows, Ubuntu) |
 | **[testing/](./testing/)** | Test coverage status and backend phased testing plan ([README](./testing/README.md)) |

--- a/docs/RUNTIME_CONFIG.md
+++ b/docs/RUNTIME_CONFIG.md
@@ -1,0 +1,57 @@
+# Runtime application config (`AppConfig`)
+
+Backend-owned limits and feature flags, fetched by the frontend over Tauri IPC instead of hardcoded per-component.
+
+## Source of truth
+
+`src-tauri/src/app_config.rs` is the **only** place these values are defined. Everything else — the Zod schema, the compiled TS fallback, and every UI `maxlength` — derives from or mirrors it.
+
+| Rust constant | AppConfig field (camelCase) | Default | Enforced in |
+|---|---|---|---|
+| `SQUAD_NAME_MAX_LENGTH` | `squadNameMaxLength` | 50 | `create_group_chat`, `squad_catalog::upsert_squad` |
+| `CHANNEL_NAME_MAX_LENGTH` | `channelNameMaxLength` | 50 | UI only (channels are created inside an already-capped squad) |
+| `COMMONS_MAX_TAGS` | `commonsMaxTags` | 3 | `commons::normalize_commons_tags`, `squad_catalog::normalize_commons_tags` |
+| `DEPLOY_SAFE_MAX_SIGNERS` | `deploySafeMaxSigners` | 10 | UI only (Safe contract itself allows more) |
+| `ROLE_LABEL_MAX_LENGTH` | `roleLabelMaxLength` | 32 | `evm::squad_admin_write::bytes32_role_tag` (bytes32 packing) |
+| `WALLET_ACCOUNT_LABEL_MAX_LENGTH` | `walletAccountLabelMaxLength` | 64 | `evm::evm_accounts::add_evm_account` / `update_evm_account` |
+| `CUSTOM_TOKEN_SYMBOL_MAX_LENGTH` | `customTokenSymbolMaxLength` | 16 | UI only (watched tokens are local-only, no backend write path) |
+| `PIN_DIGIT_COUNT` | `pinDigitCount` | 6 | Compile-time `assert!(>= 4)`; not currently re-validated per-write |
+| `ANALYTICS_ENABLED` | `analyticsEnabled` | `false` | Not yet consumed; reserved feature flag |
+
+Fields marked **UI only** have no corresponding backend write-path check (there's nothing to enforce server-side, or the constraint is inherent elsewhere) — the frontend cap is the only guard for those. Everything else is enforced twice: once for UX (frontend `maxlength` / disabled state) and once for real, at the Rust command that persists or signs the data. **The Rust check is the actual boundary** — a modified or bypassed frontend client cannot get past it.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  const[app_config.rs constants] --> cmd[get_app_config Tauri command]
+  const --> writes[Write-path checks\ncreate_group_chat, upsert_squad,\nadd_evm_account, bytes32_role_tag, ...]
+  cmd -- IPC --> store[appConfig store\nsrc/stores/app-config.ts]
+  store --> ui[Svelte components\nmaxlength, validation, error copy]
+  store -.on fetch failure or\nschema mismatch.-> fallback[DEFAULT_APP_CONFIG\none error toast]
+```
+
+## Frontend pieces
+
+- `src/lib/api/app-config.ts` — `getAppConfig()`, a thin `invoke('get_app_config')` wrapper.
+- `src/stores/app-config.ts` — `AppConfigSchema` (Zod, validates shape/type only — it does not hardcode the backend's numbers), `DEFAULT_APP_CONFIG` (compiled fallback, numerically pinned to today's Rust defaults), the `appConfig` writable store, and `loadAppConfig()`.
+- `src/routes/+layout.svelte` calls `loadAppConfig()` once in `onMount`.
+- Components read `$appConfig.<field>` reactively (`$: maxSquadNameLength = $appConfig.squadNameMaxLength;`) rather than caching a snapshot, so a later `refresh` (if ever added) would propagate.
+
+**Fallback behavior:** if `get_app_config` is unreachable or its response fails `AppConfigSchema.parse`, `loadAppConfig()` sets the store to `DEFAULT_APP_CONFIG` and shows exactly one error toast. It does not retry.
+
+`DEFAULT_APP_CONFIG` is **not** authoritative — it exists only so the UI still behaves sanely if IPC fails. `src/stores/app-config.test.ts` has a parity test asserting it matches the Rust defaults, but nothing enforces this across languages at compile time; if you change a constant in `app_config.rs`, update `DEFAULT_APP_CONFIG` by hand or that test will fail.
+
+## Adding a new limit
+
+1. Add the constant + struct field to `src-tauri/src/app_config.rs` (`snake_case` constant, `snake_case` struct field — `serde(rename_all = "camelCase")` handles the wire format).
+2. Add the matching `camelCase` field to `AppConfigSchema` and `DEFAULT_APP_CONFIG` in `src/stores/app-config.ts`, and to `AppConfigDto` in `src/lib/api/app-config.ts`.
+3. Add the field to the `get_app_config` fixture in `src/lib/api/mock-fixtures.ts` (`settingFixtures`).
+4. If the limit gates a backend write, add the check at the command boundary (not inside a shared/internal helper that might also process remote/synced data — see `squad_catalog::upsert_squad` vs. `prepare_row` for the pattern: validate at the command entrypoint, keep internal helpers permissive).
+5. Wire the UI: import `appConfig` from `../stores/app-config` (adjust relative depth), read it reactively, bind it to the relevant `maxlength`/validation.
+6. Update the parity test in `src/stores/app-config.test.ts` and the table above.
+
+## Non-goals
+
+- Not a remote feature-flag service — values are compiled into the binary, fetched once at boot. No hot reload, no per-account overrides.
+- `analyticsEnabled` is scaffolding for a future flag; nothing reads it yet.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "intl-messageformat": "^11.2.12",
     "intl-pluralrules": "^2.0.1",
     "svelte-i18n": "^4.0.1",
-    "viem": "^2.46.3"
+    "viem": "^2.46.3",
+    "zod": "^3.25.7"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,10 @@ importers:
         version: 4.0.1(svelte@5.46.0)
       viem:
         specifier: ^2.46.3
-        version: 2.46.3(typescript@5.6.3)(zod@4.4.3)
+        version: 2.46.3(typescript@5.6.3)(zod@3.25.76)
+      zod:
+        specifier: ^3.25.7
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -56,7 +59,7 @@ importers:
         version: 1.0.0(eslint@10.5.0)(svelte@5.46.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(zod@3.25.76)
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.61.1
@@ -4728,7 +4731,7 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.31)
       ajv: 8.18.0
@@ -4745,8 +4748,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -5319,10 +5322,10 @@ snapshots:
 
   '@zeit/schemas@2.36.0': {}
 
-  abitype@1.2.3(typescript@5.6.3)(zod@4.4.3):
+  abitype@1.2.3(typescript@5.6.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.6.3
-      zod: 4.4.3
+      zod: 3.25.76
 
   accepts@2.0.0:
     dependencies:
@@ -6774,7 +6777,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ox@0.12.4(typescript@5.6.3)(zod@4.4.3):
+  ox@0.12.4(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -6782,7 +6785,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.6.3)(zod@4.4.3)
+      abitype: 1.2.3(typescript@5.6.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.6.3
@@ -7526,15 +7529,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.46.3(typescript@5.6.3)(zod@4.4.3):
+  viem@2.46.3(typescript@5.6.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.6.3)(zod@4.4.3)
+      abitype: 1.2.3(typescript@5.6.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@5.6.3)(zod@4.4.3)
+      ox: 0.12.4(typescript@5.6.3)(zod@3.25.76)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.6.3
@@ -7708,9 +7711,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
-      zod: 4.4.3
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -1,0 +1,82 @@
+//! Application-wide configuration constants and the serializable [`AppConfig`]
+//! snapshot exposed to the frontend through Tauri IPC.
+//!
+//! This module is the source of truth for runtime limits and feature flags that
+//! both the Rust backend and the Svelte frontend must agree on. See
+//! `docs/RUNTIME_CONFIG.md` for the full field table and how to add a new limit.
+
+use serde::Serialize;
+
+/// Maximum length of a squad or channel name.
+pub const SQUAD_NAME_MAX_LENGTH: usize = 50;
+
+/// Maximum length of a channel name.
+///
+/// Channels are created inside squads, so this is the same cap as squad names
+/// for v1.
+pub const CHANNEL_NAME_MAX_LENGTH: usize = 50;
+
+/// Maximum number of author-selectable Commons tags on a squad or broadcast.
+pub const COMMONS_MAX_TAGS: usize = 3;
+
+/// Maximum number of owners/signers on a Safe deployed through the treasury flow.
+pub const DEPLOY_SAFE_MAX_SIGNERS: usize = 10;
+
+/// Maximum length of a role label in squad governance.
+pub const ROLE_LABEL_MAX_LENGTH: usize = 32;
+
+/// Maximum length of a wallet/account label.
+pub const WALLET_ACCOUNT_LABEL_MAX_LENGTH: usize = 64;
+
+/// Maximum length of a custom token symbol.
+pub const CUSTOM_TOKEN_SYMBOL_MAX_LENGTH: usize = 16;
+
+/// Number of PIN digits used for account unlock and key encryption.
+pub const PIN_DIGIT_COUNT: u8 = 6;
+
+/// Whether analytics/telemetry collection is enabled in this build.
+/// Currently disabled by default; included as a proof-of-concept feature flag.
+pub const ANALYTICS_ENABLED: bool = false;
+
+/// Compile-time guard: PIN must be at least 4 digits to prevent dangerously low entropy.
+/// If `PIN_DIGIT_COUNT` is ever changed from the v1 default of 6, this assertion must keep holding.
+const _: () = assert!(PIN_DIGIT_COUNT >= 4, "PIN_DIGIT_COUNT must be at least 4");
+
+/// Backend-owned application configuration snapshot.
+///
+/// All fields are derived from compiled constants so the frontend can adapt
+/// validation and UX without hardcoding its own assumptions.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AppConfig {
+    pub squad_name_max_length: usize,
+    pub channel_name_max_length: usize,
+    pub commons_max_tags: usize,
+    pub deploy_safe_max_signers: usize,
+    pub role_label_max_length: usize,
+    pub wallet_account_label_max_length: usize,
+    pub custom_token_symbol_max_length: usize,
+    pub pin_digit_count: u8,
+    pub analytics_enabled: bool,
+}
+
+/// Returns the default application configuration snapshot.
+pub fn default_app_config() -> AppConfig {
+    AppConfig {
+        squad_name_max_length: SQUAD_NAME_MAX_LENGTH,
+        channel_name_max_length: CHANNEL_NAME_MAX_LENGTH,
+        commons_max_tags: COMMONS_MAX_TAGS,
+        deploy_safe_max_signers: DEPLOY_SAFE_MAX_SIGNERS,
+        role_label_max_length: ROLE_LABEL_MAX_LENGTH,
+        wallet_account_label_max_length: WALLET_ACCOUNT_LABEL_MAX_LENGTH,
+        custom_token_symbol_max_length: CUSTOM_TOKEN_SYMBOL_MAX_LENGTH,
+        pin_digit_count: PIN_DIGIT_COUNT,
+        analytics_enabled: ANALYTICS_ENABLED,
+    }
+}
+
+/// Tauri command returning the compiled application configuration.
+#[tauri::command]
+pub async fn get_app_config() -> AppConfig {
+    default_app_config()
+}

--- a/src-tauri/src/commons.rs
+++ b/src-tauri/src/commons.rs
@@ -15,7 +15,6 @@ pub const COMMONS_BROADCAST_SCHEMA: &str = "pacto.commons.broadcast.v1";
 pub const COMMONS_CLIENT_TAG: &str = "pacto";
 pub const COMMONS_MAX_LOOKBACK_SECS: u64 = 72 * 3600;
 const EXPIRY_SKEW_SECS: i64 = 60;
-const MAX_TAGS: usize = 3;
 /// Reserved tags applied by the app (e.g. `#new` for fresh users/squads), allowed
 /// in addition to the author-selectable tags. Users cannot self-select these.
 const RESERVED_TAGS: [&str; 1] = ["new"];
@@ -127,8 +126,11 @@ pub fn normalize_commons_tags(raw: &[String]) -> Result<Vec<String>, String> {
         }
         if !is_reserved_tag(&t) {
             author_tags += 1;
-            if author_tags > MAX_TAGS {
-                return Err(format!("At most {MAX_TAGS} tags allowed"));
+            if author_tags > crate::app_config::COMMONS_MAX_TAGS {
+                return Err(format!(
+                    "At most {} tags allowed",
+                    crate::app_config::COMMONS_MAX_TAGS
+                ));
             }
         }
         out.push(t);

--- a/src-tauri/src/evm/evm_accounts.rs
+++ b/src-tauri/src/evm/evm_accounts.rs
@@ -591,6 +591,12 @@ pub async fn add_evm_account<R: Runtime>(
     }
     let phrase = get_mnemonic_for_hd(handle.clone()).await?;
     let label_trimmed = label.trim().to_string();
+    if label_trimmed.len() > crate::app_config::WALLET_ACCOUNT_LABEL_MAX_LENGTH {
+        return Err(format!(
+            "Account label must be at most {} characters",
+            crate::app_config::WALLET_ACCOUNT_LABEL_MAX_LENGTH
+        ));
+    }
 
     let conn = account_manager::get_db_connection(&handle)?;
     let max_idx: Option<i64> = conn
@@ -738,6 +744,12 @@ pub async fn update_evm_account<R: Runtime>(
 ) -> Result<EvmAccountRow, String> {
     ensure_ready(handle.clone()).await?;
     let label_trimmed = label.trim().to_string();
+    if label_trimmed.len() > crate::app_config::WALLET_ACCOUNT_LABEL_MAX_LENGTH {
+        return Err(format!(
+            "Account label must be at most {} characters",
+            crate::app_config::WALLET_ACCOUNT_LABEL_MAX_LENGTH
+        ));
+    }
     let conn = account_manager::get_db_connection(&handle)?;
     let n: i64 = conn
         .query_row(

--- a/src-tauri/src/evm/squad_admin_write.rs
+++ b/src-tauri/src/evm/squad_admin_write.rs
@@ -26,8 +26,11 @@ pub fn bytes32_role_tag(label: &str) -> Result<B256, String> {
     if trimmed.is_empty() {
         return Err("role label must be non-empty".to_string());
     }
-    if trimmed.len() > 32 {
-        return Err("role label must be at most 32 ASCII characters".to_string());
+    if trimmed.len() > crate::app_config::ROLE_LABEL_MAX_LENGTH as usize {
+        return Err(format!(
+            "role label must be at most {} ASCII characters",
+            crate::app_config::ROLE_LABEL_MAX_LENGTH
+        ));
     }
     if !trimmed.is_ascii() {
         return Err("role label must be ASCII".to_string());
@@ -249,7 +252,7 @@ mod tests {
     #[test]
     fn bytes32_role_tag_rejects_empty_and_overlong() {
         assert!(bytes32_role_tag("").is_err());
-        assert!(bytes32_role_tag(&"a".repeat(33)).is_err());
+        assert!(bytes32_role_tag(&"a".repeat(crate::app_config::ROLE_LABEL_MAX_LENGTH + 1)).is_err());
         assert!(bytes32_role_tag("FULL").is_ok());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ use rand::distributions::Alphanumeric;
 
 mod crypto;
 
+mod app_config;
+
 mod test_sandbox;
 
 mod squad_catalog;
@@ -5561,6 +5563,12 @@ async fn create_group_chat(group_name: String, member_ids: Vec<String>) -> Resul
     if name.is_empty() {
         return Err("Group name must not be empty".to_string());
     }
+    if name.len() > crate::app_config::SQUAD_NAME_MAX_LENGTH {
+        return Err(format!(
+            "Group name must be at most {} characters",
+            crate::app_config::SQUAD_NAME_MAX_LENGTH
+        ));
+    }
     if member_ids.is_empty() {
         return Err("Select at least one member to create a group".to_string());
     }
@@ -6761,7 +6769,9 @@ pub fn run() {
             #[cfg(all(not(target_os = "android"), feature = "whisper"))]
             whisper::delete_whisper_model,
             #[cfg(all(not(target_os = "android"), feature = "whisper"))]
-            whisper::list_models
+            whisper::list_models,
+            // Runtime configuration / feature flags
+            app_config::get_app_config
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/squad_catalog.rs
+++ b/src-tauri/src/squad_catalog.rs
@@ -113,8 +113,11 @@ fn normalize_commons_tags(raw: Option<&[String]>, visibility: &str) -> Result<Op
     if tags.is_empty() {
         return Ok(None);
     }
-    if tags.len() > 3 {
-        return Err("commonsTags must contain 1 to 3 tags".to_string());
+    if tags.len() > crate::app_config::COMMONS_MAX_TAGS {
+        return Err(format!(
+            "commonsTags must contain 1 to {} tags",
+            crate::app_config::COMMONS_MAX_TAGS
+        ));
     }
     let mut out: Vec<String> = Vec::new();
     for item in tags {
@@ -416,6 +419,14 @@ pub fn get_squad<R: Runtime>(handle: AppHandle<R>, parent_id: String) -> Result<
 #[command]
 pub fn upsert_squad<R: Runtime>(handle: AppHandle<R>, squad: SquadUpsert) -> Result<SquadRow, String> {
     crate::migration::require_key_derivation_version_2_on_handle(&handle)?;
+    let mut squad = squad;
+    squad.name = squad.name.trim().to_string();
+    if squad.name.len() > crate::app_config::SQUAD_NAME_MAX_LENGTH {
+        return Err(format!(
+            "Squad name must be at most {} characters",
+            crate::app_config::SQUAD_NAME_MAX_LENGTH
+        ));
+    }
     let mut row = prepare_row(squad)?;
     let conn = crate::account_manager::get_db_connection(&handle)?;
     if let Some(existing) = get_squad_inner(&conn, row.id.as_str())? {

--- a/src/components/auth/Login.svelte
+++ b/src/components/auth/Login.svelte
@@ -6,6 +6,7 @@
   import KeyImport from './KeyImport.svelte';
   import PinInput from './PinInput.svelte';
   import { checkAuthStatus, createAccount, importAccount, unlockWithPin, authLoading, authError, clearAuthError, checkSession, isAuthenticated, currentUser } from '../../stores/auth';
+  import { appConfig } from '../../stores/app-config';
   import { validateRecoveryPhraseForImport } from '../../lib/api/encryption';
 
   type AuthStep = 'checking' | 'welcome' | 'import' | 'pin-create' | 'pin-confirm' | 'pin-unlock';
@@ -15,6 +16,8 @@
   let firstPin: string = '';
   let error: string | null = null;
   let unlockInFlight = false;
+
+  $: pinDigitCount = $appConfig.pinDigitCount;
 
   // Check if user has stored encrypted key on mount, and confirm backend session state.
   onMount(async () => {
@@ -164,6 +167,7 @@
         onErrorClear={() => { error = null; clearAuthError(); }}
         onBack={handlePinCreateBack}
         isProcessing={$authLoading}
+        {pinDigitCount}
         {error}
       />
     </div>
@@ -175,6 +179,7 @@
         onErrorClear={() => { error = null; clearAuthError(); }}
         onBack={handlePinConfirmBack}
         isProcessing={$authLoading}
+        {pinDigitCount}
         {error}
       />
     </div>
@@ -185,6 +190,7 @@
         onComplete={handlePinUnlock}
         onErrorClear={() => { error = null; clearAuthError(); }}
         isProcessing={$authLoading}
+        {pinDigitCount}
         {error}
       />
     </div>

--- a/src/components/auth/PinInput.svelte
+++ b/src/components/auth/PinInput.svelte
@@ -8,14 +8,15 @@
   export let error: string | null = null;
   export let onErrorClear: (() => void) | undefined = undefined;
   export let onBack: (() => void) | undefined = undefined;
+  export let pinDigitCount: number = 6;
 
-  let digits: string[] = ['', '', '', '', '', ''];
+  let digits: string[] = Array(pinDigitCount).fill('');
   let inputs: HTMLInputElement[] = [];
   let isShaking = false;
   let lastClearedForError: string | null = null;
 
   function clearInputs() {
-    digits = ['', '', '', '', '', ''];
+    digits = Array(pinDigitCount).fill('');
     inputs.forEach((input) => {
       if (input) input.value = '';
     });
@@ -40,7 +41,7 @@
     digits[index] = value;
     target.value = value;
 
-    if (value && index < 5) {
+    if (value && index < pinDigitCount - 1) {
       inputs[index + 1]?.focus();
     }
 
@@ -65,19 +66,19 @@
   function handlePaste(event: ClipboardEvent) {
     event.preventDefault();
     const pastedData = event.clipboardData?.getData('text') || '';
-    const cleaned = pastedData.replace(/[^0-9]/g, '').slice(0, 6);
+    const cleaned = pastedData.replace(/[^0-9]/g, '').slice(0, pinDigitCount);
 
     cleaned.split('').forEach((digit, i) => {
-      if (i < 6) {
+      if (i < pinDigitCount) {
         digits[i] = digit;
         inputs[i].value = digit;
       }
     });
 
-    if (cleaned.length < 6) {
+    if (cleaned.length < pinDigitCount) {
       inputs[cleaned.length]?.focus();
     } else {
-      inputs[5]?.blur();
+      inputs[pinDigitCount - 1]?.blur();
       if (digits.every((d) => d !== '') && !isProcessing) {
         onComplete(digits.join(''));
       }

--- a/src/components/channel/CreateChannelModal.svelte
+++ b/src/components/channel/CreateChannelModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-
+  import { appConfig } from '../../stores/app-config';
   export let open = false;
   export let parentName = '';
   export let subtitle = '';
@@ -23,6 +23,8 @@
   export let onCreateClosed: () => void = () => {};
   export let onToggleMember: (npub: string) => void = () => {};
   export let getMemberDisplayName: (npub: string) => string = (npub) => npub;
+
+  $: maxChannelNameLength = $appConfig.channelNameMaxLength;
 
   const titleId = 'create-channel-modal-title';
   const resolvedInputId = inputId ?? 'create-channel-name';
@@ -58,6 +60,7 @@
         class="create-channel-input"
         placeholder={$t('messaging.channel.namePlaceholder')}
         bind:value={channelName}
+        maxlength={maxChannelNameLength}
         required
         disabled={creating}
       />

--- a/src/components/commons/BroadcastSquadModal.svelte
+++ b/src/components/commons/BroadcastSquadModal.svelte
@@ -188,7 +188,6 @@
       <span class="broadcast-label">{$t('commons.broadcast.tagsLabel')}</span>
       <CommonsTagPicker
         bind:selected={tags}
-        maxTags={3}
         disabled={busy || !roleAllowed}
         placeholder={$t('commons.broadcast.searchTags')}
       />

--- a/src/components/commons/CommonsTagPicker.svelte
+++ b/src/components/commons/CommonsTagPicker.svelte
@@ -6,10 +6,11 @@
     findCommonsTagGroup,
     getLocalizedCommonsTagGroups,
   } from '../../lib/commons/tag-catalog';
+  import { appConfig } from '../../stores/app-config';
 
   /** Selected leaf tags (bindable). */
   export let selected: string[] = [];
-  export let maxTags = 3;
+  export let maxTags: number | undefined = undefined;
   export let disabled = false;
   export let placeholder = $t('commons.tagPicker.searchPlaceholder');
 
@@ -21,7 +22,8 @@
   let container: HTMLDivElement;
   let blurCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
-  $: atMax = selected.length >= maxTags;
+  $: resolvedMaxTags = maxTags ?? $appConfig.commonsMaxTags;
+  $: atMax = selected.length >= resolvedMaxTags;
   $: q = query.trim().toLowerCase();
   $: activeSet = new Set(selected);
 
@@ -160,7 +162,7 @@
   </div>
 
   {#if atMax}
-    <p class="tag-picker-hint">{$t('commons.tagPicker.maxTagsHint', { values: { maxTags } })}</p>
+    <p class="tag-picker-hint">{$t('commons.tagPicker.maxTagsHint', { values: { maxTags: resolvedMaxTags } })}</p>
   {/if}
 
   {#if categoryBrowse}

--- a/src/components/commons/UserCommonsBroadcastPanel.svelte
+++ b/src/components/commons/UserCommonsBroadcastPanel.svelte
@@ -100,7 +100,7 @@
 
 <form class="user-broadcast-panel" on:submit|preventDefault={handleSubmit}>
   <span class="broadcast-label">{$t('commons.broadcast.tagsLabelPersonal')}</span>
-  <CommonsTagPicker bind:selected={tags} maxTags={3} disabled={onCooldown || publishing} />
+  <CommonsTagPicker bind:selected={tags} disabled={onCooldown || publishing} />
 
   {#if loadingActive}
     <p class="broadcast-muted">{$t('commons.broadcast.checkingActive')}</p>

--- a/src/components/layout/Navbar.svelte
+++ b/src/components/layout/Navbar.svelte
@@ -68,6 +68,7 @@
   import { getProfileDisplayName } from '../../lib/utils/profile';
   import { portal } from '../../lib/utils/portal';
   import { profiles } from '../../stores/profiles';
+  import { appConfig } from '../../stores/app-config';
 
   const translate = get(t);
   $: orderedSquads = orderSquads($squads, $squadNavOrder);
@@ -279,6 +280,7 @@
   $: addButtonLabel = showAddButton ? $t(addButtonLabelKeys[$activeTopNavTab]) : '';
   $: showAddButton =
     $activeTopNavTab === 'commons' || $activeTopNavTab === 'dms' || $activeTopNavTab === 'squads';
+  $: maxSquadNameLength = $appConfig.squadNameMaxLength;
 
   $: commonsStartBroadcastDisabled =
     $activeTopNavTab === 'commons' && $commonsUserHasActiveBroadcast;
@@ -483,6 +485,10 @@
     if (!requireBackupVerified()) return;
     const name = organizeSquadName.trim();
     if (!name) return;
+    if (name.length > maxSquadNameLength) {
+      organizeSquadError = 'Squad name must be at most ' + maxSquadNameLength + ' characters.';
+      return;
+    }
     organizeSquadError = '';
     const myNpub = $currentUser?.npub;
     const memberIds = (organizeSquadMembers || []).filter((n) => n !== myNpub);
@@ -685,6 +691,7 @@
         class="organize-input"
         placeholder={squadNamePlaceholder}
         bind:value={organizeSquadName}
+        maxlength={maxSquadNameLength}
         required
       />
       <label class="organize-label" for="squad-icon">{iconUrlLabel}</label>

--- a/src/components/parent/DeploySafeModal.svelte
+++ b/src/components/parent/DeploySafeModal.svelte
@@ -17,7 +17,8 @@
   import { profiles } from '../../stores/profiles';
   import { currentUser } from '../../stores/auth';
   import { getProfileAvatarSrc, getProfileDisplayName } from '../../lib/utils/profile';
-  import { DEPLOY_SAFE_MAX_SIGNERS, TREASURY_SAFE_UI_CAP } from '../../lib/treasury/treasury-safes';
+  import { TREASURY_SAFE_UI_CAP } from '../../lib/treasury/treasury-safes';
+  import { appConfig } from '../../stores/app-config';
   import { listSquadMemberEvmInvokeArgs } from '../../lib/squad/squad-member-evm-share';
   import { runOnChainInBackground } from '../../lib/evm/on-chain-background';
 
@@ -108,7 +109,8 @@
   $: ownerCount = ownerAddresses.length;
   $: thresholdNum = Math.max(1, parseInt(thresholdInput, 10) || 1);
   $: thresholdValid = ownerCount > 0 && thresholdNum >= 1 && thresholdNum <= ownerCount;
-  $: ownerOverMax = ownerCount > DEPLOY_SAFE_MAX_SIGNERS;
+  $: maxSafeSigners = $appConfig.deploySafeMaxSigners;
+  $: ownerOverMax = ownerCount > maxSafeSigners;
 
   function toggleMember(npub: string): void {
     const evm = effectiveEvm(npub);
@@ -124,7 +126,7 @@
     }
     would.set(evm.toLowerCase(), evm);
     if (includeMeAsOwner && myEvm) would.set(myEvm.toLowerCase(), myEvm);
-    if (would.size > DEPLOY_SAFE_MAX_SIGNERS) return;
+    if (would.size > maxSafeSigners) return;
     selectedMemberNpubs = [...selectedMemberNpubs, npub];
   }
 
@@ -202,8 +204,8 @@
       deployError = tFn('governance.deploySafe.errorNoSigners');
       return;
     }
-    if (owners.length > DEPLOY_SAFE_MAX_SIGNERS) {
-      deployError = tFn('governance.deploySafe.errorMaxOwners', { values: { max: DEPLOY_SAFE_MAX_SIGNERS } });
+    if (owners.length > maxSafeSigners) {
+      deployError = tFn('governance.deploySafe.errorMaxOwners', { values: { max: maxSafeSigners } });
       return;
     }
     const th = Math.max(1, parseInt(thresholdInput, 10) || 1);
@@ -275,7 +277,7 @@
 
     <p class="deploy-safe-signers-caption">{$t('governance.deploySafe.signersCaption')}</p>
     <p class="deploy-safe-signers-hint muted">
-      {$t('governance.deploySafe.signersHint', { values: { max: DEPLOY_SAFE_MAX_SIGNERS } })}
+      {$t('governance.deploySafe.signersHint', { values: { max: maxSafeSigners } })}
     </p>
     <ul class="deploy-safe-member-list" role="list">
       {#each signersListNpubs as npub (npub)}
@@ -340,7 +342,7 @@
     <p class="deploy-safe-owner-count muted">{$t('governance.deploySafe.ownerCount', { values: { count: ownerCount } })}</p>
     {#if ownerOverMax}
       <p class="input-error" role="alert">
-        {$t('governance.deploySafe.ownerOverMax', { values: { max: DEPLOY_SAFE_MAX_SIGNERS } })}
+        {$t('governance.deploySafe.ownerOverMax', { values: { max: maxSafeSigners } })}
       </p>
     {/if}
 

--- a/src/components/parent/governance/SquadRolesModal.svelte
+++ b/src/components/parent/governance/SquadRolesModal.svelte
@@ -16,6 +16,7 @@
   } from '../../../lib/governance/governance-privilege';
   import { runOnChainInBackground } from '../../../lib/evm/on-chain-background';
   import { showToast } from '../../../stores/toast';
+  import { appConfig } from '../../../stores/app-config';
 
   export let open = false;
   export let onClose: () => void;
@@ -37,6 +38,8 @@
   let actionError = '';
   let loadedPrivilege: GovernancePrivilege | null = null;
   let privilegeLoadKey = '';
+
+  $: roleLabelMaxLength = $appConfig.roleLabelMaxLength;
 
   $: effectivePrivilege = privilege ?? loadedPrivilege;
   $: saGate = effectivePrivilege
@@ -98,7 +101,7 @@
   async function createRole() {
     const label = roleLabel.trim();
     if (!label) {
-      actionError = tFn('governance.squadRoles.error.noRoleLabel');
+      actionError = tFn('governance.squadRoles.error.noRoleLabel', { values: { max: roleLabelMaxLength } });
       return;
     }
     if (!saGate.enabled) {
@@ -187,7 +190,7 @@
         class="squad-roles-input"
         placeholder={$t('governance.squadRoles.rolePlaceholder')}
         bind:value={roleLabel}
-        maxlength="32"
+        maxlength={roleLabelMaxLength}
         autocomplete="off"
       />
     </div>

--- a/src/components/settings/EvmAccountKeyExportModal.svelte
+++ b/src/components/settings/EvmAccountKeyExportModal.svelte
@@ -8,6 +8,7 @@
   import { evmAccountSchemeLabel, type EvmAccountRow } from '../../lib/wallet/evm-accounts';
   import { portal } from '../../lib/utils/portal';
   import { showToast } from '../../stores/toast';
+  import { appConfig } from '../../stores/app-config';
 
   export let open = false;
   /** `evm` | `nostr` | `seed` (BIP-39 recovery phrase). */
@@ -22,7 +23,7 @@
   type Phase = 'pin' | 'key';
 
   let phase: Phase = 'pin';
-  let pinDigits = ['', '', '', '', '', ''];
+  let pinDigits = Array(6).fill('');
   let pinError = '';
   let busy = false;
   let privateKey = '';
@@ -31,6 +32,9 @@
   let pinInputs: HTMLInputElement[] = [];
 
   let wasOpen = false;
+
+  $: pinDigitCount = $appConfig.pinDigitCount;
+  $: if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
 
   $: {
     if (open && !wasOpen && phase === 'pin') {
@@ -44,7 +48,7 @@
 
   function resetState() {
     phase = 'pin';
-    pinDigits = ['', '', '', '', '', ''];
+    pinDigits = Array(pinDigitCount).fill('');
     pinError = '';
     busy = false;
     privateKey = '';
@@ -61,8 +65,8 @@
     if (busy) return;
     if (variant === 'evm' && !account) return;
     const pinValue = pinDigits.join('');
-    if (pinValue.length !== 6) {
-      pinError = tFn('auth.pinMustBeSixDigits');
+    if (pinValue.length !== pinDigitCount) {
+      pinError = tFn('auth.pinMustBeSixDigits', { values: { count: pinDigitCount } });
       return;
     }
 
@@ -94,7 +98,7 @@
               : tFn('export.error.couldNotExportPrivateKey')
         )
       );
-      pinDigits = ['', '', '', '', '', ''];
+      pinDigits = Array(pinDigitCount).fill('');
       setTimeout(() => pinInputs[0]?.focus(), 100);
     } finally {
       busy = false;
@@ -110,7 +114,7 @@
     }
     pinDigits[index] = value;
     pinError = '';
-    if (value && index < 5) pinInputs[index + 1]?.focus();
+    if (value && index < pinDigitCount - 1) pinInputs[index + 1]?.focus();
     if (pinDigits.every((d) => d !== '')) void handlePinSubmit();
   }
 
@@ -125,7 +129,7 @@
       event.preventDefault();
     } else if (event.key === 'ArrowLeft' && index > 0) {
       pinInputs[index - 1]?.focus();
-    } else if (event.key === 'ArrowRight' && index < 5) {
+    } else if (event.key === 'ArrowRight' && index < pinDigitCount - 1) {
       pinInputs[index + 1]?.focus();
     } else if (event.key === 'Enter') {
       void handlePinSubmit();
@@ -134,13 +138,13 @@
 
   function handlePinPaste(event: ClipboardEvent) {
     event.preventDefault();
-    const digits = (event.clipboardData?.getData('text') || '').replace(/\D/g, '').split('').slice(0, 6);
+    const digits = (event.clipboardData?.getData('text') || '').replace(/\D/g, '').split('').slice(0, pinDigitCount);
     digits.forEach((digit, i) => {
-      if (i < 6) pinDigits[i] = digit;
+      if (i < pinDigitCount) pinDigits[i] = digit;
     });
-    const lastIndex = Math.min(digits.length - 1, 5);
+    const lastIndex = Math.min(digits.length - 1, pinDigitCount - 1);
     pinInputs[lastIndex]?.focus();
-    if (digits.length === 6) void handlePinSubmit();
+    if (digits.length === pinDigitCount) void handlePinSubmit();
   }
 
   async function copyPrivateKey() {

--- a/src/components/settings/ExportAllSecretsModal.svelte
+++ b/src/components/settings/ExportAllSecretsModal.svelte
@@ -8,6 +8,7 @@
   import { copyTextToClipboard } from '../../lib/wallet/clipboard-copy';
   import { portal } from '../../lib/utils/portal';
   import { showToast } from '../../stores/toast';
+  import { appConfig } from '../../stores/app-config';
 
   export let open = false;
   export let npub = '';
@@ -31,7 +32,7 @@
   }
 
   let phase: Phase = 'pin';
-  let pinDigits = ['', '', '', '', '', ''];
+  let pinDigits = Array(6).fill('');
   let pinError = '';
   let busy = false;
   let bundle: ExportBundle | null = null;
@@ -39,6 +40,9 @@
   let pinInputs: HTMLInputElement[] = [];
 
   let wasOpen = false;
+
+  $: pinDigitCount = $appConfig.pinDigitCount;
+  $: if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
 
   $: {
     if (open && !wasOpen && phase === 'pin') {
@@ -52,7 +56,7 @@
 
   function resetState() {
     phase = 'pin';
-    pinDigits = ['', '', '', '', '', ''];
+    pinDigits = Array(pinDigitCount).fill('');
     pinError = '';
     busy = false;
     bundle = null;
@@ -115,8 +119,8 @@
   async function handlePinSubmit() {
     if (busy) return;
     const pinValue = pinDigits.join('');
-    if (pinValue.length !== 6) {
-      pinError = tFn('auth.pinMustBeSixDigits');
+    if (pinValue.length !== pinDigitCount) {
+      pinError = tFn('auth.pinMustBeSixDigits', { values: { count: pinDigitCount } });
       return;
     }
 
@@ -130,7 +134,7 @@
       pinError = tFn('auth.incorrectPinOrExportFailed');
       console.error('Export all failed:', e);
       showToast(getInvokeErrorMessage(e, tFn('export.error.couldNotExportSecrets')));
-      pinDigits = ['', '', '', '', '', ''];
+      pinDigits = Array(pinDigitCount).fill('');
       setTimeout(() => pinInputs[0]?.focus(), 100);
     } finally {
       busy = false;
@@ -146,7 +150,7 @@
     }
     pinDigits[index] = value;
     pinError = '';
-    if (value && index < 5) pinInputs[index + 1]?.focus();
+    if (value && index < pinDigitCount - 1) pinInputs[index + 1]?.focus();
     if (pinDigits.every((d) => d !== '')) void handlePinSubmit();
   }
 
@@ -161,7 +165,7 @@
       event.preventDefault();
     } else if (event.key === 'ArrowLeft' && index > 0) {
       pinInputs[index - 1]?.focus();
-    } else if (event.key === 'ArrowRight' && index < 5) {
+    } else if (event.key === 'ArrowRight' && index < pinDigitCount - 1) {
       pinInputs[index + 1]?.focus();
     } else if (event.key === 'Enter') {
       void handlePinSubmit();
@@ -170,13 +174,13 @@
 
   function handlePinPaste(event: ClipboardEvent) {
     event.preventDefault();
-    const digits = (event.clipboardData?.getData('text') || '').replace(/\D/g, '').split('').slice(0, 6);
+    const digits = (event.clipboardData?.getData('text') || '').replace(/\D/g, '').split('').slice(0, pinDigitCount);
     digits.forEach((digit, i) => {
-      if (i < 6) pinDigits[i] = digit;
+      if (i < pinDigitCount) pinDigits[i] = digit;
     });
-    const lastIndex = Math.min(digits.length - 1, 5);
+    const lastIndex = Math.min(digits.length - 1, pinDigitCount - 1);
     pinInputs[lastIndex]?.focus();
-    if (digits.length === 6) void handlePinSubmit();
+    if (digits.length === pinDigitCount) void handlePinSubmit();
   }
 
   function evmRowLabel(row: EvmSecretRow): string {

--- a/src/components/squad/PairWithSquadModal.svelte
+++ b/src/components/squad/PairWithSquadModal.svelte
@@ -4,6 +4,7 @@
   import SquadCommonsVisibilityFields from './SquadCommonsVisibilityFields.svelte';
   import type { Squad } from '../../stores/app';
   import type { SquadVisibility } from '../../stores/squads';
+  import { appConfig } from '../../stores/app-config';
 
   export let open = false;
   export let anchorSquadName = '';
@@ -28,12 +29,14 @@
   let tagError = '';
   let commonsFields: SquadCommonsVisibilityFields;
 
+  $: maxCommonsTags = $appConfig.commonsMaxTags;
+
   $: canCreate =
     pairName.trim().length > 0 &&
     !!selectedPartnerSquadId &&
     candidates.length > 0 &&
     !creating &&
-    (visibility !== 'public' || tags.length === 3);
+    (visibility !== 'public' || tags.length === maxCommonsTags);
 
   $: if (open) {
     setTimeout(() => document.getElementById('squad-pair-name')?.focus(), 0);

--- a/src/components/squad/SquadCommonsVisibilityFields.svelte
+++ b/src/components/squad/SquadCommonsVisibilityFields.svelte
@@ -33,7 +33,7 @@
 
 {#if visibility === 'public'}
   <span class="commons-tags-label">{$t('commons.broadcast.tagsLabel')}</span>
-  <CommonsTagPicker bind:selected={tags} maxTags={3} {disabled} placeholder={$t('commons.tagPicker.searchPlaceholder')} />
+  <CommonsTagPicker bind:selected={tags} {disabled} placeholder={$t('commons.tagPicker.searchPlaceholder')} />
   {#if tagError}
     <p class="commons-tags-error" role="alert">{tagError}</p>
   {/if}

--- a/src/components/wallet/WalletImportTokensModal.svelte
+++ b/src/components/wallet/WalletImportTokensModal.svelte
@@ -12,6 +12,7 @@
     type CatalogSearchEntry,
     type WatchedErc20Row,
   } from '../../lib/wallet/watched-tokens';
+  import { appConfig } from '../../stores/app-config';
 
   export let open = false;
   export let onClose: () => void;
@@ -33,6 +34,8 @@
   let customDecimalsStr = '18';
 
   let lastOpened = false;
+
+  $: customTokenSymbolMaxLength = $appConfig.customTokenSymbolMaxLength;
 
   $: catalog = buildCatalogSearchEntries();
 
@@ -84,7 +87,7 @@
     if (!accountNpub) return;
     const sym = customSymbol.trim().toUpperCase();
     const dec = Number.parseInt(customDecimalsStr, 10);
-    if (!sym || sym.length > 16 || !/^[A-Z0-9]+$/.test(sym)) return;
+    if (!sym || sym.length > customTokenSymbolMaxLength || !/^[A-Z0-9]+$/.test(sym)) return;
     if (!isHexAddress(customAddress)) return;
     if (!Number.isInteger(dec) || dec < 0 || dec > 36) return;
     const id = customTokenId(customNetwork, customAddress);
@@ -111,7 +114,7 @@
     return Number.isInteger(d) && d >= 0 && d <= 36;
   })();
 
-  $: customSymbolValid = /^[A-Z0-9]{1,16}$/.test(customSymbol.trim().toUpperCase());
+  $: customSymbolValid = customSymbol.trim().length > 0 && customSymbol.trim().length <= customTokenSymbolMaxLength && /^[A-Z0-9]+$/.test(customSymbol.trim().toUpperCase());
 
   $: canSaveCustom =
     accountNpub != null &&
@@ -215,7 +218,7 @@
             type="text"
             placeholder={$t('wallet.symbolPlaceholder')}
             bind:value={customSymbol}
-            maxlength="16"
+            maxlength={customTokenSymbolMaxLength}
             autocomplete="off"
           />
         </label>

--- a/src/components/wallet/WalletView.svelte
+++ b/src/components/wallet/WalletView.svelte
@@ -40,6 +40,7 @@
   import EvmWalletExtras from '../settings/EvmWalletExtras.svelte';
   import { portal } from '../../lib/utils/portal';
   import { settingsSectionCollapsed } from '../../lib/settings/settings-section-collapse';
+  import { appConfig } from '../../stores/app-config';
 
   const tFn = get(t);
 
@@ -52,6 +53,8 @@
   let watchedRows: WatchedErc20Row[] = [];
   let enabledSet = new Set<SupportedChainId>(defaultWalletEnabledChains());
   let tokenNetworkFilter: 'all' | SupportedChainId = DEFAULT_PREFERRED_NETWORK;
+
+  $: walletAccountLabelMaxLength = $appConfig.walletAccountLabelMaxLength;
 
   $: accountNpub = $currentUser?.npub ?? null;
 
@@ -448,7 +451,7 @@
       id="account-form-name"
       type="text"
       class="wallet-view-add-account-input"
-      maxlength="64"
+      maxlength={walletAccountLabelMaxLength}
       placeholder={$t('wallet.accountNamePlaceholder')}
       bind:value={accountFormLabel}
       disabled={accountFormBusy}

--- a/src/lib/api/app-config.test.ts
+++ b/src/lib/api/app-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { getAppConfig, type AppConfigDto } from './app-config';
+
+vi.mock('@tauri-apps/api/core');
+
+const mockedInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+});
+
+describe('app-config command wrappers', () => {
+  it('getAppConfig sends get_app_config with no args and returns the result unchanged', async () => {
+    const dto: AppConfigDto = {
+      squadNameMaxLength: 50,
+      channelNameMaxLength: 50,
+      commonsMaxTags: 3,
+      deploySafeMaxSigners: 10,
+      roleLabelMaxLength: 32,
+      walletAccountLabelMaxLength: 64,
+      customTokenSymbolMaxLength: 16,
+      pinDigitCount: 6,
+      analyticsEnabled: false,
+    };
+    mockedInvoke.mockResolvedValueOnce(dto);
+
+    const result = await getAppConfig();
+
+    expect(mockedInvoke).toHaveBeenCalledWith('get_app_config');
+    expect(result).toEqual(dto);
+  });
+});

--- a/src/lib/api/app-config.ts
+++ b/src/lib/api/app-config.ts
@@ -1,0 +1,19 @@
+import { invoke } from './index';
+
+/** Runtime application configuration and feature flags, mirrored by `AppConfigSchema`. */
+export interface AppConfigDto {
+  squadNameMaxLength: number;
+  channelNameMaxLength: number;
+  commonsMaxTags: number;
+  deploySafeMaxSigners: number;
+  roleLabelMaxLength: number;
+  walletAccountLabelMaxLength: number;
+  customTokenSymbolMaxLength: number;
+  pinDigitCount: number;
+  analyticsEnabled: boolean;
+}
+
+/** Fetch the backend-owned runtime application configuration. */
+export async function getAppConfig(): Promise<AppConfigDto> {
+  return await invoke('get_app_config');
+}

--- a/src/lib/api/mock-fixtures.ts
+++ b/src/lib/api/mock-fixtures.ts
@@ -201,6 +201,17 @@ export const walletFixtures: Record<string, MockCommandHandler> = {
 export const settingFixtures: Record<string, MockCommandHandler> = {
   get_sql_setting: () => null,
   set_sql_setting: () => undefined,
+  get_app_config: () => ({
+    squadNameMaxLength: 50,
+    channelNameMaxLength: 50,
+    commonsMaxTags: 3,
+    deploySafeMaxSigners: 10,
+    roleLabelMaxLength: 32,
+    walletAccountLabelMaxLength: 64,
+    customTokenSymbolMaxLength: 16,
+    pinDigitCount: 6,
+    analyticsEnabled: false,
+  }),
 };
 
 export const encryptionFixtures: Record<string, MockCommandHandler> = {

--- a/src/lib/i18n/locales/en/auth.json
+++ b/src/lib/i18n/locales/en/auth.json
@@ -23,6 +23,6 @@
 	"auth.errorPinsDontMatch": "PINs don't match",
 	"auth.errorCreateAccountFailed": "Failed to create account",
 	"auth.errorIncorrectPin": "Incorrect PIN",
-	"auth.pinMustBeSixDigits": "PIN must be 6 digits",
+	"auth.pinMustBeSixDigits": "PIN must be {count} digits",
 	"auth.incorrectPinOrExportFailed": "Incorrect PIN or export failed"
 }

--- a/src/lib/i18n/locales/en/governance.json
+++ b/src/lib/i18n/locales/en/governance.json
@@ -358,7 +358,7 @@
 	"governance.squadRoles.rolePlaceholder": "e.g. TREASURY",
 	"governance.squadRoles.executorLabel": "Executor address",
 	"governance.squadRoles.executorPlaceholder": "0x…",
-	"governance.squadRoles.error.noRoleLabel": "Enter a role label (max 32 ASCII characters).",
+	"governance.squadRoles.error.noRoleLabel": "Enter a role label (max {max} ASCII characters).",
 	"governance.squadRoles.error.noRoleToEnable": "Enter the role label to enable.",
 	"governance.squadRoles.error.invalidExecutor": "Pick or enter a valid executor address.",
 	"governance.squadRoles.toast.submitted": "Transaction submitted. Confirmation continues in the background.",

--- a/src/lib/i18n/locales/es/auth.json
+++ b/src/lib/i18n/locales/es/auth.json
@@ -23,6 +23,6 @@
 	"auth.errorPinsDontMatch": "Los PINs no coinciden",
 	"auth.errorCreateAccountFailed": "No se pudo crear la cuenta",
 	"auth.errorIncorrectPin": "PIN incorrecto",
-	"auth.pinMustBeSixDigits": "El PIN debe tener 6 dígitos",
+	"auth.pinMustBeSixDigits": "El PIN debe tener {count} dígitos",
 	"auth.incorrectPinOrExportFailed": "PIN incorrecto o fallo al exportar"
 }

--- a/src/lib/i18n/locales/es/governance.json
+++ b/src/lib/i18n/locales/es/governance.json
@@ -358,7 +358,7 @@
 	"governance.squadRoles.rolePlaceholder": "ej. TREASURY",
 	"governance.squadRoles.executorLabel": "Dirección del ejecutor",
 	"governance.squadRoles.executorPlaceholder": "0x…",
-	"governance.squadRoles.error.noRoleLabel": "Ingresa una etiqueta de rol (máx. 32 caracteres ASCII).",
+	"governance.squadRoles.error.noRoleLabel": "Ingresa una etiqueta de rol (máx. {max} caracteres ASCII).",
 	"governance.squadRoles.error.noRoleToEnable": "Ingresa la etiqueta del rol a habilitar.",
 	"governance.squadRoles.error.invalidExecutor": "Elige o ingresa una dirección de ejecutor válida.",
 	"governance.squadRoles.toast.submitted": "Transacción enviada. La confirmación continúa en segundo plano.",

--- a/src/lib/treasury/treasury-safes.ts
+++ b/src/lib/treasury/treasury-safes.ts
@@ -10,9 +10,6 @@ export interface TreasurySafeEntry {
 
 export const TREASURY_SAFE_UI_CAP = 10;
 
-/** Max co-owners selectable in the Deploy Safe flow (UI limit; chain contract allows more). */
-export const DEPLOY_SAFE_MAX_SIGNERS = 10;
-
 /** Treasury tab vaults only — excludes the Pacto Gov governance treasury row. */
 export function vaultTreasurySafesForParent(
   safes: TreasurySafeEntry[],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
   import { DEFAULT_THEME, getStoredTheme, setTheme } from '../stores/theme';
   import { scheduleCommonsStartupPrefetch } from '../lib/commons/commons-prefetch';
   import { locale } from '../stores/locale';
+  import { loadAppConfig } from '../stores/app-config';
 
   // Before first paint: clear any leftover auth state. The backend session check on mount
   // is the authoritative source of truth, so never assume the session is still valid.
@@ -20,6 +21,7 @@
   onMount(() => {
     // Confirm the backend session on every layout mount; drop auth state if locked.
     void checkSession();
+    void loadAppConfig();
     scheduleCommonsStartupPrefetch();
     const stored = getStoredTheme();
     setTheme(stored ?? DEFAULT_THEME);

--- a/src/stores/app-config.test.ts
+++ b/src/stores/app-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('../lib/api/app-config', () => ({
+  getAppConfig: vi.fn(),
+}));
+vi.mock('./toast', () => ({
+  showToast: vi.fn(),
+}));
+
+import { getAppConfig } from '../lib/api/app-config';
+import { showToast } from './toast';
+import { appConfig, loadAppConfig, DEFAULT_APP_CONFIG, AppConfigSchema } from './app-config';
+
+const mockedGetAppConfig = vi.mocked(getAppConfig);
+const mockedShowToast = vi.mocked(showToast);
+
+describe('app-config store', () => {
+  beforeEach(() => {
+    mockedGetAppConfig.mockReset();
+    mockedShowToast.mockReset();
+  });
+
+  afterEach(() => {
+    appConfig.set(DEFAULT_APP_CONFIG);
+  });
+
+  it('starts with DEFAULT_APP_CONFIG before any load', () => {
+    expect(get(appConfig)).toEqual(DEFAULT_APP_CONFIG);
+  });
+
+  it('loadAppConfig populates appConfig with a valid backend response and shows no toast', async () => {
+    const fetched = { ...DEFAULT_APP_CONFIG, squadNameMaxLength: 80 };
+    mockedGetAppConfig.mockResolvedValueOnce(fetched);
+
+    await loadAppConfig();
+
+    expect(get(appConfig)).toEqual(fetched);
+    expect(mockedShowToast).not.toHaveBeenCalled();
+  });
+
+  it('loadAppConfig falls back to DEFAULT_APP_CONFIG and toasts once when getAppConfig rejects', async () => {
+    mockedGetAppConfig.mockRejectedValueOnce(new Error('backend unreachable'));
+
+    await loadAppConfig();
+
+    expect(get(appConfig)).toEqual(DEFAULT_APP_CONFIG);
+    expect(mockedShowToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('loadAppConfig falls back to DEFAULT_APP_CONFIG and toasts once when the response is malformed', async () => {
+    mockedGetAppConfig.mockResolvedValueOnce({
+      ...DEFAULT_APP_CONFIG,
+      squadNameMaxLength: 'not-a-number',
+    } as never);
+
+    await loadAppConfig();
+
+    expect(get(appConfig)).toEqual(DEFAULT_APP_CONFIG);
+    expect(mockedShowToast).toHaveBeenCalledTimes(1);
+  });
+
+  // Must be kept in sync with the compiled constants in src-tauri/src/app_config.rs
+  // (SQUAD_NAME_MAX_LENGTH, CHANNEL_NAME_MAX_LENGTH, COMMONS_MAX_TAGS,
+  // DEPLOY_SAFE_MAX_SIGNERS, ROLE_LABEL_MAX_LENGTH, WALLET_ACCOUNT_LABEL_MAX_LENGTH,
+  // CUSTOM_TOKEN_SYMBOL_MAX_LENGTH, PIN_DIGIT_COUNT, ANALYTICS_ENABLED).
+  it('DEFAULT_APP_CONFIG matches the Rust default_app_config() constants', () => {
+    expect(DEFAULT_APP_CONFIG).toEqual({
+      squadNameMaxLength: 50,
+      channelNameMaxLength: 50,
+      commonsMaxTags: 3,
+      deploySafeMaxSigners: 10,
+      roleLabelMaxLength: 32,
+      walletAccountLabelMaxLength: 64,
+      customTokenSymbolMaxLength: 16,
+      pinDigitCount: 6,
+      analyticsEnabled: false,
+    });
+  });
+
+  it('AppConfigSchema accepts DEFAULT_APP_CONFIG', () => {
+    expect(AppConfigSchema.safeParse(DEFAULT_APP_CONFIG).success).toBe(true);
+  });
+});

--- a/src/stores/app-config.ts
+++ b/src/stores/app-config.ts
@@ -1,0 +1,51 @@
+import { writable } from 'svelte/store';
+import { z } from 'zod';
+import { getAppConfig } from '../lib/api/app-config';
+import { showToast } from './toast';
+
+/** Mirrors the Rust `AppConfig` struct (`src-tauri/src/app_config.rs`). See `docs/RUNTIME_CONFIG.md`. */
+export const AppConfigSchema = z.object({
+  squadNameMaxLength: z.number().int().positive(),
+  channelNameMaxLength: z.number().int().positive(),
+  commonsMaxTags: z.number().int().positive(),
+  deploySafeMaxSigners: z.number().int().positive(),
+  roleLabelMaxLength: z.number().int().positive(),
+  walletAccountLabelMaxLength: z.number().int().positive(),
+  customTokenSymbolMaxLength: z.number().int().positive(),
+  pinDigitCount: z.number().int().min(4),
+  analyticsEnabled: z.boolean(),
+});
+
+export type AppConfig = z.infer<typeof AppConfigSchema>;
+
+/** Compiled fallback; must match `default_app_config()` in `src-tauri/src/app_config.rs`. */
+export const DEFAULT_APP_CONFIG: AppConfig = {
+  squadNameMaxLength: 50,
+  channelNameMaxLength: 50,
+  commonsMaxTags: 3,
+  deploySafeMaxSigners: 10,
+  roleLabelMaxLength: 32,
+  walletAccountLabelMaxLength: 64,
+  customTokenSymbolMaxLength: 16,
+  pinDigitCount: 6,
+  analyticsEnabled: false,
+};
+
+/** Runtime application configuration, fetched from the backend at boot. */
+export const appConfig = writable<AppConfig>(DEFAULT_APP_CONFIG);
+
+/**
+ * Fetch and validate `get_app_config` from the backend, populating `appConfig`.
+ * On an unreachable backend or a malformed/missing field, falls back to
+ * `DEFAULT_APP_CONFIG` and shows exactly one error toast.
+ */
+export async function loadAppConfig(): Promise<void> {
+  try {
+    const raw = await getAppConfig();
+    appConfig.set(AppConfigSchema.parse(raw));
+  } catch (e) {
+    console.error('[app-config] Failed to load/validate app config:', e);
+    appConfig.set(DEFAULT_APP_CONFIG);
+    showToast('Could not load app configuration. Using defaults.', undefined, undefined, { error: true });
+  }
+}


### PR DESCRIPTION
## Summary

Runtime limits (name/tag lengths, PIN digit count, safe-signer cap, etc.) were previously hardcoded independently in the frontend and enforced inconsistently — or not at all — on the backend write paths. This PR makes `src-tauri/src/app_config.rs` the single source of truth, exposes it to the frontend via `get_app_config`, and enforces the same constants where writes happen.

Before this change, a frontend-only validation limit could silently drift from what the backend actually accepted (or the backend accepted values the UI never should have allowed). After this change, both sides read from — or are enforced against — one set of constants, with the frontend falling back to compiled defaults and a single toast if the fetch/validation fails.

## Changes

- **Backend:** `src-tauri/src/app_config.rs` defines the runtime limits/feature flags and `get_app_config` Tauri command; `create_group_chat`, `upsert_squad`, commons/squad_catalog tag validation, `add`/`update_evm_account`, and `bytes32_role_tag` now enforce the same constants at the write-path boundary.
- **Frontend:** Zod-validated `appConfig` store (`src/stores/app-config.ts`), fetched once at boot in `+layout.svelte`, with compiled defaults and a single error toast on failure.
- **Frontend UI:** Navbar, `CreateChannelModal`, `CommonsTagPicker` (+3 callers), `PairWithSquadModal`, `DeploySafeModal`, `PinInput` (+3 PIN callers), `SquadRolesModal`, `WalletView`, and `WalletImportTokensModal` now read their limits from the store instead of hardcoded literals.
- **Docs:** `docs/RUNTIME_CONFIG.md` documents the field table, data flow, and checklist for adding a new limit.

## Test plan

- `pnpm test run src/lib/api/app-config.test.ts src/stores/app-config.test.ts` — 7/7 passing (IPC wrapper, store init/success/error-toast/malformed-response coverage, TS default-parity check against the Rust struct).
- `cd src-tauri && cargo test` — backend builds and unit tests pass with the new `app_config` module and its write-path enforcement wired in.
- `pnpm lint` — 0 errors (4 pre-existing i18n warnings in an unrelated file).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


Closes #154 
