### PR TITLE
fix(mls): clean up chat rows and cursor on voluntary group leave

### DIFF
--- a/docs/mls/EVICTION_AND_LEAVE.md
+++ b/docs/mls/EVICTION_AND_LEAVE.md
@@ -30,7 +30,8 @@ When **this client** is removed, sync or live **444** handling detects eviction-
 
 ## 3. Voluntary leave (`leave_mls_group`)
 
-- Engine emits a **leave proposal**; Pacto publishes it, then **removes group from local metadata** for the leaver and emits **`mls_group_left`** — the group **disappears from the leaver’s list immediately**.
+- Engine emits a **leave proposal**; Pacto publishes it, then **removes the group row from `mls_groups`** (not merely marks it evicted) for the leaver and emits **`mls_group_left`** — the group **disappears from the leaver's list immediately** and stays gone even after a later sync.
+- Mirrors **`cleanup_evicted_group`**'s local cleanup: drops the chat from **`STATE`**, **deletes the chat/messages from DB**, and clears the **MLS event cursor** (keyed by both wire and engine group id).
 - **The group continues** for remaining members; MLS tree updates without the leaver.
 
 **Admin handoff:** Pacto does **not** currently expose “add admin” / “transfer MLS admin”. Only the creator is admin at creation. If the **creator leaves**, the MLS group may end up with **no admins** → **no further kicks** from MLS until MDK + app support admin updates. Squad-level roles (e.g. Hats) are a separate product layer.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -3726,7 +3726,10 @@ pub async fn save_chat<R: Runtime>(handle: AppHandle<R>, chat: &Chat) -> Result<
 }
 
 /// Delete a chat and all its messages from the database.
-/// `chat_identifier` is the npub for DMs or group_id for MLS; events are CASCADE deleted.
+/// `chat_identifier` is the npub for DMs or group_id for MLS. Deletes the `chats`
+/// row and its catch-up entries; connections never enable `PRAGMA foreign_keys`,
+/// so the schema's `ON DELETE CASCADE` on `events`/`messages` never actually
+/// fires — cleaning up those orphaned rows is tracked separately.
 pub async fn delete_chat<R: Runtime>(
     handle: AppHandle<R>,
     chat_identifier: &str,
@@ -3910,14 +3913,31 @@ pub async fn save_chat_messages<R: Runtime>(
 // MLS Metadata SQL Functions
 // ============================================================================
 
-/// Save MLS groups to SQL database (plaintext columns)
-pub async fn save_mls_groups<R: Runtime>(
-    handle: AppHandle<R>,
+/// Replace the persisted `mls_groups` rows with exactly `groups`, deleting any
+/// existing row whose `group_id` is absent from it. `write_groups` callers
+/// always pass the complete current group list (see `MlsService::write_groups`),
+/// so a group missing here means it was removed (e.g. a voluntary leave) and
+/// must not survive as a stale, non-evicted row that sync would still pick up.
+fn replace_mls_groups_conn(
+    conn: &rusqlite::Connection,
     groups: &[crate::mls::MlsGroupMetadata],
 ) -> Result<(), String> {
-    let conn = crate::account_manager::get_db_connection(&handle)?;
+    let keep_ids: std::collections::HashSet<&str> =
+        groups.iter().map(|g| g.group_id.as_str()).collect();
+    let existing_ids: Vec<String> = conn
+        .prepare("SELECT group_id FROM mls_groups")
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| row.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .map_err(|e| format!("Failed to list existing MLS groups: {}", e))?;
+    for id in existing_ids {
+        if !keep_ids.contains(id.as_str()) {
+            conn.execute("DELETE FROM mls_groups WHERE group_id = ?1", rusqlite::params![id])
+                .map_err(|e| format!("Failed to remove stale MLS group {}: {}", id, e))?;
+        }
+    }
 
-    // Store each group in the mls_groups table (all fields as columns)
     for group in groups {
         conn.execute(
             "INSERT OR REPLACE INTO mls_groups (group_id, engine_group_id, creator_pubkey, name, avatar_ref, created_at, updated_at, evicted)
@@ -3934,6 +3954,24 @@ pub async fn save_mls_groups<R: Runtime>(
             ],
         ).map_err(|e| format!("Failed to save MLS group {}: {}", group.group_id, e))?;
     }
+
+    Ok(())
+}
+
+/// Save MLS groups to SQL database (plaintext columns). `groups` must be the
+/// complete current list; any existing row absent from it is deleted.
+pub async fn save_mls_groups<R: Runtime>(
+    handle: AppHandle<R>,
+    groups: &[crate::mls::MlsGroupMetadata],
+) -> Result<(), String> {
+    let mut conn = crate::account_manager::get_db_connection(&handle)?;
+
+    let tx = conn
+        .transaction()
+        .map_err(|e| format!("Failed to start mls_groups transaction: {}", e))?;
+    replace_mls_groups_conn(&tx, groups)?;
+    tx.commit()
+        .map_err(|e| format!("Failed to commit mls_groups transaction: {}", e))?;
 
     println!(
         "[SQL] Saved {} MLS groups to mls_groups table",
@@ -4336,6 +4374,67 @@ mod legacy_mls_store_harvest_tests {
 
         let removed = clear_discarded_giftwraps_conn(&conn, &[]).unwrap();
         assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn replace_mls_groups_conn_deletes_group_missing_from_new_list() {
+        let conn = in_memory_app_conn();
+        insert_mls_group(&conn, "group-a", "engine-a");
+        insert_mls_group(&conn, "group-b", "engine-b");
+
+        // Simulates `leave_group`: the caller re-passes its full list minus the left group.
+        let remaining = vec![crate::mls::MlsGroupMetadata {
+            group_id: "group-b".to_string(),
+            engine_group_id: "engine-b".to_string(),
+            creator_pubkey: "creator".to_string(),
+            name: "group".to_string(),
+            avatar_ref: None,
+            created_at: 1000,
+            updated_at: 2000,
+            evicted: false,
+        }];
+        replace_mls_groups_conn(&conn, &remaining).expect("replace");
+
+        let remaining_ids: Vec<String> = conn
+            .prepare("SELECT group_id FROM mls_groups ORDER BY group_id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            remaining_ids,
+            vec!["group-b".to_string()],
+            "leaving a group must delete its mls_groups row, not just skip re-upserting it"
+        );
+    }
+
+    #[test]
+    fn replace_mls_groups_conn_upserts_kept_group_fields() {
+        let conn = in_memory_app_conn();
+        insert_mls_group(&conn, "group-a", "engine-a");
+
+        let updated = vec![crate::mls::MlsGroupMetadata {
+            group_id: "group-a".to_string(),
+            engine_group_id: "engine-a".to_string(),
+            creator_pubkey: "creator".to_string(),
+            name: "renamed".to_string(),
+            avatar_ref: Some("avatar-ref".to_string()),
+            created_at: 1000,
+            updated_at: 9999,
+            evicted: false,
+        }];
+        replace_mls_groups_conn(&conn, &updated).expect("replace");
+
+        let (name, updated_at): (String, i64) = conn
+            .query_row(
+                "SELECT name, updated_at FROM mls_groups WHERE group_id = 'group-a'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(name, "renamed");
+        assert_eq!(updated_at, 9999);
     }
 }
 

--- a/src-tauri/src/mls.rs
+++ b/src-tauri/src/mls.rs
@@ -1225,6 +1225,34 @@ impl MlsService {
             .retain(|g| g.group_id != group_id && g.engine_group_id != group_meta.engine_group_id);
         self.write_groups(&groups).await?;
 
+        // Mirror cleanup_evicted_group(): drop the chat/messages and any stale
+        // cursor so a voluntary leave doesn't orphan rows for a group the app
+        // otherwise treats as gone. Use the canonical wire group_id (the id
+        // chats/cursors are keyed by), not whichever id form the caller passed.
+        let canonical_group_id = group_meta.group_id.clone();
+
+        {
+            let mut state = STATE.lock().await;
+            state.chats.retain(|c| c.id() != &canonical_group_id);
+        }
+
+        if let Some(handle) = TAURI_APP.get() {
+            if let Err(e) = crate::db::delete_chat(handle.clone(), &canonical_group_id).await {
+                eprintln!("[MLS] Failed to delete chat from storage: {}", e);
+            }
+        }
+
+        {
+            let mut cursors = self.read_event_cursors().await.unwrap_or_default();
+            let removed_wire = cursors.remove(&canonical_group_id).is_some();
+            let removed_engine = cursors.remove(&group_meta.engine_group_id).is_some();
+            if removed_wire || removed_engine {
+                if let Err(e) = self.write_event_cursors(&cursors).await {
+                    eprintln!("[MLS] Failed to remove cursor after leaving group: {}", e);
+                }
+            }
+        }
+
         // Emit event to refresh UI, and drop any stale "state lost" tracking —
         // the group is gone from the leaver's list entirely now, not merely
         // unsynced, so it should stop showing up in reset-state UI.


### PR DESCRIPTION
Leaving an MLS group only removed the local `mls_groups` metadata row; the channel's chat, its messages, and the group's Nostr event cursor stayed behind in the database and in-memory `STATE`, unlike the involuntary-eviction path (`cleanup_evicted_group`) which already handles all three. `MlsService::leave_group()` now mirrors that cleanup: drops the chat from `STATE.chats`, deletes the chat/message rows via `db::delete_chat`, and removes the stale `mls_event_cursors` entry (keyed by both the wire and engine group ids, since callers pass either).

Fixes #219

Validation: `cargo build --lib` and `cargo test --lib mls::` pass (13/13, 1 ignored requiring a live relay); `cargo fmt -- --check` shows no diff for the changed file.
