### PR TITLE
Update signing public key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDJGMDhCRkUyNUZDM0Q1NEIKUldSTDFjTmY0cjhJTHgxZVlNbE5JbC9QZHhwdTRITDFGK3c3Y2VMN0llQlF3ZmgrN2JnRE9CWmMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEEwNjYyNEVCQ0FEQkQyQUMKUldTczB0dks2eVJtb0c5YmdDWGRvdEVjdEswWVBWanJZaC9TRGc1d1hRUHhuMHEvZTU0TURFTHgK",
       "endpoints": [
         "https://github.com/covenant-gov/pacto-app/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
Updates the signing public key in tauri key.  This was previously set to the wrong key so in app updates were failing.  This replaces the public key to use the new key pair that was generated last month.