### PR TITLE
chore: isolate make dev's data dir per git branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 	@echo "Pacto — available make targets"
 	@echo ""
 	@echo "  install      install Node/Rust dependencies"
-	@echo "  dev          run the desktop app in development mode"
+	@echo "  dev          run the desktop app in development mode (auto-isolated per branch, except main)"
 	@echo "  dev-sandbox  run the desktop app against a throwaway account for MCP-driven UI verification"
 	@echo "  dev-account  run the desktop app against the persistent, reusable primary test account"
 	@echo "  dev-buddy    run the desktop app against the persistent, reusable secondary test account"
@@ -37,8 +37,22 @@ install:
 	pnpm install --frozen-lockfile
 	cd src-tauri && cargo fetch
 
+# Persistent per-branch data dir, so switching branches with different DB
+# migrations never trips the storage-format update gate (a newer branch's
+# schema blocking an older one, or vice versa). `main` keeps the real,
+# stable account at the OS-default location; every other branch gets its
+# own isolated, persistent test_fixtures/ dir keyed by branch name - not
+# swept by `make clean`; delete test_fixtures/ manually to reset.
 dev:
-	pnpm tauri dev
+	@branch=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached); \
+	if [ "$$branch" = "main" ]; then \
+		pnpm tauri dev; \
+	else \
+		slug=$$(printf '%s' "$$branch" | tr -c 'A-Za-z0-9_.-' '-'); \
+		mkdir -p test_fixtures; \
+		echo "make dev: branch '$$branch' -> isolated data dir test_fixtures/dev-branch-$$slug"; \
+		PACTO_TEST_SANDBOX_ROOT="$(CURDIR)/test_fixtures/dev-branch-$$slug" pnpm tauri dev; \
+	fi
 
 # Isolated sandbox account for agent-driven MCP verification (docs/TAURI_MCP_INTEGRATION.md).
 # Avoids colliding with a real dev account whose PIN nobody remembers.

--- a/docs/build/OPERATOR_UPDATES.md
+++ b/docs/build/OPERATOR_UPDATES.md
@@ -170,6 +170,8 @@ The block screen deliberately does not show which npub or file path is at fault,
 4. The one profile whose `version` matches the number from the block screen is the offender. Move that single directory aside (e.g. rename `npub1…` to `npub1…-quarantined`) — do not delete it.
 5. Relaunch the app. Every other account on the machine unblocks immediately; the moved-aside profile no longer participates in account discovery until it is restored (e.g. by a build that recognizes its schema).
 
+**Local dev cause and prevention:** the most common local trigger isn't a shipped release at all — it's checking out a branch with newer migrations, running it against your primary account, then switching back to a branch that doesn't have those migrations yet. `make dev` isolates its data directory per git branch automatically (except `main`, which keeps the OS-default account unchanged), so this can't happen from branch-hopping; see `Makefile`'s `dev` target.
+
 ## Limits of this gate
 
 - **The manifest is unsigned.** `latest.json`, including `minimum_compatible_version`, carries no signature — only the platform installers themselves are Ed25519-signed. Anyone who can write to the release's assets can alter the manifest.


### PR DESCRIPTION
## Summary

`make dev` used a single shared local data directory regardless of git branch. Switching branches with different local database migrations tripped the storage-format update gate: a newer branch's schema, once written to that shared account, blocked an older branch's build from opening the same data — every account on the machine, not just one.

`make dev` now derives its `PACTO_TEST_SANDBOX_ROOT` from the current git branch. Data stays persistent (you still get a real account to look at, unlike the throwaway `dev-sandbox` target) but is isolated per branch, so branch-hopping can never trip the gate again. `main` is a deliberate exception — it keeps using the real OS app-data directory, so the existing dev account and PIN nobody wants to lose keep working exactly as before.

## Changes

- `Makefile`: `dev` target branches on `git rev-parse --abbrev-ref HEAD`; non-`main` branches get `test_fixtures/dev-branch-<slug>` (persistent, not swept by `make clean`).
- `docs/build/OPERATOR_UPDATES.md`: added a prevention note to the existing storage-format-gate recovery section pointing at this behavior.

## Test plan

- `make -n dev` dry-run confirms correct expansion for both the `main` and non-`main` branches.
- Verified branch-name sanitization (slashes, spaces) produces a clean filesystem-safe slug with no stray trailing characters.

## Follow-up

This is a stopgap, not the full fix. It doesn't solve running two `make dev` instances concurrently across worktrees (fixed `strictPort` Vite ports at 1420/1421 still block that), and a fresh worktree/branch still starts from an empty account. Tracked in #237.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)