### PR TITLE
fix: stop invite-to-channel modal hanging on a full-account MLS sync

### DIFF
--- a/src/components/channel/ChatView.svelte
+++ b/src/components/channel/ChatView.svelte
@@ -482,7 +482,7 @@
       const inChannel = new Set(result.members ?? []);
       const myNpub = $currentUser?.npub;
       if (activeSquad && !hideChannelOverflowMenu) {
-        const ann = activeSquad.channels[0];
+        const ann = getAnnouncementsChannel(activeSquad);
         if (ann) {
           const annResult = await getMlsGroupMembers(ann.groupId);
           const squadNpubs = annResult.members ?? [];

--- a/src/lib/api/nostr.test.ts
+++ b/src/lib/api/nostr.test.ts
@@ -524,14 +524,14 @@ describe('syncMlsGroupsNow', () => {
   it('invokes sync_mls_groups_now with all groups when no groupId', async () => {
     mockedInvoke.mockResolvedValueOnce([2, 5]);
     const result = await syncMlsGroupsNow();
-    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { group_id: null });
+    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { groupId: null });
     expect(result).toEqual({ synced: 2, total: 5 });
   });
 
   it('invokes sync_mls_groups_now with a specific groupId', async () => {
     mockedInvoke.mockResolvedValueOnce([1, 1]);
     const result = await syncMlsGroupsNow('g1');
-    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { group_id: 'g1' });
+    expect(mockedInvoke).toHaveBeenCalledWith('sync_mls_groups_now', { groupId: 'g1' });
     expect(result).toEqual({ synced: 1, total: 1 });
   });
 });

--- a/src/lib/api/nostr.ts
+++ b/src/lib/api/nostr.ts
@@ -671,7 +671,7 @@ export async function leaveMlsGroup(groupId: string): Promise<void> {
 export async function syncMlsGroupsNow(groupId?: string | null): Promise<{ synced: number; total: number }> {
   dmLog('sync_mls_groups_now', { groupId: groupId ?? '(all)' });
   const [synced, total] = (await invoke('sync_mls_groups_now', {
-    group_id: groupId ?? null,
+    groupId: groupId ?? null,
   })) as [number, number];
   dmLog('sync_mls_groups_now result', { synced, total });
   return { synced, total };


### PR DESCRIPTION
Opening "Invite to channel" from a channel's overflow menu left the modal stuck on "Loading…" forever for any account whose squad had more than a couple of channels — the candidate list never rendered and Invite stayed disabled. Root cause: `syncMlsGroupsNow()` sent the invoke payload key as `group_id` instead of `groupId`; Tauri resolves invoke args against the Rust param name in camelCase, so the mismatch silently resolved the (optional) `group_id` param to `None` on every call. That made `sync_mls_groups_now` always take its "sync every group" branch — a sequential loop over every MLS group the account belongs to, each with up to two 15s relay-fetch timeouts — instead of syncing only the channel the user was inviting to.

Also swapped `ChatView`'s `activeSquad.channels[0]` lookup for `getAnnouncementsChannel(activeSquad)`, the helper every other announcements-channel lookup in the codebase already uses, so once loading finishes the invite candidates come from the correct MLS group regardless of channel array ordering.

Fixes #150.

**Validation:** confirmed the invoke key-matching mechanism live against a running `pnpm tauri dev` build via direct IPC calls before applying the fix (a required-param command threw `missing required key groupId` when sent `group_id`, proving the mismatch). After the fix: full frontend suite green (190 files / 1706 tests), `pnpm check` 0 errors, `eslint` clean on the touched files. Did not re-drive the live invite-modal UI end-to-end post-fix (would need a second test account + squad with no new evidentiary value beyond the mechanism proof and the updated unit-test assertions that now pin the corrected invoke shape).
