### PR TITLE
fix(ci): auto-tag releases regardless of merge strategy

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -4,6 +4,11 @@ name: Tag Release
 # version out of package.json, cross-checks it against Cargo.toml /
 # tauri.conf.json, and pushes v<version> if that tag doesn't exist yet.
 # Pushing the tag is what triggers release.yaml.
+#
+# The bump PR may land via squash, merge-commit, or rebase merge; only squash
+# folds the bump commit message into github.event.head_commit. Match against
+# every commit in the push instead of just the head commit so a merge-commit
+# merge (two commits pushed: the bump commit + the merge commit) still tags.
 
 on:
   push:
@@ -16,7 +21,7 @@ permissions:
 
 jobs:
   tag:
-    if: "startsWith(github.event.head_commit.message, 'chore(release): bump version to ')"
+    if: "contains(join(github.event.commits.*.message, '\n'), 'chore(release): bump version to ')"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Release bump PRs merged with GitHub's "merge commit" strategy were silently skipping the auto-tag step in `tag-release.yaml`, leaving `main` and the release tag out of sync until someone pushed the tag by hand. The gate checked only `github.event.head_commit.message`, which holds the bump commit's message under squash merge but becomes `"Merge pull request #N ..."` under merge-commit merge — confirmed against real run history: the `tag-release` runs for PR #191 (v0.5.2) and PR #205 (v0.5.4) both show `conclusion: skipped`, and both of those tags exist only because they were pushed by hand afterward. This is exactly the "lag returns" regression #206 asked to watch for.

The gate now matches against every commit in the push instead of just the head commit, so squash, merge-commit, and rebase-merge bump PRs all auto-tag correctly.

Related: #206

## New concepts

**GitHub Actions push-event object filters, not just `head_commit`**

A `push` event carries every new commit reachable by that push in `github.event.commits[]`, but `head_commit` is only the tip. A merge-commit merge pushes two new commits at once (the feature branch's tip + the new merge commit), so gating on `head_commit.message` alone misses whichever commit isn't the tip.

Chosen here over widening the string match (e.g. also checking for `"Merge pull request"`) because that approach is strategy-specific and breaks again the next time someone picks rebase merge or squash-with-a-different-title-format. Matching the whole commit list is strategy-agnostic by construction.

```yaml
if: "contains(join(github.event.commits.*.message, '\n'), 'chore(release): bump version to ')"
```

`github.event.commits.*.message` is an Actions expression *object filter* — it maps `.message` over every element of the array — then `join()` flattens it to one string `contains()` can search.

Don't reach for this when a workflow only ever needs the tip commit (e.g. gating on the exact SHA that triggered the run); `head_commit` is still correct and simpler there.

## Validation

`actionlint` passes on the edited workflow. Simulated the gate's `join`/`contains` logic against squash, merge-commit, rebase, and an unrelated-push payload — the new gate matches on all three merge strategies and correctly ignores the unrelated push, unlike the old `startsWith(head_commit...)` check, which only matched the squash case.

Not deployment-tested against a live push (that requires an actual Prepare Release run merging to `main`), so the existing manual-tag fallback stays available as a safety net if this needs a follow-up correction.
