### PR TITLE
chore: automate version-bump PR and homebrew tap update

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,77 @@
+name: Prepare Release
+
+# Manual trigger only (Actions tab -> Prepare Release -> Run workflow). Bumps
+# package.json / src-tauri/tauri.conf.json / src-tauri/Cargo.toml, regenerates
+# CHANGELOG.md, runs the same checks scripts/bump-version.sh runs locally, and
+# opens a PR with the result. Does not create or push a git tag -- tagging
+# v<version> happens manually (or via GitHub's "Draft a new release" UI) after
+# the PR merges to main, which is what actually triggers release.yaml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: lts/*
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.7.0
+          run_install: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: install Tauri system dependencies (ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake clang libclang-dev file curl wget git pkg-config libvulkan-dev libxdo-dev libssl-dev libayatana-appindicator3-dev libwebkit2gtk-4.1-dev librsvg2-dev patchelf libasound2-dev xdg-utils glslc
+
+      - name: bump version, changelog, checks
+        run: ./scripts/bump-version.sh "${{ inputs.bump }}" --no-commit
+
+      - name: read bumped version
+        id: bumped
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(release): bump version to ${{ steps.bumped.outputs.version }}"
+          title: "chore(release): bump version to ${{ steps.bumped.outputs.version }}"
+          body: |
+            Automated version prep for `v${{ steps.bumped.outputs.version }}`, opened by the "Prepare Release" workflow.
+
+            - `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`/`Cargo.lock`: version bump.
+            - `CHANGELOG.md`: regenerated via `git-cliff`.
+            - `pnpm check`, `pnpm test`, `cargo check`, `cargo test` all passed in this run.
+
+            No tag is created by this PR. After merging to `main`, cut the release by pushing tag `v${{ steps.bumped.outputs.version }}` (or via GitHub's Releases -> Draft a new release UI), which triggers `release.yaml`.
+          branch: "chore/release-${{ steps.bumped.outputs.version }}"
+          base: main
+          delete-branch: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -199,3 +199,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${{ github.ref_name }}" CHANGELOG.md --clobber
+
+  update-homebrew-tap:
+    # Points covenant-gov/homebrew-pacto's Cask at the DMGs just published above.
+    # Requires HOMEBREW_TAP_TOKEN: a PAT (or fine-grained token) with contents:write
+    # on homebrew-pacto, since GITHUB_TOKEN here only covers this repo.
+    needs: publish-tauri
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout homebrew-pacto
+        uses: actions/checkout@v6
+        with:
+          repository: covenant-gov/homebrew-pacto
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-pacto
+
+      - name: Download macOS release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release download "$TAG" --repo covenant-gov/pacto-app \
+            --pattern 'Pacto_*_aarch64.dmg' --pattern 'Pacto_*_x64.dmg' --dir dmgs
+
+      - name: Update Cask
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          ARM_SHA="$(sha256sum "dmgs/Pacto_${VERSION}_aarch64.dmg" | cut -d' ' -f1)"
+          INTEL_SHA="$(sha256sum "dmgs/Pacto_${VERSION}_x64.dmg" | cut -d' ' -f1)"
+          CASK=homebrew-pacto/Casks/pacto.rb
+          sed -i \
+            -e "s/^  version \".*\"/  version \"${VERSION}\"/" \
+            -e "s/^  sha256 arm:   \".*\"/  sha256 arm:   \"${ARM_SHA}\"/" \
+            -e "s/^         intel: \".*\"/         intel: \"${INTEL_SHA}\"/" \
+            -e 's|/pacto_#{version}_#{arch}\.dmg|/Pacto_#{version}_#{arch}.dmg|' \
+            "$CASK"
+          cat "$CASK"
+
+      - name: Open PR against homebrew-pacto
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-pacto
+          commit-message: "chore: bump cask to ${{ github.ref_name }}"
+          title: "chore: bump cask to ${{ github.ref_name }}"
+          body: |
+            Automated from covenant-gov/pacto-app's `${{ github.ref_name }}` release publish.
+          branch: "chore/bump-${{ github.ref_name }}"
+          base: main
+          delete-branch: true

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ARG="${1:-}"
+NO_COMMIT="${2:-}"
 
 if [[ -z "$ARG" ]]; then
   echo "Usage: $0 <version|patch|minor|major>"
@@ -133,13 +134,18 @@ if [[ -f "src-tauri/Cargo.lock" ]]; then
   FILES_TO_STAGE+=(src-tauri/Cargo.lock)
 fi
 
-git add "${FILES_TO_STAGE[@]}"
+if [[ "$NO_COMMIT" == "--no-commit" ]]; then
+  git add "${FILES_TO_STAGE[@]}"
+  echo ""
+  echo "Version $VERSION staged (not committed)."
+else
+  git add "${FILES_TO_STAGE[@]}"
+  git commit -m "chore(release): bump version to $VERSION"
+  git tag -a "$TAG" -m "Release $TAG"
 
-git commit -m "chore(release): bump version to $VERSION"
-git tag -a "$TAG" -m "Release $TAG"
-
-echo ""
-echo "Version $VERSION is ready. Tag $TAG created."
-echo "Next steps:"
-echo "  git push origin $(git branch --show-current)"
-echo "  git push origin $TAG"
+  echo ""
+  echo "Version $VERSION is ready. Tag $TAG created."
+  echo "Next steps:"
+  echo "  git push origin $(git branch --show-current)"
+  echo "  git push origin $TAG"
+fi


### PR DESCRIPTION
## Summary

Two release-process improvements, both raised while prepping 0.5.0:

1. **Version bump is now a button, not a terminal session.** `prepare-release.yaml` adds a `workflow_dispatch` trigger (Actions tab -> "Prepare Release" -> Run workflow -> pick patch/minor/major) that bumps `package.json` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.toml`, regenerates `CHANGELOG.md`, runs `pnpm check`, `pnpm test`, `cargo check`, `cargo test`, and opens a PR — all in CI, no local pnpm/Rust toolchain required. `bump-version.sh` gets a `--no-commit` flag so it can be reused for this without committing/tagging locally (local usage is unchanged).
2. **The homebrew tap no longer needs a manual bump.** `release.yaml` gets a new `update-homebrew-tap` job that runs after a successful publish: downloads the two macOS DMGs from the release, computes sha256, and opens a PR against `covenant-gov/homebrew-pacto` with the version/checksums. This also fixes a real bug: the tap's DMG filename casing (`pacto_...` vs the actual `Pacto_...` release assets) went stale when the product name was capitalized after v0.3.0 — `brew install --cask pacto` has been silently broken for v0.4.0.

Tagging (`v0.5.0`, etc.) is still a separate, deliberate step — done via `git push origin vX.Y.Z` or GitHub's Releases -> "Draft a new release" UI — neither workflow creates a tag.

## Changes

- `.github/workflows/prepare-release.yaml` (new): manual version-bump-PR workflow.
- `scripts/bump-version.sh`: `--no-commit` flag for CI reuse.
- `.github/workflows/release.yaml`: `update-homebrew-tap` job.

## Setup required before first use

`update-homebrew-tap` needs a **`HOMEBREW_TAP_TOKEN`** repo secret on `pacto-app` — a PAT or fine-grained token with `contents: write` (and PR creation) on `covenant-gov/homebrew-pacto`. It does not exist yet; add it under Settings -> Secrets and variables -> Actions before the next tagged release, or the new job will fail (the rest of the release is unaffected — it's an independent job).

## Test plan

- Both workflow YAML files parsed with `yamllint`.
- The `sed` transform in `update-homebrew-tap` was simulated against the real current `Casks/pacto.rb` content to confirm it updates exactly `version`/`sha256 arm`/`sha256 intel`/the DMG filename casing and nothing else (no live run possible without the token + a real tag push).
- `bash -n scripts/bump-version.sh` for shell syntax.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)