### PR TITLE
fix(ci): deploy the download page from the release run

### DIFF
--- a/.github/workflows/deploy-landing.yaml
+++ b/.github/workflows/deploy-landing.yaml
@@ -1,20 +1,46 @@
 name: Deploy landing site
 
+# Publishes the public download page (https://covenant-gov.github.io/pacto-app).
+#
+# There is deliberately no `release: published` trigger. Releases are created by
+# tauri-action using GITHUB_TOKEN, and workflow runs authenticated with
+# GITHUB_TOKEN do not fire other workflows' `release` listeners. Relying on that
+# event is what left the download page serving v0.5.1 while v0.5.4 shipped
+# (covenant-gov/pacto-app#213). `release.yaml` now calls this workflow directly
+# after the full installer matrix finishes; `workflow_dispatch` remains for
+# emergency republishes.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish. Blank resolves to the latest release.'
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish. Blank resolves to the latest release.'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
 
+# GitHub Pages accepts one deployment at a time. Queue instead of cancelling so
+# an emergency dispatch cannot drop a release-triggered deploy mid-flight.
+concurrency:
+  group: deploy-landing
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      manifest_tag: ${{ steps.manifest.outputs.tag }}
     permissions:
       contents: read
-      pages: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,10 +64,14 @@ jobs:
         run: pnpm svelte-kit sync
 
       - name: Generate release manifest
+        id: manifest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: node scripts/generate-release-manifest.mjs
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          node scripts/generate-release-manifest.mjs
+          tag="$(jq -er '.tag' landing/public/pacto-release.json)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Build Astro landing site
         run: pnpm --filter pacto-landing build
@@ -60,7 +90,37 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  verify:
+    # Post-deploy assertion: the live manifest must serve the tag we just built.
+    # Catches a silently stale Pages cache or a deploy that landed on the wrong
+    # artifact, instead of discovering it weeks later from a user report.
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert published manifest matches the built tag
+        env:
+          EXPECTED_TAG: ${{ needs.build.outputs.manifest_tag }}
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+        run: |
+          set -uo pipefail
+          url="${PAGE_URL%/}/pacto-release.json"
+          served=''
+          for attempt in $(seq 1 10); do
+            served="$(curl -fsSL -H 'Cache-Control: no-cache' \
+              "${url}?cachebust=${GITHUB_RUN_ID}-${attempt}" | jq -r '.tag' || true)"
+            if [ "$served" = "$EXPECTED_TAG" ]; then
+              echo "Download page serves ${served}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: expected ${EXPECTED_TAG}, got ${served:-<unavailable>}; retrying in 15s."
+            sleep 15
+          done
+          echo "::error::${url} serves ${served:-<unavailable>}, expected ${EXPECTED_TAG}"
+          exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,3 +274,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: node scripts/stamp-updater-compatibility.mjs
+
+  deploy-landing:
+    # Refreshes the public download page for the tag just published.
+    #
+    # Chained here rather than left to deploy-landing.yaml's own
+    # `release: published` listener: tauri-action publishes the release with
+    # GITHUB_TOKEN, and GITHUB_TOKEN-authenticated runs do not reliably trigger
+    # other workflows' release events. That gap left the site on v0.5.1 through
+    # two releases (#213). `needs: publish-tauri` also guarantees every platform
+    # in the matrix has uploaded its installers before the manifest is
+    # generated, so the download page never lists a partial asset set.
+    needs: publish-tauri
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-landing.yaml
+    with:
+      release_tag: ${{ github.ref_name }}

--- a/docs/build/OPERATOR_UPDATES.md
+++ b/docs/build/OPERATOR_UPDATES.md
@@ -22,6 +22,49 @@ That URL is configured in `src-tauri/tauri.conf.json` under `plugins.updater.end
    - Windows (`x86_64-pc-windows-msvc`)
 4. The workflow uploads installers and `latest.json` to the GitHub release.
    - `uploadUpdaterJson: true` tells the Tauri action to generate and attach `latest.json`.
+5. Once the **entire** platform matrix finishes, `release.yaml` fans out three
+   follow-up jobs, all gated on `needs: publish-tauri`:
+   - `update-homebrew-tap` — opens a Cask bump PR against `covenant-gov/homebrew-pacto`.
+   - `stamp-updater-compatibility` — stamps `minimum_compatible_version` onto `latest.json`.
+   - `deploy-landing` — refreshes the public download page (see below).
+
+## Download page (release → landing deploy)
+
+The public download page at <https://covenant-gov.github.io/pacto-app/> is a
+static Astro site in `landing/`. It renders `pacto-release.json`, which
+`scripts/generate-release-manifest.mjs` builds from the GitHub release's actual
+assets.
+
+`release.yaml`'s `deploy-landing` job calls `.github/workflows/deploy-landing.yaml`
+as a reusable workflow with `release_tag: ${{ github.ref_name }}`, so a tagged
+release refreshes the download page with **no manual step**. Because the job
+needs `publish-tauri`, the manifest is only generated after every platform has
+uploaded its installers — the page never advertises a partial asset set. After
+deploying, a `verify` job polls the live `pacto-release.json` and fails the run
+if the served `tag` does not match the tag that was built.
+
+`deploy-landing.yaml` intentionally has **no** `release: published` trigger.
+tauri-action publishes the release using `GITHUB_TOKEN`, and runs authenticated
+with `GITHUB_TOKEN` do not reliably fire other workflows' `release` listeners.
+Depending on that event is what left the site serving v0.5.1 across the v0.5.2
+and v0.5.4 releases (#213).
+
+### Emergency republish
+
+To rebuild the page outside a release — a Pages outage, a landing-site fix on
+`main`, or a manifest that needs regenerating:
+
+```bash
+# Publish whatever release is currently `latest`:
+gh workflow run deploy-landing.yaml
+
+# Or pin a specific tag:
+gh workflow run deploy-landing.yaml -f release_tag=v0.5.4
+```
+
+Leaving `release_tag` blank resolves to `releases/latest`. Deploys are
+serialized by the `deploy-landing` concurrency group, so a dispatch issued
+during a release deploy queues behind it rather than cancelling it.
 
 ## Signing key
 
@@ -67,6 +110,7 @@ Repeat on at least one additional desktop platform before promoting a release br
 - **No update found when one exists:** verify the tag, the release workflow completion, and that `latest.json` is attached to the release.
 - **Signature mismatch:** confirm the public key in `src-tauri/tauri.conf.json` matches the private key used to sign the release.
 - **Missing platform asset:** the workflow must produce an installer for the running platform. Check the release assets and platform matrix in `.github/workflows/release.yaml`.
+- **Download page shows an older version than the latest release:** check the `deploy-landing` job on the tag's `publish` run. If it never ran, the release predates the chained job; republish with `gh workflow run deploy-landing.yaml`. If it ran but the `verify` job failed, the Pages deployment did not serve the new manifest — re-run the workflow and confirm `curl -s https://covenant-gov.github.io/pacto-app/pacto-release.json | jq -r .tag`.
 - **macOS: app closes but does not relaunch after updating:** this can happen when the process exits before the updater's spawned replacement is fully launched (tauri-apps/tauri#11392). The in-app relaunch now routes through a backend command that runs `cleanup_before_exit()` followed by `tauri::process::restart()` directly, which avoids the race.
 - **macOS: update downloads but fails to install with "Failed to move the new app into place":** the app is likely sandboxed or installed with permissions that prevent replacing `/Applications/pacto.app`. Ensure the app is installed by dragging to `/Applications`, run `xattr -r -d com.apple.quarantine /Applications/pacto.app`, and approve any system prompt for administrator privileges.
 - **Unsigned builds and Gatekeeper:** Pacto is currently unsigned. On macOS, removing the quarantine attribute before first launch is required; otherwise Gatekeeper translocation can cause the updater to modify a temporary copy instead of the app in `/Applications`. On Windows, unsigned installers may trigger SmartScreen; users should choose "More info" → "Run anyway".


### PR DESCRIPTION
Closes #213

## Problem

`covenant-gov.github.io/pacto-app` served **v0.5.1** while **v0.5.4** was the latest release.

`deploy-landing.yaml` only listened for `release: published`. `release.yaml` publishes via `tauri-action` with `GITHUB_TOKEN`, and runs authenticated with `GITHUB_TOKEN` do not reliably fire other workflows' `release` listeners — so no deploy ran for v0.5.2 or v0.5.4. The last successful deploy was a manual `workflow_dispatch` on 2026-07-30.

## Immediate fix (already applied, no code required)

Dispatched `deploy-landing.yaml` against `main` ([run 31271441816](https://github.com/covenant-gov/pacto-app/actions/runs/31271441816), green). Live manifest now:

```json
{ "tag": "v0.5.4", "publishedAt": "2026-08-07T04:33:10Z", "assets": 8 }
```

## Automation (option C from the issue)

**`release.yaml`** gains a `deploy-landing` job that calls `deploy-landing.yaml` as a reusable workflow:

```yaml
  deploy-landing:
    needs: publish-tauri
    permissions: { contents: read, pages: write, id-token: write }
    uses: ./.github/workflows/deploy-landing.yaml
    with:
      release_tag: ${{ github.ref_name }}
```

`needs: publish-tauri` mirrors `stamp-updater-compatibility`, so the manifest is generated only after the **entire** platform matrix has uploaded its installers — no race that publishes a partial asset set.

**`deploy-landing.yaml`**:

- `workflow_call` + `workflow_dispatch`, both taking an optional `release_tag` (blank resolves to `releases/latest`, matching the existing `getReleaseTag()` fallback).
- The dead `release: published` trigger is **removed** rather than kept alongside the call. One automatic path, no double-deploy if the event ever does fire (it did for the v0.3.x tags).
- `concurrency: { group: deploy-landing, cancel-in-progress: false }` — Pages takes one deployment at a time; an emergency dispatch queues behind a release deploy instead of cancelling it.
- New `verify` job: polls the live `pacto-release.json` after deploy and fails the run if the served `tag` is not the tag that was built. A stale Pages deploy now surfaces in CI, not in a user report.

**`docs/build/OPERATOR_UPDATES.md`**: new *Download page (release → landing deploy)* section covering the chain, why the `release` event is not used, and the emergency republish commands; plus a troubleshooting entry for a stale download page.

## Verification

- `actionlint` on both workflows: 16 findings, byte-identical to the `main` baseline (all pre-existing shellcheck noise in `release.yaml`'s pre-existing steps). Zero findings in `deploy-landing.yaml`.
- `RELEASE_TAG=v0.5.4 node scripts/generate-release-manifest.mjs` → `v0.5.4`, 8 installers; `jq -er '.tag'` (used for the new job output) resolves correctly.
- `verify` job script exercised locally against the live URL on all three paths: tag match → exit 0; tag mismatch → retries then `::error::` + exit 1; 404 → `<unavailable>` + exit 1.
- Live site confirmed at `v0.5.4` post-dispatch.

## Acceptance criteria

- [x] Live download site / `pacto-release.json` shows current latest (v0.5.4)
- [x] Next tagged release updates the download page without manual `workflow_dispatch`
- [x] Manifest generation waits until release assets for that tag are complete (`needs: publish-tauri`)
- [x] Documented in `docs/build/OPERATOR_UPDATES.md`
- [x] Post-deploy assertion that fails if the Pages manifest tag ≠ built tag

## Residual risk

The chained job cannot be exercised end-to-end until the next tag push. The two mechanics that only run there are the reusable-workflow call (validated by `actionlint`, which resolves local `uses:` inputs) and the `github-pages` environment accepting a deploy from a tag ref — which it already did for the v0.3.x `release`-event deploys.
