### PR TITLE
fix: update gate freeze race

### DIFF
--- a/src/lib/updater/update-gate.test.ts
+++ b/src/lib/updater/update-gate.test.ts
@@ -261,6 +261,31 @@ describe('awaitGateBeforeAuth', () => {
       vi.useRealTimers();
     }
   });
+
+  it('freezes on clear so a late remote cannot flip to blocked mid-auth', async () => {
+    vi.useFakeTimers();
+    try {
+      const { promise: remotePromise, resolve: releaseRemote } =
+        Promise.withResolvers<FakeUpdate | null>();
+      mockedGetMemoizedUpdateCheck.mockReturnValue(remotePromise as never);
+
+      await resolveGateAtLaunch();
+      expect(currentState()).toEqual({ status: 'clear' });
+
+      const resultPromise = awaitGateBeforeAuth(20);
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(resultPromise).resolves.toBe('clear');
+
+      releaseRemote(
+        fakeUpdate({ version: '0.4.0', rawJson: { minimum_compatible_version: '0.4.0' } }),
+      );
+      await flushMicrotasks();
+
+      expect(currentState()).toEqual({ status: 'clear' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('freezeGate', () => {

--- a/src/lib/updater/update-gate.ts
+++ b/src/lib/updater/update-gate.ts
@@ -172,7 +172,8 @@ export async function resolveGateAtLaunch(): Promise<void> {
  * Awaited as the first statement inside every authentication path's try
  * block, ahead of any backend call. Resolves immediately once the remote
  * verdict has settled; otherwise waits under a bounded timeout and treats
- * expiry as fail-open, matching R4.
+ * expiry as fail-open, matching R4. Freezes the gate before returning so a
+ * late remote verdict cannot flip mid-auth (R9).
  */
 export async function awaitGateBeforeAuth(timeoutMs = AUTH_AWAIT_TIMEOUT_MS): Promise<'clear' | 'blocked'> {
   if (!remoteSettled) {
@@ -181,14 +182,17 @@ export async function awaitGateBeforeAuth(timeoutMs = AUTH_AWAIT_TIMEOUT_MS): Pr
       setTimeout(resolve, timeoutMs);
     });
   }
-  return gate.current.status === 'blocked' ? 'blocked' : 'clear';
+  const verdict = gate.current.status === 'blocked' ? 'blocked' : 'clear';
+  // Commit before returning so a late remote cannot flip mid-auth (R9).
+  gate.freeze();
+  return verdict;
 }
 
 /**
- * Marks the gate verdict final. Called on every authentication success
- * path. A remote verdict arriving after this point is recorded by
- * `resolveRemoteVerdict` but never applied - the store's own setter drops
- * it - so it can only take effect at the next launch (R9).
+ * Marks the gate verdict final. Idempotent with the freeze inside
+ * `awaitGateBeforeAuth`; still called on auth success so the success path
+ * documents R9 even when the await already committed. A remote verdict
+ * arriving after freeze is never applied.
  */
 export function freezeGate(): void {
   gate.freeze();

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -229,8 +229,8 @@ export async function createAccount(pin: string): Promise<void> {
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
 
     dmLog('createAccount: done');
     authLoading.set(false);
@@ -285,8 +285,8 @@ export async function importAccount(recoveryPhrase: string, pin: string): Promis
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
     await markBackupVerified(true);
     authLoading.set(false);
     runPostLoginNetworkSync(npub);
@@ -325,8 +325,8 @@ export async function unlockWithPin(pin: string): Promise<void> {
       npub: npub,
       pubkey: keys.public
     });
-    await maybeApplyLocalDevDefaults(npub);
     freezeGate();
+    await maybeApplyLocalDevDefaults(npub);
 
     dmLog('unlockWithPin: done');
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Closes a race in the mandatory update gate where a late remote `minimum_compatible_version` verdict could flip the app to the non-dismissible block screen after auth had already been allowed to proceed — leaving an authenticated session stuck behind the gate until relaunch.

**Before:** `awaitGateBeforeAuth` could return `clear` (including on the fail-open timeout) while the remote check was still pending. Until `freezeGate()` ran after unlock/create/import completed, a late remote block could still apply mid-auth and then freeze as blocked over an authenticated session.

**After:** The gate commits (freezes) at the `awaitGateBeforeAuth` boundary before returning clear or blocked, so a late remote verdict cannot interrupt mid-auth. Success-path `freezeGate()` stays as an idempotent belt-and-suspenders call, moved to immediately after auth flags are set with no intervening awaits.

## Changes

- Freeze inside `awaitGateBeforeAuth` before returning, so R9 holds for the whole auth attempt (not only after success).
- Reorder `freezeGate()` in create/import/unlock to run right after `isAuthenticated` / `currentUser`, before any post-auth await.
- Add a regression test: timeout clear + late blocking remote leaves the gate clear.

## Test plan

- [x] `pnpm exec vitest run src/lib/updater/update-gate.test.ts src/stores/auth.test.ts` (61/61)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)