### PR TITLE
refactor: rename app database from vector.db to pacto.db

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ cd src-tauri && cargo test
 ### Backend
 - **Commands:** Expose functions to the frontend with `#[tauri::command]` and add them to the `generate_handler!` list in `src-tauri/src/lib.rs`. Most return `Result<T, String>`.
 - **State:** Access globals via `crate::STATE`, `crate::TAURI_APP`, `crate::get_nostr_client()`. Avoid holding synchronous locks across await points.
-- **Database:** One SQLite database per account at `<app_data_dir>/<npub>/vector.db`. `src-tauri/src/migrations/` is the source of truth for the schema and migration history; `src-tauri/src/db.rs` contains most query logic. `account_manager` provides a pooled connection that must be returned with `return_db_connection`.
+- **Database:** One SQLite database per account at `<app_data_dir>/<npub>/pacto.db`. `src-tauri/src/migrations/` is the source of truth for the schema and migration history; `src-tauri/src/db.rs` contains most query logic. `account_manager` provides a pooled connection that must be returned with `return_db_connection`.
 - **Error handling:** String errors for most commands. EVM wallet code uses `wallet_err_json` / `wallet_err_json_with_tx_hash` to return structured `{ code, message, txHash? }`. Always call `wallet_security::redact_urls_in_text` before surfacing RPC errors/logs.
 - **Crypto:** `crypto::internal_encrypt`/`internal_decrypt` use ChaCha20-Poly1305 with an Argon2id-derived key cached in `ENCRYPTION_KEY`. Attachments use AES-256-GCM.
 - **EVM:** Respect signer purpose (`squad` vs `advanced`). Treasury/deploy paths require phrase-derived `bip44_v1` signers, not imported keys. Contract addresses belong in `src/lib/evm/pacto-protocol-addresses.json`, not `.env` or comments.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -65,7 +65,7 @@ A shared vocabulary for humans and coding agents working on Pacto. Terms are ord
 | **Tauri v2** | Desktop app framework: Svelte frontend in a webview, Rust backend. |
 | **invoke** | Frontend -> backend typed RPC via `tauri-apps/api/core`. |
 | **emit** | Backend -> frontend event pushed through `AppHandle::emit`. |
-| **per-account SQLite** | Two databases per npub: `vector.db` (messages, chats, squad metadata) and `vector-mls.db` (MLS crypto state only). Resetting the latter costs group access, not history. |
+| **per-account SQLite** | Two databases per npub: `pacto.db` (messages, chats, squad metadata) and `vector-mls.db` (MLS crypto state only). Resetting the latter costs group access, not history. |
 | **read-plane** | Frontend viem read-only chain access: balances, contract observation, receipt polling. |
 | **Rust send** | WalletBar and governance writes are signed and broadcast from the Rust backend using Alloy. |
 | **require_capability** | Rust ACL gate on squad-scoped writes; denies unbound roster or missing hat/role before broadcast. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Each account is isolated under its npub.
 ```mermaid
 flowchart TB
     subgraph Account["Tauri app_data_dir/<npub>/"]
-        A[vector.db]
+        A[pacto.db]
         B[mls/vector-mls.db]
         C[attachments / media]
     end
@@ -122,7 +122,7 @@ flowchart TB
 ```
 
 - `vector-mls.db` is owned by the MDK engine; do not edit it by hand.
-- `vector.db` holds chat metadata, Nostr-shaped events, profiles, and squad infrastructure pointers.
+- `pacto.db` holds chat metadata, Nostr-shaped events, profiles, and squad infrastructure pointers.
 - Frontend state is npub-scoped via `localStorage` keys built with `persistenceKey(prefix)`.
 
 ## Key directories

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,7 +72,7 @@ flowchart LR
 
 - **DMs** use NIP-17 private DMs (gift wraps per NIP-59, kind 1059). The inner rumor uses kinds 14 (text), 15 (file), 7 (reaction), 30078 (typing), etc.
 - **MLS groups** use kind 444 on the wire; kind 443 welcomes arrive inside a Gift Wrap.
-- Both DM and MLS decrypted messages are materialized into the same in-memory `Chat` / `Message` model. The persisted storage is more layered: raw Nostr-shaped events live in the `events` table, chat metadata in `chats`, and MDK engine state in `vector-mls.db`. A legacy `messages` table is still present but no longer the primary store.
+- Both DM and MLS decrypted messages are materialized into the same in-memory `Chat` / `Message` model. The persisted storage is more layered: raw Nostr-shaped events live in the `events` table, chat metadata in `chats`, and MDK engine state in `pacto-mls.db`. A legacy `messages` table is still present but no longer the primary store.
 
 ### 2. EVM wallet
 
@@ -108,7 +108,7 @@ Each account is isolated under its npub.
 flowchart TB
     subgraph Account["Tauri app_data_dir/<npub>/"]
         A[pacto.db]
-        B[mls/vector-mls.db]
+        B[mls/pacto-mls.db]
         C[attachments / media]
     end
     subgraph Engine["MDK engine"]
@@ -121,7 +121,7 @@ flowchart TB
     A --> E
 ```
 
-- `vector-mls.db` is owned by the MDK engine; do not edit it by hand.
+- `pacto-mls.db` is owned by the MDK engine; do not edit it by hand.
 - `pacto.db` holds chat metadata, Nostr-shaped events, profiles, and squad infrastructure pointers.
 - Frontend state is npub-scoped via `localStorage` keys built with `persistenceKey(prefix)`.
 

--- a/docs/build/OPERATOR_UPDATES.md
+++ b/docs/build/OPERATOR_UPDATES.md
@@ -153,18 +153,18 @@ Use these in priority order.
 
 ## Recovering a machine the local storage-format check blocked
 
-This is a **different** trigger from the minimum-version check above: it never touches the network. It fires when the app opens a profile's `vector.db` on launch and finds a migration history that this build doesn't recognize — for example, a profile last opened by a newer or divergent build. Because the check runs before account selection, one bad profile blocks **every** account on that machine, not just the one it belongs to.
+This is a **different** trigger from the minimum-version check above: it never touches the network. It fires when the app opens a profile's `pacto.db` on launch and finds a migration history that this build doesn't recognize — for example, a profile last opened by a newer or divergent build. Because the check runs before account selection, one bad profile blocks **every** account on that machine, not just the one it belongs to.
 
 The block screen deliberately does not show which npub or file path is at fault, so recovery is manual:
 
 1. Note the schema version number the block screen reports.
-2. Profile directories live under `<app_data_dir>/npub1…/vector.db` — see [`../storage-layout/SQLITE_AND_FILES.md`](../storage-layout/SQLITE_AND_FILES.md) for the full on-disk layout. `<app_data_dir>` here is Tauri's per-OS app data directory *including* this app's identifier (`io.pacto`, from `src-tauri/tauri.conf.json`):
+2. Profile directories live under `<app_data_dir>/npub1…/pacto.db` — see [`../storage-layout/SQLITE_AND_FILES.md`](../storage-layout/SQLITE_AND_FILES.md) for the full on-disk layout. `<app_data_dir>` here is Tauri's per-OS app data directory *including* this app's identifier (`io.pacto`, from `src-tauri/tauri.conf.json`):
    - macOS: `~/Library/Application Support/io.pacto/`
    - Windows: `%APPDATA%\io.pacto\`
    - Linux: `$XDG_DATA_HOME/io.pacto/` (usually `~/.local/share/io.pacto/`)
-3. For each `npub1…` subdirectory, open its `vector.db` with a `sqlite3` client and check the highest applied version:
+3. For each `npub1…` subdirectory, open its `pacto.db` with a `sqlite3` client and check the highest applied version:
    ```bash
-   sqlite3 "<app_data_dir>/npub1exampleaddress/vector.db" \
+   sqlite3 "<app_data_dir>/npub1exampleaddress/pacto.db" \
      "SELECT version, name, applied_on FROM refinery_schema_history ORDER BY version DESC LIMIT 1;"
    ```
 4. The one profile whose `version` matches the number from the block screen is the offender. Move that single directory aside (e.g. rename `npub1…` to `npub1…-quarantined`) — do not delete it.

--- a/docs/communities/SQUAD_CATALOG.md
+++ b/docs/communities/SQUAD_CATALOG.md
@@ -1,6 +1,6 @@
 # Squad catalog (SQLite)
 
-Per-account squad and squad-pair rows live in **`squads`** (`vector.db`), not `localStorage`. Identity rules match [`DESIGN.md`](./DESIGN.md): **`id`** = announcements MLS `groupId`.
+Per-account squad and squad-pair rows live in **`squads`** (`pacto.db`), not `localStorage`. Identity rules match [`DESIGN.md`](./DESIGN.md): **`id`** = announcements MLS `groupId`.
 
 ## Table
 

--- a/docs/mls/ARCHITECTURE.md
+++ b/docs/mls/ARCHITECTURE.md
@@ -5,13 +5,13 @@
 - **Crates:** `mdk-core`, `mdk-sqlite-storage`, and `mdk-storage-traits` **0.8.0** from crates.io, using the `nostr` **0.44.7** line. The old git revision is no longer part of the dependency graph.
 - **Facade:** **`MlsService`** in `src-tauri/src/mls.rs` — creates a persistent engine at:
 
-  `get_mls_directory(...)/vector-mls.db`
+  `get_mls_directory(...)/pacto-mls.db`
 
   (per **npub**, under the app data profile folder — see `account_manager.rs`).
 
 ## Two storage layers
 
-1. **MDK SQLite (`vector-mls.db`)** — cryptographic MLS state (groups, epochs, etc.) managed by the engine. Do not hand-edit.
+1. **MDK SQLite (`pacto-mls.db`)** — cryptographic MLS state (groups, epochs, etc.) managed by the engine. Do not hand-edit.
 2. **App SQLite (`pacto.db`)** — plaintext-ish metadata the UI and sync logic need:
    - **`mls_groups`** — `group_id`, `engine_group_id`, name, eviction flag, timestamps, …
    - **`mls_keypackages`** — cached key packages for members/devices
@@ -21,7 +21,7 @@ Decrypted **application messages** are integrated into the same **chat/message m
 
 ## Store encryption and upgrades
 
-`vector-mls.db` is SQLCipher-encrypted. `MlsService` derives a distinct 32-byte store key from the unlocked account session key with the `pacto/mls-store/v1` domain separator; MDK never receives the app database's plaintext key material.
+`pacto-mls.db` is SQLCipher-encrypted. `MlsService` derives a distinct 32-byte store key from the unlocked account session key with the `pacto/mls-store/v1` domain separator; MDK never receives the app database's plaintext key material.
 
 Before MDK 0.8.0 opens the store, `mls_store_reset.rs` reads the MDK refinery history directly. Stores from the old V100–V104 series are harvested and the entire `<npub>/mls/` directory—database, WAL, and SHM together—is moved to `<npub>/mls.archive.<timestamp>/`. A fresh encrypted store is then created. Archive directories are removed after seven days.
 
@@ -36,7 +36,7 @@ The app keeps message history, chat names, and participant lists in `pacto.db`, 
 CI covers reset with synthetic V100/V104 SQLite fixtures. To exercise a copied pre-upgrade `mls/` directory (including hot WAL):
 
 ```bash
-export MLS_LEGACY_FIXTURE=/path/to/copied/mls   # contains vector-mls.db (+ optional -wal/-shm)
+export MLS_LEGACY_FIXTURE=/path/to/copied/mls   # contains a pre-rename mls store copy named vector-mls.db (+ optional -wal/-shm)
 cd src-tauri && cargo test --lib mls_store_reset::tests::real_legacy_store_copy_archives_with_hot_wal_and_fresh_store_opens -- --ignored --exact
 ```
 

--- a/docs/mls/ARCHITECTURE.md
+++ b/docs/mls/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 ## Two storage layers
 
 1. **MDK SQLite (`vector-mls.db`)** — cryptographic MLS state (groups, epochs, etc.) managed by the engine. Do not hand-edit.
-2. **App SQLite (`vector.db`)** — plaintext-ish metadata the UI and sync logic need:
+2. **App SQLite (`pacto.db`)** — plaintext-ish metadata the UI and sync logic need:
    - **`mls_groups`** — `group_id`, `engine_group_id`, name, eviction flag, timestamps, …
    - **`mls_keypackages`** — cached key packages for members/devices
    - **`mls_event_cursors`** — last seen Nostr event per group for backfill
@@ -29,7 +29,7 @@ Seven-day retention bounds disk exposure; it does **not** revoke credentials. Un
 
 Unknown MDK schema versions outside **1–5** (current) and **≥100** (legacy) fail closed: the app refuses to open or archive the store rather than guessing.
 
-The app keeps message history, chat names, and participant lists in `vector.db`, so those remain visible. Cryptographic group state does not migrate: affected channels show the last admins recorded on the device until a new welcome restores the group. Pending legacy welcomes are re-fetched by exact wrapper event id, and the device publishes a fresh KeyPackage before it can be restored. Multi-admin rollout must leave one admin on the pre-upgrade build until others are restored. Harvest records `mls_store_reset_at` as a KeyPackage creation-time floor when no prior keypackage reference exists for a member.
+The app keeps message history, chat names, and participant lists in `pacto.db`, so those remain visible. Cryptographic group state does not migrate: affected channels show the last admins recorded on the device until a new welcome restores the group. Pending legacy welcomes are re-fetched by exact wrapper event id, and the device publishes a fresh KeyPackage before it can be restored. Multi-admin rollout must leave one admin on the pre-upgrade build until others are restored. Harvest records `mls_store_reset_at` as a KeyPackage creation-time floor when no prior keypackage reference exists for a member.
 
 ### Optional real legacy fixture
 

--- a/docs/mls/README.md
+++ b/docs/mls/README.md
@@ -24,7 +24,7 @@ Group messaging uses **nostr-mls** / **MDK** with **SQLite-backed** engine state
 
 ## On-disk storage
 
-- **Engine state:** `<app_data>/<npub>/mls/vector-mls.db` (see `MlsService::new_persistent` in `mls.rs`).
+- **Engine state:** `<app_data>/<npub>/mls/pacto-mls.db` (see `MlsService::new_persistent` in `mls.rs`).
 - **App metadata / cursors:** tables inside **`pacto.db`** (same directory as profile DB). Details in **`docs/storage-layout/SQLITE_AND_FILES.md`**.
 
 ## Related docs

--- a/docs/mls/README.md
+++ b/docs/mls/README.md
@@ -1,6 +1,6 @@
 # MLS (Message Layer Security) — contributor map
 
-Group messaging uses **nostr-mls** / **MDK** with **SQLite-backed** engine state, plus app tables in the main **`vector.db`** for group metadata and cursors.
+Group messaging uses **nostr-mls** / **MDK** with **SQLite-backed** engine state, plus app tables in the main **`pacto.db`** for group metadata and cursors.
 
 ## Read next
 
@@ -25,7 +25,7 @@ Group messaging uses **nostr-mls** / **MDK** with **SQLite-backed** engine state
 ## On-disk storage
 
 - **Engine state:** `<app_data>/<npub>/mls/vector-mls.db` (see `MlsService::new_persistent` in `mls.rs`).
-- **App metadata / cursors:** tables inside **`vector.db`** (same directory as profile DB). Details in **`docs/storage-layout/SQLITE_AND_FILES.md`**.
+- **App metadata / cursors:** tables inside **`pacto.db`** (same directory as profile DB). Details in **`docs/storage-layout/SQLITE_AND_FILES.md`**.
 
 ## Related docs
 

--- a/docs/security/CRYPTOGRAPHY.md
+++ b/docs/security/CRYPTOGRAPHY.md
@@ -8,7 +8,7 @@ This doc explains the two cryptographic layers in Pacto: the **app-level PIN-der
 
 | Layer | Scope | Keys live in | Protects |
 |---|---|---|---|
-| **App-level (PIN)** | At-rest SQLite | Per-account `vector.db` settings + in-memory `ENCRYPTION_KEY` | Seed phrase, EVM imported keys, DM/MLS text message content, edits, bot secrets |
+| **App-level (PIN)** | At-rest SQLite | Per-account `pacto.db` settings + in-memory `ENCRYPTION_KEY` | Seed phrase, EVM imported keys, DM/MLS text message content, edits, bot secrets |
 | **MLS protocol** | Group messaging in transit | `mdk_core` engine inside `vector-mls.db` | Group messages on the wire (Kind 444) |
 
 The two layers are independent. A failure in the PIN layer cannot make the MLS engine reject a wire message, and a corrupted MLS engine state cannot decrypt the app-level SQLite rows.

--- a/docs/security/CRYPTOGRAPHY.md
+++ b/docs/security/CRYPTOGRAPHY.md
@@ -9,7 +9,7 @@ This doc explains the two cryptographic layers in Pacto: the **app-level PIN-der
 | Layer | Scope | Keys live in | Protects |
 |---|---|---|---|
 | **App-level (PIN)** | At-rest SQLite | Per-account `pacto.db` settings + in-memory `ENCRYPTION_KEY` | Seed phrase, EVM imported keys, DM/MLS text message content, edits, bot secrets |
-| **MLS protocol** | Group messaging in transit | `mdk_core` engine inside `vector-mls.db` | Group messages on the wire (Kind 444) |
+| **MLS protocol** | Group messaging in transit | `mdk_core` engine inside `pacto-mls.db` | Group messages on the wire (Kind 444) |
 
 The two layers are independent. A failure in the PIN layer cannot make the MLS engine reject a wire message, and a corrupted MLS engine state cannot decrypt the app-level SQLite rows.
 
@@ -136,7 +136,7 @@ Only these rows are migrated; MLS engine state is **not** in this list:
 MLS is handled by the `mdk_core` / `mdk_sqlite_storage` engine behind `MlsService` in `src-tauri/src/mls.rs`. The engine keeps its own cryptographic state in a separate SQLite database:
 
 ```text
-<app_data_dir>/<npub>/mls/vector-mls.db
+<app_data_dir>/<npub>/mls/pacto-mls.db
 ```
 
 ### 4.1 What the engine manages

--- a/docs/storage-layout/ACCOUNT_LOGOUT_AND_ISOLATION.md
+++ b/docs/storage-layout/ACCOUNT_LOGOUT_AND_ISOLATION.md
@@ -10,7 +10,7 @@ How Pacto stores data **per Nostr identity (`npub`)**, what **logout** removes, 
 
 | Location | Contents | Removed on logout? |
 |----------|----------|-------------------|
-| **`AppData/<npub>/`** (see `account_manager::get_profile_directory`) | **`vector.db`**, **`mls/`** (engine DB), encrypted keys in `settings`, chats, events, profiles | **Yes** — only the **current** account’s directory |
+| **`AppData/<npub>/`** (see `account_manager::get_profile_directory`) | **`pacto.db`**, **`mls/`** (engine DB), encrypted keys in `settings`, chats, events, profiles | **Yes** — only the **current** account’s directory |
 | **Downloads / Documents** | `Download/vector/` (desktop) or `Document/vector/` (iOS) — attachments | **Yes** (whole folder) |
 
 ### Global (not npub-scoped)
@@ -59,7 +59,7 @@ Order (simplified):
 
 ## 5. Clear storage (separate from logout)
 
-**`clear_storage`** — clears attachment files / metadata and **cache**, profile cached image paths; **does not** delete `vector.db`, keys, or MLS engine DB.
+**`clear_storage`** — clears attachment files / metadata and **cache**, profile cached image paths; **does not** delete `pacto.db`, keys, or MLS engine DB.
 
 ---
 

--- a/docs/storage-layout/README.md
+++ b/docs/storage-layout/README.md
@@ -1,6 +1,6 @@
 # Storage layout — contributor map
 
-Local persistence is **per Nostr account (`npub`)**: one profile directory under the Tauri **app data** path, containing **`pacto.db`** (app SQLite) and **`mls/vector-mls.db`** (MLS engine).
+Local persistence is **per Nostr account (`npub`)**: one profile directory under the Tauri **app data** path, containing **`pacto.db`** (app SQLite) and **`mls/pacto-mls.db`** (MLS engine).
 
 ## Read next
 

--- a/docs/storage-layout/README.md
+++ b/docs/storage-layout/README.md
@@ -1,6 +1,6 @@
 # Storage layout — contributor map
 
-Local persistence is **per Nostr account (`npub`)**: one profile directory under the Tauri **app data** path, containing **`vector.db`** (app SQLite) and **`mls/vector-mls.db`** (MLS engine).
+Local persistence is **per Nostr account (`npub`)**: one profile directory under the Tauri **app data** path, containing **`pacto.db`** (app SQLite) and **`mls/vector-mls.db`** (MLS engine).
 
 ## Read next
 

--- a/docs/storage-layout/SQLITE_AND_FILES.md
+++ b/docs/storage-layout/SQLITE_AND_FILES.md
@@ -7,14 +7,16 @@ For a given **`npub`** (full `npub1…` string):
 | Path (under Tauri `app_data_dir`) | Role |
 |-----------------------------------|------|
 | `<npub>/` | Profile directory — `account_manager::get_profile_directory` |
-| `<npub>/vector.db` | Primary app database — `get_database_path` |
+| `<npub>/pacto.db` | Primary app database — `get_database_path` |
 | `<npub>/mls/` | MLS directory — `get_mls_directory` |
 | `<npub>/mls/vector-mls.db` | MDK engine database (see `docs/mls/ARCHITECTURE.md`) |
 | `<npub>/mls.archive.<unix-seconds>/` | A complete pre-upgrade MLS store set (`vector-mls.db`, `-wal`, and `-shm` together), retained for seven days |
 
 Account discovery scans **`npub1*`** subfolders and validates stored keys — see **`list_accounts`** in `account_manager.rs`.
 
-## `vector.db` schema (source of truth)
+**Legacy filename migration:** `pacto.db` was named `vector.db` before Pacto forked from the upstream Vector project. `account_manager::migrate_legacy_databases` runs once per app launch, before any other database or profile access, and renames each profile's `vector.db` (plus any live `-wal`/`-shm` companions) to `pacto.db` in place. It is idempotent and safe to interrupt: WAL/SHM companions move before the main file, so a crash mid-migration just leaves `vector.db` as the source of truth for the next launch to retry.
+
+## `pacto.db` schema (source of truth)
 
 The **authoritative schema and migration history** lives in **`src-tauri/src/migrations/`** as ordered refinery migration files (`V1__initial_schema.sql`, `V2__messages_wrapper_event_id.sql`, …). **`init_profile_database`** and **`get_db_connection`** run the refinery migration runner on every database open, so new accounts start at the latest version and existing accounts are migrated automatically.
 
@@ -48,7 +50,7 @@ The active MLS database is SQLCipher-encrypted with a key domain-separated from 
 
 ## MLS legacy reset
 
-`mls_store_reset.rs` runs before MDK opens `vector-mls.db`. It classifies the old V100–V104 migration series as legacy; MDK 0.8.0 V1–V5 stores are current. For a legacy store it harvests known group admins and pending welcome wrapper ids, commits those rows and reset settings to `vector.db`, atomically moves the whole `mls/` directory to a timestamped sibling, and only then writes the completion marker. Missing files and interrupted runs are safe to re-enter, and reset work is serialized per account.
+`mls_store_reset.rs` runs before MDK opens `vector-mls.db`. It classifies the old V100–V104 migration series as legacy; MDK 0.8.0 V1–V5 stores are current. For a legacy store it harvests known group admins and pending welcome wrapper ids, commits those rows and reset settings to `pacto.db`, atomically moves the whole `mls/` directory to a timestamped sibling, and only then writes the completion marker. Missing files and interrupted runs are safe to re-enter, and reset work is serialized per account.
 
 The pending wrapper ids are removed from `discarded_giftwraps` and retained in a durable exact-refetch queue, because the normal forward sync window may no longer include an old invitation. Lost group ids remain in a settings value until a welcome restores that group; while listed, participant synchronization does not replace the surviving chat roster with an empty fresh-engine roster.
 

--- a/docs/storage-layout/SQLITE_AND_FILES.md
+++ b/docs/storage-layout/SQLITE_AND_FILES.md
@@ -9,12 +9,12 @@ For a given **`npub`** (full `npub1…` string):
 | `<npub>/` | Profile directory — `account_manager::get_profile_directory` |
 | `<npub>/pacto.db` | Primary app database — `get_database_path` |
 | `<npub>/mls/` | MLS directory — `get_mls_directory` |
-| `<npub>/mls/vector-mls.db` | MDK engine database (see `docs/mls/ARCHITECTURE.md`) |
-| `<npub>/mls.archive.<unix-seconds>/` | A complete pre-upgrade MLS store set (`vector-mls.db`, `-wal`, and `-shm` together), retained for seven days |
+| `<npub>/mls/pacto-mls.db` | MDK engine database (see `docs/mls/ARCHITECTURE.md`) |
+| `<npub>/mls.archive.<unix-seconds>/` | A complete pre-upgrade MLS store set (`pacto-mls.db`, `-wal`, and `-shm` together), retained for seven days |
 
 Account discovery scans **`npub1*`** subfolders and validates stored keys — see **`list_accounts`** in `account_manager.rs`.
 
-**Legacy filename migration:** `pacto.db` was named `vector.db` before Pacto forked from the upstream Vector project. `account_manager::migrate_legacy_databases` runs once per app launch, before any other database or profile access, and renames each profile's `vector.db` (plus any live `-wal`/`-shm` companions) to `pacto.db` in place. It is idempotent and safe to interrupt: WAL/SHM companions move before the main file, so a crash mid-migration just leaves `vector.db` as the source of truth for the next launch to retry.
+**Legacy filename migration:** `pacto.db` was named `vector.db`, and the MLS engine store was named `vector-mls.db`, before Pacto forked from the upstream Vector project. `account_manager::migrate_legacy_databases` runs once per app launch, before any other database or profile access, and renames each profile's `vector.db` to `pacto.db` and `vector-mls.db` to `pacto-mls.db` (plus any live `-wal`/`-shm` companions, and any `mls.archive.*` copies) in place. It is idempotent and safe to interrupt: WAL/SHM companions move before the main file, so a crash mid-migration just leaves the legacy file as the source of truth for the next launch to retry.
 
 ## `pacto.db` schema (source of truth)
 
@@ -50,7 +50,7 @@ The active MLS database is SQLCipher-encrypted with a key domain-separated from 
 
 ## MLS legacy reset
 
-`mls_store_reset.rs` runs before MDK opens `vector-mls.db`. It classifies the old V100–V104 migration series as legacy; MDK 0.8.0 V1–V5 stores are current. For a legacy store it harvests known group admins and pending welcome wrapper ids, commits those rows and reset settings to `pacto.db`, atomically moves the whole `mls/` directory to a timestamped sibling, and only then writes the completion marker. Missing files and interrupted runs are safe to re-enter, and reset work is serialized per account.
+`mls_store_reset.rs` runs before MDK opens `pacto-mls.db`. It classifies the old V100–V104 migration series as legacy; MDK 0.8.0 V1–V5 stores are current. For a legacy store it harvests known group admins and pending welcome wrapper ids, commits those rows and reset settings to `pacto.db`, atomically moves the whole `mls/` directory to a timestamped sibling, and only then writes the completion marker. Missing files and interrupted runs are safe to re-enter, and reset work is serialized per account.
 
 The pending wrapper ids are removed from `discarded_giftwraps` and retained in a durable exact-refetch queue, because the normal forward sync window may no longer include an old invitation. Lost group ids remain in a settings value until a welcome restores that group; while listed, participant synchronization does not replace the surviving chat roster with an empty fresh-engine roster.
 
@@ -69,7 +69,7 @@ Browser **localStorage** and in-memory stores can still hold account-specific UI
 
 ## Naming note
 
-Comments in Rust sometimes say **“Vector”** database; the shipped app name is **Pacto** — same files and paths.
+`vector.db`/`vector-mls.db` are the pre-rename filenames from the upstream Vector project. `account_manager::migrate_legacy_databases` renames both to `pacto.db`/`pacto-mls.db` on first launch after upgrade; comments in older, dated planning docs may still refer to the old names as a historical record.
 
 ## See also
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,7 +72,7 @@ symphonia = { version = "0.5.5", features = ["mp3", "wav", "flac", "pcm"] }
 # Cargo unifies this with mdk-sqlite-storage's `bundled-sqlcipher` to the SQLCipher
 # variant. The vendored-openssl superset drops the system-OpenSSL and Windows-Perl
 # requirements that plain `bundled-sqlcipher` carries. Unkeyed databases open as
-# stock SQLite, so existing `vector.db` files are unaffected.
+# stock SQLite, so existing `pacto.db` files are unaffected.
 rusqlite = { version = "0.37", features = ["bundled-sqlcipher-vendored-openssl"] }
 refinery = { version = "0.9", features = ["rusqlite"] }
 log = "0.4"

--- a/src-tauri/src/account_manager.rs
+++ b/src-tauri/src/account_manager.rs
@@ -16,6 +16,13 @@ lazy_static! {
         Arc::new(Mutex::new(None));
 }
 
+/// Current app database filename.
+const DB_FILENAME: &str = "pacto.db";
+/// Filename used before the rename from the upstream Vector project's
+/// `vector.db`; `migrate_legacy_database_file` moves it to `DB_FILENAME`
+/// in place the first time a profile directory is seen.
+const LEGACY_DB_FILENAME: &str = "vector.db";
+
 /// Get the profile directory for a given npub (full npub, no truncation)
 ///
 /// Returns: AppData/npub1qwertyuiop.../
@@ -49,10 +56,75 @@ pub fn get_profile_directory<R: Runtime>(
 
 /// Get the database path for a given npub
 ///
-/// Returns: AppData/npub1qwerty.../vector.db
+/// Returns: AppData/npub1qwerty.../pacto.db
 pub fn get_database_path<R: Runtime>(handle: &AppHandle<R>, npub: &str) -> Result<PathBuf, String> {
     let profile_dir = get_profile_directory(handle, npub)?;
-    Ok(profile_dir.join("vector.db"))
+    Ok(profile_dir.join(DB_FILENAME))
+}
+
+/// Best-effort, one-time migration of every profile's legacy `vector.db`
+/// (and any `-wal`/`-shm` companions) to the current `pacto.db` filename.
+/// Meant to run once at app startup, before any other database or profile
+/// access, so existing users transition automatically with no action and
+/// no data loss. A failure on one profile is logged and never blocks the
+/// others or app startup.
+pub fn migrate_legacy_databases<R: Runtime>(handle: &AppHandle<R>) {
+    let Ok(app_data) = crate::test_sandbox::test_data_dir(handle) else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(&app_data) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_profile_dir = path.is_dir()
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("npub1"));
+        if !is_profile_dir {
+            continue;
+        }
+        if let Err(e) = migrate_legacy_database_file(&path) {
+            eprintln!(
+                "[Account Manager] Failed to migrate legacy database in {}: {}",
+                path.display(),
+                e
+            );
+        }
+    }
+}
+
+/// Idempotent migration of a single profile directory's database file (and
+/// any live `-wal`/`-shm` companions) from `LEGACY_DB_FILENAME` to
+/// `DB_FILENAME`. Renames the WAL/SHM companions before the main file, so
+/// an interruption between them leaves the legacy file as the source of
+/// truth and the next call simply retries; does nothing if `DB_FILENAME`
+/// already exists or no legacy file is present.
+fn migrate_legacy_database_file(profile_dir: &std::path::Path) -> Result<(), String> {
+    let new_path = profile_dir.join(DB_FILENAME);
+    let legacy_path = profile_dir.join(LEGACY_DB_FILENAME);
+    if new_path.exists() || !legacy_path.exists() {
+        return Ok(());
+    }
+
+    for suffix in ["-wal", "-shm"] {
+        let legacy_aux = profile_dir.join(format!("{LEGACY_DB_FILENAME}{suffix}"));
+        if legacy_aux.exists() {
+            let new_aux = profile_dir.join(format!("{DB_FILENAME}{suffix}"));
+            std::fs::rename(&legacy_aux, &new_aux)
+                .map_err(|e| format!("failed to migrate {}: {}", legacy_aux.display(), e))?;
+        }
+    }
+
+    std::fs::rename(&legacy_path, &new_path)
+        .map_err(|e| format!("failed to migrate {}: {}", legacy_path.display(), e))?;
+    println!(
+        "[Account Manager] Migrated legacy database {} -> {}",
+        legacy_path.display(),
+        new_path.display()
+    );
+    Ok(())
 }
 
 /// Get the MLS directory for a given npub
@@ -106,8 +178,9 @@ pub fn list_accounts<R: Runtime>(handle: &AppHandle<R>) -> Result<Vec<String>, S
                     if name.starts_with("npub1") {
                         let in_flight =
                             is_in_flight_account(name, current.as_deref(), pending.as_deref());
-                        let format =
-                            crate::storage_format::classify_database(&entry.path().join("vector.db"));
+                        let format = crate::storage_format::classify_database(
+                            &entry.path().join(DB_FILENAME),
+                        );
                         let has_pkey = account_has_valid_pkey(handle, name);
                         match classify_account_scan(&has_pkey, in_flight, format) {
                             AccountScanVerdict::Include => {
@@ -689,7 +762,7 @@ mod list_accounts_orphan_exemption_tests {
         let npub = "npub1u3orphanexemptionintegration";
 
         let profile_dir = get_profile_directory(handle, npub).unwrap();
-        let db_path = profile_dir.join("vector.db");
+        let db_path = profile_dir.join(DB_FILENAME);
 
         {
             let mut conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -718,6 +791,118 @@ mod list_accounts_orphan_exemption_tests {
             profile_dir.exists(),
             "an unrecognized-format profile must never be deleted by list_accounts"
         );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+}
+
+#[cfg(test)]
+mod legacy_database_migration_tests {
+    use super::*;
+
+    #[test]
+    fn migrates_main_file_and_wal_shm_companions() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymigrationmainpath";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        std::fs::write(profile_dir.join(LEGACY_DB_FILENAME), b"main").unwrap();
+        std::fs::write(
+            profile_dir.join(format!("{LEGACY_DB_FILENAME}-wal")),
+            b"wal",
+        )
+        .unwrap();
+        std::fs::write(
+            profile_dir.join(format!("{LEGACY_DB_FILENAME}-shm")),
+            b"shm",
+        )
+        .unwrap();
+
+        migrate_legacy_database_file(&profile_dir).unwrap();
+
+        assert!(!profile_dir.join(LEGACY_DB_FILENAME).exists());
+        assert!(!profile_dir
+            .join(format!("{LEGACY_DB_FILENAME}-wal"))
+            .exists());
+        assert!(!profile_dir
+            .join(format!("{LEGACY_DB_FILENAME}-shm"))
+            .exists());
+        assert_eq!(
+            std::fs::read(profile_dir.join(DB_FILENAME)).unwrap(),
+            b"main"
+        );
+        assert_eq!(
+            std::fs::read(profile_dir.join(format!("{DB_FILENAME}-wal"))).unwrap(),
+            b"wal"
+        );
+        assert_eq!(
+            std::fs::read(profile_dir.join(format!("{DB_FILENAME}-shm"))).unwrap(),
+            b"shm"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    #[test]
+    fn leaves_legacy_file_alone_when_current_file_already_exists() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymigrationnoclobber";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        std::fs::write(profile_dir.join(DB_FILENAME), b"current").unwrap();
+        std::fs::write(profile_dir.join(LEGACY_DB_FILENAME), b"stale-legacy").unwrap();
+
+        migrate_legacy_database_file(&profile_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read(profile_dir.join(DB_FILENAME)).unwrap(),
+            b"current",
+            "an already-migrated profile's current database must never be overwritten"
+        );
+        assert!(
+            profile_dir.join(LEGACY_DB_FILENAME).exists(),
+            "a stray legacy file left over from a prior migration is not touched"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    #[test]
+    fn is_a_noop_when_no_legacy_file_exists() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymigrationnooplegacy";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        migrate_legacy_database_file(&profile_dir).unwrap();
+
+        assert!(!profile_dir.join(DB_FILENAME).exists());
+        assert!(!profile_dir.join(LEGACY_DB_FILENAME).exists());
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    /// Integration path: `migrate_legacy_databases` walks every `npub1*`
+    /// profile directory under the app data root and migrates each one,
+    /// so a legacy account is queryable through `get_database_path`
+    /// immediately afterward with no manual step.
+    #[test]
+    fn migrate_legacy_databases_covers_every_profile_directory() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymigrationsweepall";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        std::fs::write(profile_dir.join(LEGACY_DB_FILENAME), b"sweep-me").unwrap();
+
+        migrate_legacy_databases(handle);
+
+        let db_path = get_database_path(handle, npub).unwrap();
+        assert!(db_path.exists());
+        assert_eq!(std::fs::read(&db_path).unwrap(), b"sweep-me");
+        assert!(!profile_dir.join(LEGACY_DB_FILENAME).exists());
 
         let _ = std::fs::remove_dir_all(&profile_dir);
     }

--- a/src-tauri/src/account_manager.rs
+++ b/src-tauri/src/account_manager.rs
@@ -77,7 +77,9 @@ pub fn migrate_legacy_databases<R: Runtime>(handle: &AppHandle<R>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let is_profile_dir = path.is_dir()
+        let is_profile_dir = entry
+            .file_type()
+            .is_ok_and(|file_type| file_type.is_dir())
             && entry
                 .file_name()
                 .to_str()

--- a/src-tauri/src/account_manager.rs
+++ b/src-tauri/src/account_manager.rs
@@ -23,6 +23,14 @@ const DB_FILENAME: &str = "pacto.db";
 /// in place the first time a profile directory is seen.
 const LEGACY_DB_FILENAME: &str = "vector.db";
 
+/// Current MLS engine store filename (see `get_mls_directory`).
+pub(crate) const MLS_DB_FILENAME: &str = "pacto-mls.db";
+/// Filename used before the rename from the upstream Vector project's
+/// `vector-mls.db`; `migrate_legacy_mls_store` moves it to `MLS_DB_FILENAME`
+/// in place, both in the live `mls/` directory and in any `mls.archive.*`
+/// sibling.
+const LEGACY_MLS_DB_FILENAME: &str = "vector-mls.db";
+
 /// Get the profile directory for a given npub (full npub, no truncation)
 ///
 /// Returns: AppData/npub1qwertyuiop.../
@@ -63,8 +71,10 @@ pub fn get_database_path<R: Runtime>(handle: &AppHandle<R>, npub: &str) -> Resul
 }
 
 /// Best-effort, one-time migration of every profile's legacy `vector.db`
-/// (and any `-wal`/`-shm` companions) to the current `pacto.db` filename.
-/// Meant to run once at app startup, before any other database or profile
+/// (and any `-wal`/`-shm` companions) to the current `pacto.db` filename,
+/// and of the profile's legacy `vector-mls.db` MLS engine store to
+/// `pacto-mls.db` (live directory and any `mls.archive.*` siblings). Meant
+/// to run once at app startup, before any other database or profile
 /// access, so existing users transition automatically with no action and
 /// no data loss. A failure on one profile is logged and never blocks the
 /// others or app startup.
@@ -77,9 +87,7 @@ pub fn migrate_legacy_databases<R: Runtime>(handle: &AppHandle<R>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let is_profile_dir = entry
-            .file_type()
-            .is_ok_and(|file_type| file_type.is_dir())
+        let is_profile_dir = entry.file_type().is_ok_and(|file_type| file_type.is_dir())
             && entry
                 .file_name()
                 .to_str()
@@ -94,26 +102,31 @@ pub fn migrate_legacy_databases<R: Runtime>(handle: &AppHandle<R>) {
                 e
             );
         }
+        migrate_legacy_mls_store(&path);
     }
 }
 
-/// Idempotent migration of a single profile directory's database file (and
-/// any live `-wal`/`-shm` companions) from `LEGACY_DB_FILENAME` to
-/// `DB_FILENAME`. Renames the WAL/SHM companions before the main file, so
-/// an interruption between them leaves the legacy file as the source of
-/// truth and the next call simply retries; does nothing if `DB_FILENAME`
-/// already exists or no legacy file is present.
-fn migrate_legacy_database_file(profile_dir: &std::path::Path) -> Result<(), String> {
-    let new_path = profile_dir.join(DB_FILENAME);
-    let legacy_path = profile_dir.join(LEGACY_DB_FILENAME);
+/// Rename `legacy_name` (and any live `-wal`/`-shm` companions) to
+/// `current_name` inside `dir`. Renames the WAL/SHM companions before the
+/// main file, so an interruption between them leaves the legacy file as the
+/// source of truth and the next call simply retries; does nothing if `dir`
+/// doesn't exist, `current_name` already exists, or no legacy file is
+/// present.
+fn rename_legacy_sqlite_file(
+    dir: &std::path::Path,
+    legacy_name: &str,
+    current_name: &str,
+) -> Result<(), String> {
+    let new_path = dir.join(current_name);
+    let legacy_path = dir.join(legacy_name);
     if new_path.exists() || !legacy_path.exists() {
         return Ok(());
     }
 
     for suffix in ["-wal", "-shm"] {
-        let legacy_aux = profile_dir.join(format!("{LEGACY_DB_FILENAME}{suffix}"));
+        let legacy_aux = dir.join(format!("{legacy_name}{suffix}"));
         if legacy_aux.exists() {
-            let new_aux = profile_dir.join(format!("{DB_FILENAME}{suffix}"));
+            let new_aux = dir.join(format!("{current_name}{suffix}"));
             std::fs::rename(&legacy_aux, &new_aux)
                 .map_err(|e| format!("failed to migrate {}: {}", legacy_aux.display(), e))?;
         }
@@ -127,6 +140,56 @@ fn migrate_legacy_database_file(profile_dir: &std::path::Path) -> Result<(), Str
         new_path.display()
     );
     Ok(())
+}
+
+/// Idempotent migration of a single profile directory's database file (and
+/// any live `-wal`/`-shm` companions) from `LEGACY_DB_FILENAME` to
+/// `DB_FILENAME`.
+fn migrate_legacy_database_file(profile_dir: &std::path::Path) -> Result<(), String> {
+    rename_legacy_sqlite_file(profile_dir, LEGACY_DB_FILENAME, DB_FILENAME)
+}
+
+/// Best-effort migration of a single profile's MLS engine store from
+/// `LEGACY_MLS_DB_FILENAME` to `MLS_DB_FILENAME`: the live `mls/` directory,
+/// plus every `mls.archive.*` sibling left by
+/// `mls_store_reset::ensure_store_ready`. Renaming inside an archive is
+/// cosmetic — archives are pruned after seven days and never reopened by
+/// name — but keeps them consistent with the live store. Each directory is
+/// handled independently; a failure on one is logged and never blocks
+/// another or app startup.
+fn migrate_legacy_mls_store(profile_dir: &std::path::Path) {
+    let mls_dir = profile_dir.join("mls");
+    if let Err(e) = rename_legacy_sqlite_file(&mls_dir, LEGACY_MLS_DB_FILENAME, MLS_DB_FILENAME) {
+        eprintln!(
+            "[Account Manager] Failed to migrate legacy MLS store in {}: {}",
+            mls_dir.display(),
+            e
+        );
+    }
+
+    let Ok(entries) = std::fs::read_dir(profile_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let is_archive_dir = entry.file_type().is_ok_and(|file_type| file_type.is_dir())
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(crate::mls_store_reset::ARCHIVE_PREFIX));
+        if !is_archive_dir {
+            continue;
+        }
+        let archive_dir = entry.path();
+        if let Err(e) =
+            rename_legacy_sqlite_file(&archive_dir, LEGACY_MLS_DB_FILENAME, MLS_DB_FILENAME)
+        {
+            eprintln!(
+                "[Account Manager] Failed to migrate legacy MLS store in {}: {}",
+                archive_dir.display(),
+                e
+            );
+        }
+    }
 }
 
 /// Get the MLS directory for a given npub
@@ -889,7 +952,8 @@ mod legacy_database_migration_tests {
     /// Integration path: `migrate_legacy_databases` walks every `npub1*`
     /// profile directory under the app data root and migrates each one,
     /// so a legacy account is queryable through `get_database_path`
-    /// immediately afterward with no manual step.
+    /// immediately afterward with no manual step. Also covers the MLS
+    /// engine store migrated in the same sweep.
     #[test]
     fn migrate_legacy_databases_covers_every_profile_directory() {
         let app = tauri::test::mock_app();
@@ -898,6 +962,9 @@ mod legacy_database_migration_tests {
 
         let profile_dir = get_profile_directory(handle, npub).unwrap();
         std::fs::write(profile_dir.join(LEGACY_DB_FILENAME), b"sweep-me").unwrap();
+        let mls_dir = profile_dir.join("mls");
+        std::fs::create_dir_all(&mls_dir).unwrap();
+        std::fs::write(mls_dir.join(LEGACY_MLS_DB_FILENAME), b"sweep-mls").unwrap();
 
         migrate_legacy_databases(handle);
 
@@ -905,6 +972,148 @@ mod legacy_database_migration_tests {
         assert!(db_path.exists());
         assert_eq!(std::fs::read(&db_path).unwrap(), b"sweep-me");
         assert!(!profile_dir.join(LEGACY_DB_FILENAME).exists());
+        assert_eq!(
+            std::fs::read(mls_dir.join(MLS_DB_FILENAME)).unwrap(),
+            b"sweep-mls"
+        );
+        assert!(!mls_dir.join(LEGACY_MLS_DB_FILENAME).exists());
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+}
+
+#[cfg(test)]
+mod legacy_mls_store_migration_tests {
+    use super::*;
+
+    #[test]
+    fn migrates_main_file_and_wal_shm_companions() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymlsmigrationmainpath";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        let mls_dir = profile_dir.join("mls");
+        std::fs::create_dir_all(&mls_dir).unwrap();
+        std::fs::write(mls_dir.join(LEGACY_MLS_DB_FILENAME), b"main").unwrap();
+        std::fs::write(
+            mls_dir.join(format!("{LEGACY_MLS_DB_FILENAME}-wal")),
+            b"wal",
+        )
+        .unwrap();
+        std::fs::write(
+            mls_dir.join(format!("{LEGACY_MLS_DB_FILENAME}-shm")),
+            b"shm",
+        )
+        .unwrap();
+
+        migrate_legacy_mls_store(&profile_dir);
+
+        assert!(!mls_dir.join(LEGACY_MLS_DB_FILENAME).exists());
+        assert!(!mls_dir
+            .join(format!("{LEGACY_MLS_DB_FILENAME}-wal"))
+            .exists());
+        assert!(!mls_dir
+            .join(format!("{LEGACY_MLS_DB_FILENAME}-shm"))
+            .exists());
+        assert_eq!(
+            std::fs::read(mls_dir.join(MLS_DB_FILENAME)).unwrap(),
+            b"main"
+        );
+        assert_eq!(
+            std::fs::read(mls_dir.join(format!("{MLS_DB_FILENAME}-wal"))).unwrap(),
+            b"wal"
+        );
+        assert_eq!(
+            std::fs::read(mls_dir.join(format!("{MLS_DB_FILENAME}-shm"))).unwrap(),
+            b"shm"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    #[test]
+    fn leaves_legacy_file_alone_when_current_file_already_exists() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymlsmigrationnoclobber";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        let mls_dir = profile_dir.join("mls");
+        std::fs::create_dir_all(&mls_dir).unwrap();
+        std::fs::write(mls_dir.join(MLS_DB_FILENAME), b"current").unwrap();
+        std::fs::write(mls_dir.join(LEGACY_MLS_DB_FILENAME), b"stale-legacy").unwrap();
+
+        migrate_legacy_mls_store(&profile_dir);
+
+        assert_eq!(
+            std::fs::read(mls_dir.join(MLS_DB_FILENAME)).unwrap(),
+            b"current",
+            "an already-migrated store must never be overwritten"
+        );
+        assert!(
+            mls_dir.join(LEGACY_MLS_DB_FILENAME).exists(),
+            "a stray legacy file left over from a prior migration is not touched"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    #[test]
+    fn is_a_noop_when_no_legacy_file_or_mls_dir_exists() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymlsmigrationnooplegacy";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        migrate_legacy_mls_store(&profile_dir);
+
+        assert!(!profile_dir.join("mls").join(MLS_DB_FILENAME).exists());
+
+        let _ = std::fs::remove_dir_all(&profile_dir);
+    }
+
+    /// Archives created by `mls_store_reset::ensure_store_ready` before this
+    /// rename keep their own copy of the legacy filename; the sweep must
+    /// migrate those too, not just the live `mls/` directory.
+    #[test]
+    fn migrates_legacy_file_inside_archive_directories() {
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+        let npub = "npub1u4legacymlsmigrationarchive";
+
+        let profile_dir = get_profile_directory(handle, npub).unwrap();
+        let mls_dir = profile_dir.join("mls");
+        std::fs::create_dir_all(&mls_dir).unwrap();
+        std::fs::write(mls_dir.join(LEGACY_MLS_DB_FILENAME), b"live").unwrap();
+
+        let archive_dir = profile_dir.join(format!(
+            "{}1785872647",
+            crate::mls_store_reset::ARCHIVE_PREFIX
+        ));
+        std::fs::create_dir_all(&archive_dir).unwrap();
+        std::fs::write(archive_dir.join(LEGACY_MLS_DB_FILENAME), b"archived").unwrap();
+        std::fs::write(
+            archive_dir.join(format!("{LEGACY_MLS_DB_FILENAME}-wal")),
+            b"archived-wal",
+        )
+        .unwrap();
+
+        migrate_legacy_mls_store(&profile_dir);
+
+        assert_eq!(
+            std::fs::read(mls_dir.join(MLS_DB_FILENAME)).unwrap(),
+            b"live"
+        );
+        assert_eq!(
+            std::fs::read(archive_dir.join(MLS_DB_FILENAME)).unwrap(),
+            b"archived"
+        );
+        assert_eq!(
+            std::fs::read(archive_dir.join(format!("{MLS_DB_FILENAME}-wal"))).unwrap(),
+            b"archived-wal"
+        );
+        assert!(!archive_dir.join(LEGACY_MLS_DB_FILENAME).exists());
 
         let _ = std::fs::remove_dir_all(&profile_dir);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8882,9 +8882,9 @@ pub fn run() {
                 }
             });
 
-            // Migrate any legacy `vector.db` profiles (pre-rename from the
-            // upstream Vector project) to `pacto.db` before anything else
-            // touches storage.
+            // Migrate any legacy `vector.db`/`vector-mls.db` profiles
+            // (pre-rename from the upstream Vector project) to
+            // `pacto.db`/`pacto-mls.db` before anything else touches storage.
             account_manager::migrate_legacy_databases(&handle);
 
             // Auto-select account on startup if one exists but isn't selected

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1375,7 +1375,7 @@ async fn fetch_messages<R: Runtime>(handle: AppHandle<R>, init: bool, relay_url:
 
             let app_data = crate::test_sandbox::test_data_dir(&handle).ok();
             if let Some(data_dir) = app_data {
-                let profile_db = data_dir.join(&npub).join("vector.db");
+                let profile_db = data_dir.join(&npub).join("pacto.db");
                 if profile_db.exists() {
                     let _ = crate::account_manager::set_current_account(npub.clone());
                     println!("[Startup] Set current account for SQL mode: {}", npub);
@@ -6143,7 +6143,7 @@ async fn complete_login_from_keys(keys: Keys) -> Result<LoginKeyPair, String> {
     if let Some(handle) = TAURI_APP.get() {
         let app_data = crate::test_sandbox::test_local_data_dir(handle).ok();
         if let Some(data_dir) = app_data {
-            let profile_db = data_dir.join(&npub).join("vector.db");
+            let profile_db = data_dir.join(&npub).join("pacto.db");
             if profile_db.exists() {
                 let _ = crate::account_manager::set_current_account(npub.clone());
                 println!("[Login] Set current account for SQL mode: {}", npub);
@@ -8881,6 +8881,11 @@ pub fn run() {
                     _ => {}
                 }
             });
+
+            // Migrate any legacy `vector.db` profiles (pre-rename from the
+            // upstream Vector project) to `pacto.db` before anything else
+            // touches storage.
+            account_manager::migrate_legacy_databases(&handle);
 
             // Auto-select account on startup if one exists but isn't selected
             {

--- a/src-tauri/src/mls.rs
+++ b/src-tauri/src/mls.rs
@@ -75,7 +75,7 @@ pub(crate) fn mls_wrapper_failure_reason(event_id: &[u8; 32]) -> Option<String> 
     let handle = TAURI_APP.get()?;
     let npub = crate::account_manager::get_current_account().ok()?;
     let mls_dir = crate::account_manager::get_mls_directory(&handle, &npub).ok()?;
-    let db_path = mls_dir.join("vector-mls.db");
+    let db_path = mls_dir.join(crate::account_manager::MLS_DB_FILENAME);
     let conn = rusqlite::Connection::open(&db_path).ok()?;
     conn.query_row(
         "SELECT failure_reason FROM processed_messages WHERE wrapper_event_id = ?1",
@@ -326,7 +326,7 @@ impl MlsService {
     }
 
     /// Create a new MLS service with persistent SQLite-backed storage at:
-    ///   [AppData]/npub.../mls/vector-mls.db (account-specific)
+    ///   [AppData]/npub.../mls/pacto-mls.db (account-specific)
     pub fn new_persistent<R: Runtime>(handle: &AppHandle<R>) -> Result<Self, MlsError> {
         Self::new_persistent_inner(handle, false)
     }
@@ -346,7 +346,7 @@ impl MlsService {
 
         let mls_dir = crate::account_manager::get_mls_directory(handle, &npub)
             .map_err(|e| MlsError::StorageError(format!("Failed to get MLS directory: {}", e)))?;
-        let db_path = mls_dir.join("vector-mls.db");
+        let db_path = mls_dir.join(crate::account_manager::MLS_DB_FILENAME);
         let encryption_key = Self::mls_store_encryption_key()?;
 
         // Detection and archive happen before MDK 0.8.0 can open legacy bytes.
@@ -3380,8 +3380,7 @@ mod mls_leave_group_state_lost_tests {
     #[test]
     fn engine_leave_group_on_unknown_group_id_errors_group_not_found() {
         let engine = MDK::new(
-            MdkSqliteStorage::new_with_key(":memory:", EncryptionConfig::new([42u8; 32]))
-                .unwrap(),
+            MdkSqliteStorage::new_with_key(":memory:", EncryptionConfig::new([42u8; 32])).unwrap(),
         );
 
         // A group id the fresh engine has never created, joined, or otherwise

--- a/src-tauri/src/mls_store_reset.rs
+++ b/src-tauri/src/mls_store_reset.rs
@@ -18,7 +18,7 @@ use crate::mls_store_reset_state::{
 
 const RESET_MARKER_KEY: &str = "mls_store_reset_v1";
 const ARCHIVE_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
-const ARCHIVE_PREFIX: &str = "mls.archive.";
+pub(crate) const ARCHIVE_PREFIX: &str = "mls.archive.";
 
 static ACCOUNT_RESET_LOCKS: Lazy<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -120,8 +120,7 @@ fn classify_history(
         match embedded.iter().find(|m| m.version() == row.version) {
             None => return StorageFormatVerdict::Unrecognized(row.version),
             Some(migration) => {
-                if migration.name() != row.name
-                    || migration.checksum().to_string() != row.checksum
+                if migration.name() != row.name || migration.checksum().to_string() != row.checksum
                 {
                     return StorageFormatVerdict::Divergent(row.version);
                 }
@@ -686,7 +685,10 @@ mod tests {
         assert!(report.all_recognized);
         assert_eq!(report.unrecognized_count, 0);
         assert_eq!(report.highest_offending_version, None);
-        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+        assert_eq!(
+            report.supported_schema_version,
+            crate::migrations::embedded_ceiling()
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -714,7 +716,10 @@ mod tests {
         assert!(!report.all_recognized);
         assert_eq!(report.unrecognized_count, 1);
         assert_eq!(report.highest_offending_version, Some(above_ceiling));
-        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+        assert_eq!(
+            report.supported_schema_version,
+            crate::migrations::embedded_ceiling()
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -730,7 +735,10 @@ mod tests {
         // behavior is covered against isolated temp dirs above.
         let app = tauri::test::mock_app();
         let report = get_storage_compatibility(app.handle().clone()).unwrap();
-        assert_eq!(report.supported_schema_version, crate::migrations::embedded_ceiling());
+        assert_eq!(
+            report.supported_schema_version,
+            crate::migrations::embedded_ceiling()
+        );
     }
 
     #[test]

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -1,4 +1,4 @@
-//! Read-only storage-format recognition for the app database (`vector.db`).
+//! Read-only storage-format recognition for the app database (`pacto.db`).
 //!
 //! Reproduces refinery-core 0.9.2's `verify_migrations` abort semantics
 //! ahead of time, on a read-only connection, so the app can tell a user to
@@ -66,7 +66,7 @@ fn table_exists(conn: &Connection, name: &str) -> Result<bool, rusqlite::Error> 
     )
 }
 
-/// Whether this build recognizes a profile's on-disk `vector.db` schema.
+/// Whether this build recognizes a profile's on-disk `pacto.db` schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StorageFormatVerdict {
     /// No database file at all -- nothing to recognize or reject.
@@ -192,7 +192,7 @@ pub(crate) struct StorageFormatScanReport {
     pub(crate) highest_offending_version: Option<i32>,
 }
 
-/// Scan every `npub1*` profile directory's `vector.db` under `app_data_dir`.
+/// Scan every `npub1*` profile directory's `pacto.db` under `app_data_dir`.
 /// A profile with no database file classifies `Fresh` and is not counted.
 /// Bounded by `SCAN_DEADLINE`: a profile reached after the deadline is left
 /// unscanned rather than blocking launch on a slow disk.
@@ -216,7 +216,7 @@ pub(crate) fn scan_profiles(app_data_dir: &Path) -> StorageFormatScanReport {
                 continue;
             }
 
-            let verdict = classify_database(&path.join("vector.db"));
+            let verdict = classify_database(&path.join("pacto.db"));
             if let StorageFormatVerdict::Unrecognized(version)
             | StorageFormatVerdict::Divergent(version) = verdict
             {
@@ -453,7 +453,7 @@ mod tests {
     fn pre_refinery_classification_ignores_settings_table_shape() {
         let dir = unique_temp_dir("pre-refinery-shape");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("vector.db");
+        let path = dir.join("pacto.db");
         let conn = rusqlite::Connection::open(&path).unwrap();
         // A `settings` table shaped nothing like the real schema -- the
         // classifier must not care about structure, only that it exists.
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn absent_file_is_fresh() {
-        let path = unique_temp_dir("absent").join("vector.db");
+        let path = unique_temp_dir("absent").join("pacto.db");
         assert_eq!(classify_database(&path), StorageFormatVerdict::Fresh);
     }
 
@@ -481,7 +481,7 @@ mod tests {
     fn unreadable_file_classifies_as_recognized() {
         let dir = unique_temp_dir("truncated");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("vector.db");
+        let path = dir.join("pacto.db");
         std::fs::write(&path, b"not a sqlite file").unwrap();
 
         assert_eq!(classify_database(&path), StorageFormatVerdict::Recognized);
@@ -493,7 +493,7 @@ mod tests {
     fn busy_database_classifies_as_recognized() {
         let dir = unique_temp_dir("busy");
         std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("vector.db");
+        let path = dir.join("pacto.db");
 
         let holder = rusqlite::Connection::open(&path).unwrap();
         holder
@@ -513,7 +513,7 @@ mod tests {
     // -- scan_profiles ------------------------------------------------------
 
     #[test]
-    fn scan_ignores_profile_without_vector_db() {
+    fn scan_ignores_profile_without_database() {
         let root = unique_temp_dir("scan-no-db");
         std::fs::create_dir_all(root.join("npub1scannodbprofile")).unwrap();
 
@@ -530,7 +530,7 @@ mod tests {
         let root = unique_temp_dir("scan-unrecognized");
         let profile_dir = root.join("npub1scanunrecognizedprofile");
         std::fs::create_dir_all(&profile_dir).unwrap();
-        let db_path = profile_dir.join("vector.db");
+        let db_path = profile_dir.join("pacto.db");
         write_migrated_db(&db_path);
 
         let above_ceiling = crate::migrations::embedded_ceiling() + 1;
@@ -557,14 +557,14 @@ mod tests {
         let root = unique_temp_dir("scan-multi");
         let good_dir = root.join("npub1scanmultigood");
         std::fs::create_dir_all(&good_dir).unwrap();
-        write_migrated_db(&good_dir.join("vector.db"));
+        write_migrated_db(&good_dir.join("pacto.db"));
 
         let above_ceiling = crate::migrations::embedded_ceiling() + 1;
         let mut offending_versions = Vec::new();
         for (label, bump) in [("a", 0), ("b", 1)] {
             let dir = root.join(format!("npub1scanmulti{label}"));
             std::fs::create_dir_all(&dir).unwrap();
-            let db_path = dir.join("vector.db");
+            let db_path = dir.join("pacto.db");
             write_migrated_db(&db_path);
             let version = above_ceiling + bump;
             let conn = rusqlite::Connection::open(&db_path).unwrap();
@@ -696,7 +696,7 @@ mod tests {
         let root = unique_temp_dir("compat-incompatible");
         let profile_dir = root.join("npub1compatincompatibleprofile");
         std::fs::create_dir_all(&profile_dir).unwrap();
-        let db_path = profile_dir.join("vector.db");
+        let db_path = profile_dir.join("pacto.db");
         write_migrated_db(&db_path);
 
         let above_ceiling = crate::migrations::embedded_ceiling() + 1;


### PR DESCRIPTION
Renames the per-account SQLite database from `vector.db` (the upstream Vector project's name) to `pacto.db`, and the MLS engine store from `vector-mls.db` to `pacto-mls.db`, migrating existing installs automatically with no user action and no data loss.

## Migration

`migrate_legacy_databases` runs once per launch, synchronously inside the Tauri `setup()` hook — before `TAURI_APP` is set and before any command (including the pre-auth storage-compatibility gate) can touch storage. For each `npub1*` profile directory it:

- Renames `vector.db` → `pacto.db` in place, only when `pacto.db` doesn't already exist.
- Renames `vector-mls.db` → `pacto-mls.db` in the live `mls/` directory, and in every `mls.archive.*` sibling left by a prior MLS legacy-store reset — none of these need the PIN-derived key, since it's a plain filesystem rename, not a database open.

In every case `-wal`/`-shm` companions move first, so an interruption mid-migration leaves the legacy file as the source of truth and the next launch simply retries. A failure on one profile or one directory is logged and never blocks another or app startup.

Every remaining `vector.db`/`vector-mls.db` reference in source, comments, and active/user-facing docs moved to `pacto.db`/`pacto-mls.db`. Historical dated docs under `docs/brainstorms/` and `docs/plans/` still say `vector.db`/`vector-mls.db` where they describe the state of the code at the time they were written, which is intentional — they're point-in-time records, not living references.

Fixes #217

## Testing

`cargo test --lib`: 564 passed, 0 failed (2 pre-existing ignored fixtures unrelated to this change), including migration tests covering the main-file+WAL/SHM path, no-clobber, no-op, full-sweep, and MLS-archive-directory renaming.

Manually verified against a real dev profile (`make dev`): confirmed on disk that both `mls/vector-mls.db` and a pre-existing `mls.archive.<timestamp>/vector-mls.db` were renamed to `pacto-mls.db` on launch, alongside the top-level `vector.db` → `pacto.db` rename.
