### PR TITLE
fix: landing OpenGraph metadata and workflow permissions

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -60,7 +60,7 @@ jobs:
         id: bumped
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(release): bump version to ${{ steps.bumped.outputs.version }}"
           title: "chore(release): bump version to ${{ steps.bumped.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release-notes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,7 +239,7 @@ jobs:
           cat "$CASK"
 
       - name: Open PR against homebrew-pacto
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-pacto

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -12,15 +12,20 @@ const base = import.meta.env.BASE_URL;
     <meta property="og:title" content="Pacto" />
     <meta property="og:description" content="Pacto is a free and open-source private messenger app that allows users full end-to-end encryption and transfers encrypted data via a secure, global, decentralized relay network." />
     <meta property="og:url" content="https://covenant-gov.github.io/pacto-app/" />
+    <link rel="canonical" href="https://covenant-gov.github.io/pacto-app/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Pacto" />
     <meta property="og:image" content={`https://covenant-gov.github.io${base}/assets/og-image.jpg`} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Pacto logo on a dark purple gradient with the tagline Private. Encrypted. Yours." />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@pacto_app" />
+    <meta name="twitter:creator" content="@pacto_app" />
     <meta name="twitter:title" content="Pacto" />
     <meta name="twitter:description" content="Pacto is a free and open-source private messenger app that allows users full end-to-end encryption and transfers encrypted data via a secure, global, decentralized relay network." />
     <meta name="twitter:image" content={`https://covenant-gov.github.io${base}/assets/og-image.jpg`} />
+    <meta name="twitter:image:alt" content="Pacto logo on a dark purple gradient with the tagline Private. Encrypted. Yours." />
     <meta name="theme-color" content="#7c4cff" />
     <title>Pacto</title>
     <link rel="apple-touch-icon" sizes="180x180" href={`${base}/assets/favicon/apple-icon-180x180.png`} />


### PR DESCRIPTION
- Adds canonical URL, og:image:alt, twitter:site/creator/image:alt to landing page.
- Upgrades peter-evans/create-pull-request to v8 in prepare-release and release workflows.
- Grants explicit contents:write permission to release workflow.

Note: The previous prepare-release run still needs the repo setting "Allow GitHub Actions to create and approve pull requests" enabled in GitHub UI.