### PR TITLE
Let dev-login sandboxes act: mark the identity backup-verified

### DIFF
--- a/src-tauri/src/dev_login.rs
+++ b/src-tauri/src/dev_login.rs
@@ -126,6 +126,23 @@ async fn login_backend_depth<R: Runtime>(
     }))
 }
 
+/// A dev identity's recovery phrase comes from a committed recipe or the
+/// launcher's own environment, so it is public by construction and there is
+/// nothing to back up. Leaving the flag unset would still gate every action
+/// behind `requireBackupVerified()` - accepting a squad invite among them -
+/// which silently no-ops and costs the sandbox its zero-keystroke boot.
+///
+/// Key and value must match the reader in `src/lib/api/settings.ts`.
+fn mark_backup_verified<R: Runtime>(handle: &AppHandle<R>) {
+    if let Err(e) = crate::db::set_sql_setting(
+        handle.clone(),
+        "backup_verified".to_string(),
+        "true".to_string(),
+    ) {
+        eprintln!("[dev_login] could not mark backup verified: {e}");
+    }
+}
+
 /// Full depth: a real recovery-phrase login through the existing login
 /// path, with real PIN-encrypted credentials persisted the same way
 /// `createAccount`/`importAccount` do, and the connection opened.
@@ -173,6 +190,7 @@ async fn login_full_depth<R: Runtime>(
         == Some(npub.as_str())
         && crate::get_nostr_client().is_ok()
     {
+        mark_backup_verified(&handle);
         let _ = crate::sandbox_handle::record_npub(&npub);
         return Ok(serde_json::json!({ "success": true, "npub": npub }));
     }
@@ -209,6 +227,7 @@ async fn login_full_depth<R: Runtime>(
         crate::db::set_evm_address(handle.clone(), evm_address).await?;
     }
 
+    mark_backup_verified(&handle);
     let _ = crate::sandbox_handle::record_npub(&keypair.public);
     Ok(serde_json::json!({ "success": true, "npub": keypair.public }))
 }


### PR DESCRIPTION
## The symptom

A sandbox booted with `PACTO_DEV_LOGIN_MNEMONIC` lands authenticated — and then **silently refuses to do anything** gated on `requireBackupVerified()`.

Accepting a squad invite is one of those. Observed live: the **Accept** click returned nothing, `list_mls_groups` stayed empty, and the invite sat there pending. No error, no toast — `requireBackupVerified()` returns `false`, flips a modal flag, and the caller just returns.

```ts
export function requireBackupVerified(): boolean {
  if (isBackupVerified()) return true;
  backupVerificationModalOpen.set(true);
  return false;
}
```

## Why marking it is correct, not a bypass

The gate is right for a human: they have a recovery phrase worth protecting, and losing it loses the account.

It is meaningless for a dev identity. The phrase comes from a committed recipe or the launcher's own environment — **it is public by construction and there is nothing to back up.** Leaving the flag unset protects nothing; it just costs the sandbox the zero-keystroke boot U5 exists to provide.

## Scope

Both `login_full_depth` exits set it — the fresh login *and* the idempotent re-login that adopts an already-open session — so a relaunched sandbox isn't silently different from a first-run one.

Debug-only by construction: `dev_login` is `#[cfg(debug_assertions)]` **and** gated on `PACTO_ALLOW_TEST_AUTH`, so no release path reaches this. `make release-symbol-check` still passes.

17 lines, one file.

## Verification

Live, against the local stack with the sandbox pointed only at `wss://localhost:7001`:

1. Boot → `sqlite3 pacto.db "select value from settings where key='backup_verified'"` → `true`
2. Bot creates a squad and sends the real `squad_invite` DM
3. App renders it under **DMs → Requests**: *"invited you to join this squad"*
4. **Accept** — the same click that previously no-opped — joins the group and materializes the squad with its default channels (`squad-dashboard`, `my-dashboard`, `announcements`, `polls`)

Repeated on a second, brand-new identity to confirm it isn't state-dependent.

`cargo test --lib dev_login` 6 passed, `cargo fmt --check` clean, `make release-symbol-check` OK.

## Context

This is the one app-side change needed for the **orchestrator-side** resolution of `pacto-app-384.70`: the dev world sends the app's real DM invite so a sandbox joins exactly the way a human does, rather than the app growing a second join path for bare MLS welcomes. The trust boundary there — a visible, refusable invite — is deliberately left intact.

Companion: pacto-dev-env `make invite-squad`.