### PR TITLE
chore: auto-tag releases after prepare-release PR merges

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -3,9 +3,8 @@ name: Prepare Release
 # Manual trigger only (Actions tab -> Prepare Release -> Run workflow). Bumps
 # package.json / src-tauri/tauri.conf.json / src-tauri/Cargo.toml, regenerates
 # CHANGELOG.md, runs the same checks scripts/bump-version.sh runs locally, and
-# opens a PR with the result. Does not create or push a git tag -- tagging
-# v<version> happens manually (or via GitHub's "Draft a new release" UI) after
-# the PR merges to main, which is what actually triggers release.yaml.
+# opens a PR with the result. Merging that PR to main pushes v<version>
+# automatically (see tag-release.yaml), which triggers release.yaml.
 
 on:
   workflow_dispatch:
@@ -72,7 +71,7 @@ jobs:
             - `CHANGELOG.md`: regenerated via `git-cliff`.
             - `pnpm check`, `pnpm test`, `cargo check`, `cargo test` all passed in this run.
 
-            No tag is created by this PR. After merging to `main`, cut the release by pushing tag `v${{ steps.bumped.outputs.version }}` (or via GitHub's Releases -> Draft a new release UI), which triggers `release.yaml`.
+            No tag is created by this PR. Merging to `main` triggers `tag-release.yaml`, which pushes tag `v${{ steps.bumped.outputs.version }}` and kicks off `release.yaml`.
           branch: "chore/release-${{ steps.bumped.outputs.version }}"
           base: main
           delete-branch: true

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,49 @@
+name: Tag Release
+
+# Auto-tags after a "Prepare Release" PR merges to main. Reads the bumped
+# version out of package.json, cross-checks it against Cargo.toml /
+# tauri.conf.json, and pushes v<version> if that tag doesn't exist yet.
+# Pushing the tag is what triggers release.yaml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: "startsWith(github.event.head_commit.message, 'chore(release): bump version to ')"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: read version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: verify version files are in sync
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CARGO_VERSION="$(sed -n '/^\[package\]$/,/^\[/p' src-tauri/Cargo.toml | sed -n 's/^version = "\([^"]*\)"/\1/p')"
+          TAURI_VERSION="$(node -p "JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json')).version")"
+          if [[ "$CARGO_VERSION" != "$VERSION" || "$TAURI_VERSION" != "$VERSION" ]]; then
+            echo "Error: version mismatch (package.json=$VERSION, Cargo.toml=$CARGO_VERSION, tauri.conf.json=$TAURI_VERSION)"
+            exit 1
+          fi
+
+      - name: create and push tag
+        env:
+          TAG: v${{ steps.version.outputs.version }}
+        run: |
+          if git ls-remote --tags origin "$TAG" | grep -q "refs/tags/$TAG\$"; then
+            echo "Tag $TAG already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## What
Removes the manual "push the tag yourself" step from the release flow.

- New `tag-release.yaml`: triggers on push to `main` that touches `package.json` from a `chore(release): bump version to ...` commit (the merge of a Prepare Release PR). Verifies `package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` versions are in sync, then tags and pushes `v<version>` — which is what actually kicks off `release.yaml`.
- Updates `prepare-release.yaml` comments and PR body copy to reflect that merging the release PR now tags automatically instead of requiring a manual tag push or "Draft a new release" click.

## Why
Cuts a manual, easy-to-forget step out of the release process — merging the version-bump PR is now sufficient to ship a release.

## Verification
Workflow YAML reviewed for correctness; no runtime test harness for GitHub Actions in this repo. Next real release will exercise the new tag-release job end to end.