### PR TITLE
fix: enable additional TypeScript strictness checks and fix findings

### DIFF
--- a/src/components/dm/Message.svelte
+++ b/src/components/dm/Message.svelte
@@ -75,7 +75,6 @@
   let menuOpen = false;
   let menuX = 0;
   let menuY = 0;
-  let menuAnchorEl: HTMLElement | undefined;
   let popoverEl: HTMLElement | undefined;
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -314,7 +313,6 @@
   class:compact
   class:mentioned={isMentioned}
   id={id ? `msg-${id}` : undefined}
-  bind:this={menuAnchorEl}
   use:observeLinkPreview={linkPreviewParams}
   on:contextmenu={handleContextMenu}
   on:pointerdown={handlePointerDown}

--- a/src/lib/utils/message-formatting.ts
+++ b/src/lib/utils/message-formatting.ts
@@ -111,6 +111,7 @@ const spoilerExtension = {
         text: match[1],
       };
     }
+    return undefined;
   },
   renderer(token: SpoilerToken): string {
     return `<span class="spoiler" role="button" tabindex="0">${escapeHtml(token.text ?? '')}</span>`;

--- a/src/lib/wallet/rpc-prefs.ts
+++ b/src/lib/wallet/rpc-prefs.ts
@@ -181,7 +181,6 @@ export function formatRpcDisplay(url: string): string {
 }
 
 function isAllowedDefaultRpc(
-  chainId: SupportedChainId,
   url: string,
   personal: string[],
   curated: string[],
@@ -245,7 +244,7 @@ export function saveDefaultRpc(
 
   const personal = prefs.personal[chainId] ?? [];
   const curated = getCuratedRpcUrlsForChain(chainId);
-  if (!isAllowedDefaultRpc(chainId, url, personal, curated)) return;
+  if (!isAllowedDefaultRpc(url, personal, curated)) return;
 
   prefs.defaultRpc[chainId] = url;
   saveRpcPrefs(accountNpub, prefs);
@@ -266,7 +265,7 @@ export function resolveUserRpcUrls(
 
   if (
     defaultUrl &&
-    isAllowedDefaultRpc(chainId, defaultUrl, personal, curated)
+    isAllowedDefaultRpc(defaultUrl, personal, curated)
   ) {
     const rest = dedupeUrls([...curated, ...personal].filter((u) => u !== defaultUrl));
     return dedupeUrls([defaultUrl, ...rest]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,13 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
   }
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
   // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files


### PR DESCRIPTION
`tsconfig.json` only had `strict: true`; TypeScript ships several strictness flags beyond that. Tested each remaining TS 5.6 flag empirically against `svelte-check` to find which ones are actually worth turning on here, rather than guessing.

- **Enabled (zero false positives, zero ongoing noise):** `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `noUncheckedSideEffectImports`. Together they surfaced exactly 3 real issues, now fixed:
  - `Message.svelte`: a `bind:this` DOM ref (`menuAnchorEl`) that was written but never read — dead.
  - `rpc-prefs.ts`: `isAllowedDefaultRpc`'s `chainId` param was redundant — both call sites already pass chain-scoped `personal`/`curated` lists.
  - `message-formatting.ts`: a marked.js tokenizer extension relied on an implicit fallthrough `undefined` return; made it explicit (same runtime behavior).
- **Tested, not enabled:** `noUncheckedIndexedAccess` (143 errors / 50 files), `exactOptionalPropertyTypes` (89 errors / 50 files), `noPropertyAccessFromIndexSignature` (303 errors / 28 files). All three are real signal, not noise — worth a dedicated follow-up PR each — but too large a mechanical lift to blanket-fix as a rider here.

**Validation:** `pnpm check` → 0 errors (72 pre-existing svelte-check warnings remain on `main`, unrelated to this change — tracked separately in #195). `pnpm lint` → clean.
