### PR TITLE
fix: make the sandbox port claim atomic across concurrent launches

### DIFF
--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 /**
- * Branch-hashed dev port set (U3). Pure ESM, no deps beyond node:net so the
- * mapping is identical and hand-reproducible on macOS and Linux.
+ * Branch-hashed dev port set (U3). Pure ESM, no deps beyond node: builtins so
+ * the mapping is identical and hand-reproducible on macOS and Linux.
  *
  * `main` always resolves to index 0 and today's exact ports (1420/1421/9223).
  * Every other branch derives an index from an FNV-1a 32-bit hash of its
- * slug, then probes real listeners before claiming it so two worktrees
- * landing on the same index never collide.
+ * slug, then atomically claims it (see claimIndex below) and probes real
+ * listeners before returning it, so two worktrees landing on the same index
+ * never collide -- even when they resolve at the same instant and neither
+ * has bound a socket yet.
  */
 
 import net from 'node:net';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -29,6 +32,23 @@ const PORT_STRIDE = 10;
 const BRIDGE_STRIDE = 100;
 
 const HANDLE_FILE_NAME = 'sandbox-handle.json';
+
+// Shared across every worktree on this machine so two agents in two
+// worktrees -- which is the whole point -- coordinate through the same
+// claim set even though their sandbox roots live in different directories.
+const DEFAULT_CLAIM_DIR = path.join(os.tmpdir(), 'pacto-dev-ports-claims');
+
+// How long a claim is honored after being written even if the process that
+// wrote it has already exited. See isClaimStale for why this exists: the
+// process that resolves a port set is almost always short-lived (the
+// Makefile's `node dev-ports.mjs --export` invocation prints its exports
+// and exits in milliseconds) and exits long before the app it kicks off
+// finishes compiling and actually binds a socket. 180s mirrors
+// dev-world.sh's own PACTO_DEV_WORLD_APP_TIMEOUT default -- the
+// orchestrator's own idea of how long a launch reasonably takes to bind and
+// come up -- so a claim survives at least as long as a launch the
+// orchestrator itself would still consider "in flight".
+const DEFAULT_CLAIM_GRACE_MS = 180_000;
 
 /**
  * Branch name -> filesystem/URL-safe slug.
@@ -102,16 +122,161 @@ function defaultBranch() {
   }
 }
 
+/** @param {string} claimDir @param {number} index @returns {string} */
+function claimPath(claimDir, index) {
+  return path.join(claimDir, `index-${index}.claim.json`);
+}
+
+/** @param {unknown} pid @returns {boolean} */
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the pid exists but is owned by someone else -- still alive.
+    return err.code === 'EPERM';
+  }
+}
+
+/**
+ * True when a claim record on disk no longer reflects a real, in-flight
+ * owner and the index can be handed to someone else.
+ *
+ * The recorded pid is whichever process called resolvePortSet. For the
+ * common path -- the Makefile's `node dev-ports.mjs --export` -- that
+ * process prints its exports and exits within milliseconds, long before the
+ * `pnpm tauri dev` it kicked off finishes compiling and actually binds the
+ * ports. So "is that pid alive" is not a usable *immediate* staleness
+ * signal on that path: it would go stale within milliseconds of every
+ * legitimate launch, right when the claim matters most. It only pays off
+ * for a caller that itself stays alive for the sandbox's whole lifetime
+ * (e.g. an in-process script that resolves ports and then awaits the app it
+ * spawned) -- for that caller pid liveness is exact and never times out.
+ *
+ * So a claim is stale only when *both* signals say so: the recorded pid is
+ * not alive, and the claim is older than the grace window that covers the
+ * resolve -> bind gap for the short-lived-resolver path. Once an app has
+ * really bound its ports, occupancy is re-verified for real by
+ * allPortsFree()'s live socket probe regardless of what this file says, so
+ * an over-eager reclaim here can never hand out a port that's genuinely in
+ * use -- worst case it churns the claim file and the probe sends the taker
+ * to the next index instead.
+ *
+ * @param {{ pid?: number, resolvedAt?: number }} record
+ * @param {number} graceMs
+ * @returns {boolean}
+ */
+function isClaimStale(record, graceMs) {
+  if (isPidAlive(record.pid)) return false;
+  const age = Date.now() - Number(record.resolvedAt);
+  return !(Number.isFinite(age) && age >= 0 && age < graceMs);
+}
+
+/** @param {string} filePath @returns {Record<string, unknown> | null} */
+function readClaim(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    // Missing, unreadable, or mid-write from a racing claimant -- treat the
+    // same as "no live claim here".
+    return null;
+  }
+}
+
+/** @param {string} filePath @param {Record<string, unknown>} record */
+function writeClaimExclusive(filePath, record) {
+  // O_EXCL is what makes this atomic: of any number of processes racing to
+  // create the same path, the OS guarantees exactly one open() succeeds.
+  const fd = fs.openSync(filePath, 'wx');
+  try {
+    fs.writeSync(fd, JSON.stringify(record));
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Atomically claim `index` for the current process. Returns true iff this
+ * call now owns the claim file for that index.
+ *
+ * A claim always succeeds when it doesn't exist yet, or when the existing
+ * claim already belongs to this same branch -- re-resolving your own branch
+ * (e.g. dev-world.sh's retry-on-dead-stream loop, which waits for the old
+ * app to actually die and then calls `make dev-sandbox` a second time) must
+ * reclaim its own deterministic index immediately, not sit out the grace
+ * window, or a same-branch restart would silently jump to a different port
+ * set. A claim held by a *different* branch is only taken over once
+ * isClaimStale says so.
+ *
+ * @param {string} claimDir
+ * @param {number} index
+ * @param {string} branch
+ * @param {number} graceMs
+ * @returns {boolean}
+ */
+function claimIndex(claimDir, index, branch, graceMs) {
+  fs.mkdirSync(claimDir, { recursive: true });
+  const target = claimPath(claimDir, index);
+  const record = { pid: process.pid, branch, resolvedAt: Date.now() };
+
+  try {
+    writeClaimExclusive(target, record);
+    return true;
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+
+  const existing = readClaim(target);
+  const ownedBySameBranch = existing && existing.branch === branch;
+  if (existing && !ownedBySameBranch && !isClaimStale(existing, graceMs)) {
+    return false; // live claim held by a different branch
+  }
+
+  // Stale, unreadable, or ours to reclaim: take it over. The unlink is
+  // best-effort -- another racer may already have removed it -- the
+  // exclusive create right after is what actually decides the single
+  // winner when several processes reach this point at once.
+  try {
+    fs.unlinkSync(target);
+  } catch {
+    /* already gone */
+  }
+  try {
+    writeClaimExclusive(target, record);
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') return false; // someone else won the takeover race
+    throw err;
+  }
+}
+
+/** @param {string} claimDir @param {number} index */
+function releaseClaim(claimDir, index) {
+  try {
+    fs.unlinkSync(claimPath(claimDir, index));
+  } catch {
+    /* already gone */
+  }
+}
+
 /**
  * Resolve the port set for a branch. Derives the index, then (unless
- * `probe: false`) binds real listeners to confirm every port is free,
- * advancing to the next index on occupancy. `main` never advances — its
- * ports are pinned so `make dev` on `main` keeps behaving exactly as today.
+ * `probe: false`) atomically claims it and confirms with real listeners
+ * that it's actually free, advancing to the next index when either check
+ * fails. `main` never advances -- its ports are pinned so `make dev` on
+ * `main` keeps behaving exactly as today.
  *
- * @param {{ branch?: string, probe?: boolean, maxIndex?: number }} [options]
+ * @param {{ branch?: string, probe?: boolean, maxIndex?: number, claimDir?: string, claimGraceMs?: number }} [options]
  * @returns {Promise<{ index: number, derivedIndex: number, advanced: boolean, ports: { devServer: number, hmr: number, mcpBridge: number } }>}
  */
-export async function resolvePortSet({ branch, probe = true, maxIndex = MAX_INDEX } = {}) {
+export async function resolvePortSet({
+  branch,
+  probe = true,
+  maxIndex = MAX_INDEX,
+  claimDir = DEFAULT_CLAIM_DIR,
+  claimGraceMs = DEFAULT_CLAIM_GRACE_MS,
+} = {}) {
   const resolvedBranch = branch ?? defaultBranch();
   const derivedIndex = deriveIndex(resolvedBranch);
 
@@ -127,8 +292,14 @@ export async function resolvePortSet({ branch, probe = true, maxIndex = MAX_INDE
   let index = derivedIndex > maxIndex ? 1 + ((derivedIndex - 1) % maxIndex) : derivedIndex;
   for (let attempts = 0; attempts <= maxIndex; attempts++) {
     const ports = portsForIndex(index);
-    if (await allPortsFree(ports)) {
-      return { index, derivedIndex, advanced: index !== derivedIndex, ports };
+    if (claimIndex(claimDir, index, resolvedBranch, claimGraceMs)) {
+      if (await allPortsFree(ports)) {
+        return { index, derivedIndex, advanced: index !== derivedIndex, ports };
+      }
+      // Something outside the claim system already holds these sockets
+      // (or a prior, unmanaged run left them bound) -- we don't actually
+      // own this index, so don't leave a phantom claim behind.
+      releaseClaim(claimDir, index);
     }
     index = index >= maxIndex ? 1 : index + 1;
   }
@@ -160,8 +331,10 @@ async function cli() {
   const branchFlagIndex = args.indexOf('--branch');
   const branch = branchFlagIndex >= 0 ? args[branchFlagIndex + 1] : undefined;
   const probe = !args.includes('--no-probe');
+  const claimDirFlagIndex = args.indexOf('--claim-dir');
+  const claimDir = claimDirFlagIndex >= 0 ? args[claimDirFlagIndex + 1] : undefined;
 
-  const result = await resolvePortSet({ branch, probe });
+  const result = await resolvePortSet({ branch, probe, ...(claimDir ? { claimDir } : {}) });
 
   if (args.includes('--export')) {
     console.log(`export PACTO_DEV_PORT_INDEX=${result.index}`);

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -129,13 +129,13 @@ function claimPath(claimDir, index) {
 
 /** @param {unknown} pid @returns {boolean} */
 function isPidAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
   } catch (err) {
     // EPERM means the pid exists but is owned by someone else -- still alive.
-    return err.code === 'EPERM';
+    return /** @type {NodeJS.ErrnoException} */ (err).code === 'EPERM';
   }
 }
 
@@ -224,7 +224,7 @@ function claimIndex(claimDir, index, branch, graceMs) {
     writeClaimExclusive(target, record);
     return true;
   } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
+    if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'EEXIST') throw err;
   }
 
   const existing = readClaim(target);
@@ -246,7 +246,8 @@ function claimIndex(claimDir, index, branch, graceMs) {
     writeClaimExclusive(target, record);
     return true;
   } catch (err) {
-    if (err.code === 'EEXIST') return false; // someone else won the takeover race
+    // someone else won the takeover race
+    if (/** @type {NodeJS.ErrnoException} */ (err).code === 'EEXIST') return false;
     throw err;
   }
 }

--- a/src/lib/dev/dev-ports.test.ts
+++ b/src/lib/dev/dev-ports.test.ts
@@ -3,6 +3,8 @@ import net from 'node:net';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import {
   slugForBranch,
   deriveIndex,
@@ -10,6 +12,8 @@ import {
   resolvePortSet,
   readSandboxHandle,
 } from '../../../scripts/dev-ports.mjs';
+
+const SCRIPT_PATH = fileURLToPath(new URL('../../../scripts/dev-ports.mjs', import.meta.url));
 
 function listen(port: number): Promise<net.Server> {
   const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
@@ -25,6 +29,38 @@ function close(server: net.Server): Promise<void> {
   return promise;
 }
 
+type PortSetResult = {
+  index: number;
+  derivedIndex: number;
+  advanced: boolean;
+  ports: { devServer: number; hmr: number; mcpBridge: number };
+};
+
+/** Runs the real CLI as its own OS process -- genuine cross-process concurrency. */
+function runDevPortsCli(branch: string, claimDir: string): Promise<PortSetResult> {
+  const { promise, resolve, reject } = Promise.withResolvers<PortSetResult>();
+  const child = spawn(process.execPath, [SCRIPT_PATH, '--branch', branch, '--claim-dir', claimDir], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', chunk => (stdout += chunk));
+  child.stderr.on('data', chunk => (stderr += chunk));
+  child.on('error', reject);
+  child.on('close', code => {
+    if (code !== 0) {
+      reject(new Error(`dev-ports.mjs --branch ${branch} exited ${code}: ${stderr}`));
+      return;
+    }
+    try {
+      resolve(JSON.parse(stdout.trim()));
+    } catch {
+      reject(new Error(`dev-ports.mjs --branch ${branch} produced unparseable output: ${stdout}`));
+    }
+  });
+  return promise;
+}
+
 describe('dev-ports', () => {
   const tempDirs: string[] = [];
 
@@ -33,6 +69,12 @@ describe('dev-ports', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  function makeTempDir(prefix = 'pacto-dev-ports-test-'): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
 
   describe('deriveIndex', () => {
     it('is stable across repeated derivations of the same branch', () => {
@@ -78,19 +120,24 @@ describe('dev-ports', () => {
   });
 
   describe('resolvePortSet', () => {
-    it('main resolves to index 0 with today\'s exact ports, unprobed', async () => {
-      const result = await resolvePortSet({ branch: 'main', probe: false });
+    it('main resolves to index 0 with today\'s exact ports, unprobed, and claims nothing', async () => {
+      const claimDir = makeTempDir();
+      const result = await resolvePortSet({ branch: 'main', probe: false, claimDir });
       expect(result).toEqual({
         index: 0,
         derivedIndex: 0,
         advanced: false,
         ports: { devServer: 1420, hmr: 1421, mcpBridge: 9223 },
       });
+      // main never probes and never claims -- no claim directory is even
+      // created for it.
+      expect(fs.existsSync(claimDir) && fs.readdirSync(claimDir).length > 0).toBe(false);
     });
 
     it('claims the derived index untouched when its ports are free', async () => {
+      const claimDir = makeTempDir();
       const branch = 'feat/parallel-agent-sandboxes-wave-1';
-      const result = await resolvePortSet({ branch, probe: true });
+      const result = await resolvePortSet({ branch, probe: true, claimDir });
       expect(result.derivedIndex).toBe(12);
       expect(result.index).toBe(12);
       expect(result.advanced).toBe(false);
@@ -98,13 +145,14 @@ describe('dev-ports', () => {
     });
 
     it('advances past an occupied derived index and reports advanced: true', async () => {
+      const claimDir = makeTempDir();
       const branch = 'fix/issue-237';
       const derivedIndex = deriveIndex(branch);
       const derivedPorts = portsForIndex(derivedIndex);
 
       const blocker = await listen(derivedPorts.devServer);
       try {
-        const result = await resolvePortSet({ branch, probe: true });
+        const result = await resolvePortSet({ branch, probe: true, claimDir });
         expect(result.derivedIndex).toBe(derivedIndex);
         expect(result.index).not.toBe(derivedIndex);
         expect(result.advanced).toBe(true);
@@ -115,26 +163,107 @@ describe('dev-ports', () => {
     });
 
     it('throws naming the exhausted range when every candidate index is occupied', async () => {
+      const claimDir = makeTempDir();
       const branch = 'agent-worktree-b'; // derives to index 10
       const maxIndex = 2; // shrink the range so occupying 1 and 2 exhausts it
       const blockers = await Promise.all(
         [1, 2].map(index => listen(portsForIndex(index).devServer))
       );
       try {
-        await expect(resolvePortSet({ branch, probe: true, maxIndex })).rejects.toThrow(/1\.\.=2/);
+        await expect(resolvePortSet({ branch, probe: true, maxIndex, claimDir })).rejects.toThrow(
+          /1\.\.=2/
+        );
       } finally {
         await Promise.all(blockers.map(close));
       }
     });
+
+    it('does not steal a live claim held by a different branch, and advances past it', async () => {
+      const claimDir = makeTempDir();
+      const branch = 'agent-worktree-a'; // derives to index 26
+      const index = deriveIndex(branch);
+      fs.mkdirSync(claimDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claimDir, `index-${index}.claim.json`),
+        JSON.stringify({ pid: process.pid, branch: 'someone-elses-branch', resolvedAt: Date.now() })
+      );
+
+      const result = await resolvePortSet({ branch, probe: true, claimDir });
+      expect(result.index).not.toBe(index);
+      expect(result.advanced).toBe(true);
+    });
+
+    it('reclaims a stale claim left by a dead process instead of poisoning the index forever', async () => {
+      const claimDir = makeTempDir();
+      const branch = 'agent-worktree-a'; // derives to index 26
+      const index = deriveIndex(branch);
+      fs.mkdirSync(claimDir, { recursive: true });
+      // A pid that cannot possibly be alive, recorded by a different branch,
+      // with a grace window so short that "just resolved" cannot save it --
+      // this is what a sandbox left behind by a SIGKILL (or a dev-world-
+      // reclaim run, which only ever kills the app pid and never touches
+      // this claim file) looks like well after the fact.
+      fs.writeFileSync(
+        path.join(claimDir, `index-${index}.claim.json`),
+        JSON.stringify({
+          pid: 999999999,
+          branch: 'a-completely-different-branch',
+          resolvedAt: Date.now() - 60_000,
+        })
+      );
+
+      const result = await resolvePortSet({ branch, probe: true, claimDir, claimGraceMs: 1 });
+      expect(result.index).toBe(index);
+      expect(result.advanced).toBe(false);
+      expect(result.ports).toEqual(portsForIndex(index));
+
+      // The index is takeable again by yet another later run too -- the
+      // claim was replaced, not permanently wedged.
+      const claimAfter = JSON.parse(
+        fs.readFileSync(path.join(claimDir, `index-${index}.claim.json`), 'utf8')
+      );
+      expect(claimAfter.pid).toBe(process.pid);
+    });
+
+    it(
+      'never hands the same index to two concurrently-resolving sandboxes (pacto-app-384.76)',
+      async () => {
+        const claimDir = makeTempDir();
+        // Eight distinct branch names that really do hash-collide onto the
+        // same starting index -- the exact "two launches racing the same
+        // branch index" scenario from the bug report, just with eight
+        // racers instead of two. If this ever stops being a real collision
+        // (e.g. the hash changes), the assertion below catches it instead
+        // of silently testing nothing.
+        const branches = [
+          'agent-worktree-collide-21',
+          'agent-worktree-collide-59',
+          'agent-worktree-collide-81',
+          'agent-worktree-collide-95',
+          'agent-worktree-collide-134',
+          'agent-worktree-collide-142',
+          'agent-worktree-collide-154',
+          'agent-worktree-collide-178',
+        ];
+        const derived = new Set(branches.map(deriveIndex));
+        expect(derived.size).toBe(1);
+
+        // Real OS-process concurrency, not same-process Promise.all: each
+        // branch resolves in its own `node dev-ports.mjs` invocation, just
+        // like the Makefile spawns one per `make dev-sandbox` call.
+        const results = await Promise.all(branches.map(branch => runDevPortsCli(branch, claimDir)));
+
+        const indices = results.map(r => r.index);
+        expect(new Set(indices).size).toBe(branches.length);
+        for (const result of results) {
+          expect(result.ports).toEqual(portsForIndex(result.index));
+        }
+      },
+      30_000
+    );
   });
 
   describe('readSandboxHandle', () => {
-    function makeTempDir(): string {
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pacto-dev-ports-test-'));
-      tempDirs.push(dir);
-      return dir;
-    }
-
     it('returns null when no handle file exists', () => {
       const dir = makeTempDir();
       expect(readSandboxHandle(dir)).toBeNull();

--- a/src/lib/dev/dev-ports.test.ts
+++ b/src/lib/dev/dev-ports.test.ts
@@ -226,7 +226,7 @@ describe('dev-ports', () => {
     });
 
     it(
-      'never hands the same index to two concurrently-resolving sandboxes (pacto-app-384.76)',
+      'never hands the same index to two concurrently-resolving sandboxes',
       async () => {
         const claimDir = makeTempDir();
         // Eight distinct branch names that really do hash-collide onto the


### PR DESCRIPTION
## Summary

Two sandboxes launching at the same time could be handed the same port set. The occupancy probe bound a listener, **closed it**, and returned the index — proving the port was free a moment ago, never that the caller now owns it. Two launches racing the same branch index both saw it free, both took it, and both bound for real seconds later when their app processes started.

- **Before:** eight concurrent resolutions for branches that hash to the same index all returned that one index — 1 distinct out of 8.
- **After:** they return eight distinct indices.

This is the isolation guarantee the parallel-agent sandbox work rests on: two agents in two worktrees must each land in their own sandbox without colliding.

## Changes

- The candidate index is now claimed atomically with an `O_EXCL` create before the physical probe, so the OS picks exactly one winner per race. The probe still runs and still advances on genuine occupancy, so existing behavior and its tests are preserved.
- Staleness requires **both** a dead recorded pid and an expired grace window. Pid-liveness alone is not sufficient and would have recreated the very race being fixed: the process that resolves ports exits within milliseconds, long before the app it launches finishes compiling and binds a socket.
- A claim held by the same branch is reclaimable immediately, so the existing kill-and-relaunch retry path gets its own deterministic index back rather than drifting to a different port set.
- `main` is untouched: index 0, ports 1420/1421/9223, no probe and no claim file.

No `pacto-dev-env` changes. Reclaim there releases an index by terminating the recorded pid and knows nothing about claim files; once that pid is dead the sockets are free, which the probe independently re-verifies, so a reclaim can never cause a collision even before the claim itself ages out.

## Test plan

- `pnpm test src/lib/dev/dev-ports.test.ts` — 16 passed.
- The concurrency test spawns eight real OS processes on deliberately hash-colliding branch names; it reports 1 distinct index against the old implementation and 8 against the new one.
- Further tests cover stale-claim reclamation, refusal to steal a live claim held by another branch, and `main`'s pinned ports.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
