### PR TITLE
fix: let two dev sandboxes run at once

### DIFF
--- a/docs/build/DEV_SANDBOX.md
+++ b/docs/build/DEV_SANDBOX.md
@@ -12,6 +12,13 @@ replace the normal Tauri paths everywhere account, profile, database, and
 cache state is read or written — nothing under that root touches the
 machine's real profile.
 
+A configured root also relaxes the single-instance guard — debug builds
+only — so parallel sandboxes can run side by side; a release build always
+registers the guard (`multi_instance_allowed`). Note this applies to any
+non-`main` `make dev` too, since that target sets a per-branch root. Two
+processes sharing *one* root are not prevented; each concurrent instance
+needs its own root.
+
 Used today by the per-branch `make dev` target so concurrent worktrees never
 share an account. See `src-tauri/src/test_sandbox.rs` (`sandbox_root`,
 `test_data_dir`, `test_local_data_dir`).

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -261,16 +261,17 @@ function releaseClaim(claimDir, index) {
   }
 }
 
-// Ports browser engines refuse outright: Chromium fails them with
-// ERR_UNSAFE_PORT and WebKit keeps the same legacy-protocol blocklist, so a
-// dev server bound to one serves curl fine while the webview silently renders
-// a blank page. An index whose ports land here is unusable regardless of what
-// the OS says about occupancy. With this file's strides the only in-range hit
-// is index 30 (devServer 1720, hmr 1721 -- the H.323 cluster), but the whole
-// list is checked so a stride change cannot quietly reintroduce the bug.
+// Ports browsers refuse outright: the WHATWG fetch bad-port list (Chromium's
+// ERR_UNSAFE_PORT, same list in WebKit), so a dev server bound to one serves
+// curl fine while the webview silently renders a blank page. An index whose
+// ports land here is unusable regardless of what the OS says about occupancy.
+// With this file's bases and strides the only in-range hit is index 30
+// (devServer 1720 -- H.323). Only the spec entries at or above this file's
+// lowest derivable port (1420) are listed; extend downward if a base ever
+// drops below that.
 const UNSAFE_BROWSER_PORTS = new Set([
-  1719, 1720, 1721, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
-  6697, 10080,
+  1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
+  6679, 6697, 10080,
 ]);
 
 /**
@@ -289,11 +290,12 @@ export function browserSafeIndex(index) {
 }
 
 /**
- * Resolve the port set for a branch. Derives the index, then (unless
- * `probe: false`) atomically claims it and confirms with real listeners
- * that it's actually free, advancing to the next index when either check
- * fails. `main` never advances -- its ports are pinned so `make dev` on
- * `main` keeps behaving exactly as today.
+ * Resolve the port set for a branch. Derives the index, then skips any index
+ * whose ports a browser refuses to fetch from, then (unless `probe: false`)
+ * atomically claims it and confirms with real listeners that it's actually
+ * free, advancing to the next index when any check fails. `main` never
+ * advances -- its ports are pinned (and browser-safe by construction) so
+ * `make dev` on `main` keeps behaving exactly as today.
  *
  * @param {{ branch?: string, probe?: boolean, maxIndex?: number, claimDir?: string, claimGraceMs?: number }} [options]
  * @returns {Promise<{ index: number, derivedIndex: number, advanced: boolean, ports: { devServer: number, hmr: number, mcpBridge: number } }>}
@@ -310,8 +312,17 @@ export async function resolvePortSet({
 
   if (!probe || resolvedBranch === MAIN_BRANCH) {
     let index = derivedIndex;
-    for (let attempts = 0; !browserSafeIndex(index) && attempts <= maxIndex; attempts++) {
-      index = index >= maxIndex ? 1 : index + 1;
+    if (resolvedBranch !== MAIN_BRANCH) {
+      let attempts = 0;
+      for (; !browserSafeIndex(index) && attempts <= maxIndex; attempts++) {
+        index = index >= maxIndex ? 1 : index + 1;
+      }
+      if (!browserSafeIndex(index)) {
+        throw new Error(
+          `every port index from 1 to ${maxIndex} derives a browser-refused port; ` +
+            `check UNSAFE_BROWSER_PORTS against the port bases and strides`
+        );
+      }
     }
     return {
       index,

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -261,6 +261,33 @@ function releaseClaim(claimDir, index) {
   }
 }
 
+// Ports browser engines refuse outright: Chromium fails them with
+// ERR_UNSAFE_PORT and WebKit keeps the same legacy-protocol blocklist, so a
+// dev server bound to one serves curl fine while the webview silently renders
+// a blank page. An index whose ports land here is unusable regardless of what
+// the OS says about occupancy. With this file's strides the only in-range hit
+// is index 30 (devServer 1720, hmr 1721 -- the H.323 cluster), but the whole
+// list is checked so a stride change cannot quietly reintroduce the bug.
+const UNSAFE_BROWSER_PORTS = new Set([
+  1719, 1720, 1721, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
+  6697, 10080,
+]);
+
+/**
+ * True when every port this index derives is one a browser engine will
+ * actually fetch from.
+ * @param {number} index
+ * @returns {boolean}
+ */
+export function browserSafeIndex(index) {
+  const ports = portsForIndex(index);
+  return (
+    !UNSAFE_BROWSER_PORTS.has(ports.devServer) &&
+    !UNSAFE_BROWSER_PORTS.has(ports.hmr) &&
+    !UNSAFE_BROWSER_PORTS.has(ports.mcpBridge)
+  );
+}
+
 /**
  * Resolve the port set for a branch. Derives the index, then (unless
  * `probe: false`) atomically claims it and confirms with real listeners
@@ -282,16 +309,24 @@ export async function resolvePortSet({
   const derivedIndex = deriveIndex(resolvedBranch);
 
   if (!probe || resolvedBranch === MAIN_BRANCH) {
+    let index = derivedIndex;
+    for (let attempts = 0; !browserSafeIndex(index) && attempts <= maxIndex; attempts++) {
+      index = index >= maxIndex ? 1 : index + 1;
+    }
     return {
-      index: derivedIndex,
+      index,
       derivedIndex,
-      advanced: false,
-      ports: portsForIndex(derivedIndex),
+      advanced: index !== derivedIndex,
+      ports: portsForIndex(index),
     };
   }
 
   let index = derivedIndex > maxIndex ? 1 + ((derivedIndex - 1) % maxIndex) : derivedIndex;
   for (let attempts = 0; attempts <= maxIndex; attempts++) {
+    if (!browserSafeIndex(index)) {
+      index = index >= maxIndex ? 1 : index + 1;
+      continue;
+    }
     const ports = portsForIndex(index);
     if (claimIndex(claimDir, index, resolvedBranch, claimGraceMs)) {
       if (await allPortsFree(ports)) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9101,22 +9101,33 @@ pub fn run() {
                 .build(),
         );
 
-        // Single-instance plugin: ensures deep links are passed to existing instance
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // Handle deep links from single-instance (Windows/Linux)
-            let urls: Vec<String> = args
-                .iter()
-                .filter(|arg| arg.starts_with("vector://") || arg.contains("vectorapp.io"))
-                .cloned()
-                .collect();
-            if !urls.is_empty() {
-                deep_link::handle_deep_link(app, urls);
-            }
-            // Focus the existing window
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_focus();
-            }
-        }));
+        // Single-instance plugin: ensures deep links are passed to existing instance.
+        //
+        // Skipped for a dev sandbox. The guard is keyed on the app identifier, so it
+        // cannot tell two sandboxes apart: the second one hands its argv to the first
+        // and exits, which surfaces as an app that writes its handle, starts its
+        // bridge, and then never logs in. Parallel agent sandboxes are separate
+        // accounts in separate data directories and must run side by side.
+        //
+        // `multi_instance_allowed` is debug-only, so a release build always registers
+        // the plugin no matter what the environment says.
+        if !crate::test_sandbox::multi_instance_allowed() {
+            builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+                // Handle deep links from single-instance (Windows/Linux)
+                let urls: Vec<String> = args
+                    .iter()
+                    .filter(|arg| arg.starts_with("vector://") || arg.contains("vectorapp.io"))
+                    .cloned()
+                    .collect();
+                if !urls.is_empty() {
+                    deep_link::handle_deep_link(app, urls);
+                }
+                // Focus the existing window
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_focus();
+                }
+            }));
+        }
     }
 
     builder

--- a/src-tauri/src/test_sandbox.rs
+++ b/src-tauri/src/test_sandbox.rs
@@ -294,7 +294,7 @@ mod tests {
         let _root = EnvGuard::unset(SANDBOX_ROOT_VAR);
         assert!(
             !multi_instance_allowed(),
-            "a plain dev run must stay single-instance"
+            "a run with no sandbox root must stay single-instance"
         );
     }
 

--- a/src-tauri/src/test_sandbox.rs
+++ b/src-tauri/src/test_sandbox.rs
@@ -74,6 +74,20 @@ pub fn sandbox_root() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// True when this process is a dev sandbox and may therefore run beside other
+/// instances of the app.
+///
+/// The single-instance guard is keyed on the app identifier, so it cannot tell
+/// two sandboxes apart and would make the second hand its argv to the first and
+/// exit. Parallel agent sandboxes are separate accounts in separate data
+/// directories, so the guard has to be skipped for them.
+///
+/// Debug-only by construction: a release build has no sandbox concept to honor
+/// here, so it stays single-instance whatever the environment claims.
+pub fn multi_instance_allowed() -> bool {
+    cfg!(debug_assertions) && sandbox_root().is_some()
+}
+
 /// Returns the sandboxed `app_data_dir` when a sandbox root is configured,
 /// otherwise delegates to the normal Tauri path.
 pub fn test_data_dir<R: Runtime>(handle: &AppHandle<R>) -> Result<PathBuf, String> {
@@ -262,6 +276,36 @@ mod tests {
         let dir = temp_test_dir("sandbox-root-some");
         let _root = EnvGuard::set(SANDBOX_ROOT_VAR, dir.to_str().unwrap());
         assert_eq!(sandbox_root(), Some(PathBuf::from(dir.to_str().unwrap())));
+    }
+
+    #[test]
+    fn multi_instance_allowed_only_with_a_sandbox_root() {
+        let _lock = env_lock();
+        let dir = temp_test_dir("multi-instance-allowed");
+        let _root = EnvGuard::set(SANDBOX_ROOT_VAR, dir.to_str().unwrap());
+        // Mirrors the release posture: the helper may only ever relax the
+        // guard in a debug build.
+        assert_eq!(multi_instance_allowed(), cfg!(debug_assertions));
+    }
+
+    #[test]
+    fn multi_instance_refused_without_a_sandbox_root() {
+        let _lock = env_lock();
+        let _root = EnvGuard::unset(SANDBOX_ROOT_VAR);
+        assert!(
+            !multi_instance_allowed(),
+            "a plain dev run must stay single-instance"
+        );
+    }
+
+    #[test]
+    fn multi_instance_refused_when_root_is_blank() {
+        let _lock = env_lock();
+        let _root = EnvGuard::set(SANDBOX_ROOT_VAR, "   ");
+        assert!(
+            !multi_instance_allowed(),
+            "a blank root is not a sandbox and must not relax the guard"
+        );
     }
 
     #[test]

--- a/src/lib/dev/dev-ports.test.ts
+++ b/src/lib/dev/dev-ports.test.ts
@@ -119,10 +119,10 @@ describe('dev-ports', () => {
       expect(portsForIndex(3)).toEqual({ devServer: 1450, hmr: 1451, mcpBridge: 9523 });
     });
 
-    it('index 30 lands on the browser unsafe-port blocklist (1720/1721)', () => {
-      // Chromium refuses these with ERR_UNSAFE_PORT and WebKit keeps the same
-      // list, so a dev server bound there serves curl fine while the webview
-      // renders a blank page.
+    it('index 30 lands on the browser unsafe-port blocklist (devServer 1720)', () => {
+      // Chromium refuses 1720 with ERR_UNSAFE_PORT and WebKit blocks the same
+      // fetch-spec list, so a dev server bound there serves curl fine while
+      // the webview renders a blank page.
       expect(portsForIndex(30)).toEqual({ devServer: 1720, hmr: 1721, mcpBridge: 12223 });
       expect(browserSafeIndex(30)).toBe(false);
       expect(browserSafeIndex(29)).toBe(true);
@@ -157,10 +157,13 @@ describe('dev-ports', () => {
     });
 
     it('advances a branch deriving the browser-unsafe index 30, probed or not', async () => {
-      // Find a real branch name that hashes onto the poisoned index.
+      // Find a real branch name that hashes onto the poisoned index. Bounded
+      // so a hash or range change fails the assertion instead of hanging the
+      // worker (a synchronous loop outlives vitest's testTimeout).
       let n = 0;
-      while (deriveIndex(`unsafe-probe-${n}`) !== 30) n++;
+      while (n < 10_000 && deriveIndex(`unsafe-probe-${n}`) !== 30) n++;
       const branch = `unsafe-probe-${n}`;
+      expect(deriveIndex(branch)).toBe(30);
 
       const unprobed = await resolvePortSet({ branch, probe: false });
       expect(unprobed.derivedIndex).toBe(30);

--- a/src/lib/dev/dev-ports.test.ts
+++ b/src/lib/dev/dev-ports.test.ts
@@ -11,6 +11,7 @@ import {
   portsForIndex,
   resolvePortSet,
   readSandboxHandle,
+  browserSafeIndex,
 } from '../../../scripts/dev-ports.mjs';
 
 const SCRIPT_PATH = fileURLToPath(new URL('../../../scripts/dev-ports.mjs', import.meta.url));
@@ -117,6 +118,17 @@ describe('dev-ports', () => {
     it('spaces devServer/hmr by 10 and mcpBridge by 100 per index', () => {
       expect(portsForIndex(3)).toEqual({ devServer: 1450, hmr: 1451, mcpBridge: 9523 });
     });
+
+    it('index 30 lands on the browser unsafe-port blocklist (1720/1721)', () => {
+      // Chromium refuses these with ERR_UNSAFE_PORT and WebKit keeps the same
+      // list, so a dev server bound there serves curl fine while the webview
+      // renders a blank page.
+      expect(portsForIndex(30)).toEqual({ devServer: 1720, hmr: 1721, mcpBridge: 12223 });
+      expect(browserSafeIndex(30)).toBe(false);
+      expect(browserSafeIndex(29)).toBe(true);
+      expect(browserSafeIndex(31)).toBe(true);
+      expect(browserSafeIndex(0)).toBe(true);
+    });
   });
 
   describe('resolvePortSet', () => {
@@ -142,6 +154,25 @@ describe('dev-ports', () => {
       expect(result.index).toBe(12);
       expect(result.advanced).toBe(false);
       expect(result.ports).toEqual(portsForIndex(12));
+    });
+
+    it('advances a branch deriving the browser-unsafe index 30, probed or not', async () => {
+      // Find a real branch name that hashes onto the poisoned index.
+      let n = 0;
+      while (deriveIndex(`unsafe-probe-${n}`) !== 30) n++;
+      const branch = `unsafe-probe-${n}`;
+
+      const unprobed = await resolvePortSet({ branch, probe: false });
+      expect(unprobed.derivedIndex).toBe(30);
+      expect(unprobed.index).toBe(31);
+      expect(unprobed.advanced).toBe(true);
+
+      const claimDir = makeTempDir();
+      const probed = await resolvePortSet({ branch, probe: true, claimDir });
+      expect(probed.index).not.toBe(30);
+      expect(browserSafeIndex(probed.index)).toBe(true);
+      // The unusable index must not be claimed on the way past.
+      expect(fs.existsSync(path.join(claimDir, 'index-30.claim.json'))).toBe(false);
     });
 
     it('advances past an occupied derived index and reports advanced: true', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,7 +72,16 @@ export default defineConfig({
         }
       : undefined,
     watch: {
-      ignored: ['**/src-tauri/**', '**/build-agent/**'],
+      // A dev sandbox writes its app log, SQLite database and MLS store under
+      // test_sandbox/ while the dev server is up, and a git worktree nests a
+      // whole second checkout under .worktrees/. Watching either feeds the
+      // running app's own disk churn back in as source changes.
+      ignored: [
+        '**/src-tauri/**',
+        '**/build-agent/**',
+        '**/test_sandbox/**',
+        '**/.worktrees/**',
+      ],
     },
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import packageJson from './package.json' with { type: 'json' };
 import { svelteTesting } from '@testing-library/svelte/vite';
@@ -73,14 +74,21 @@ export default defineConfig({
       : undefined,
     watch: {
       // A dev sandbox writes its app log, SQLite database and MLS store under
-      // test_sandbox/ while the dev server is up, and a git worktree nests a
-      // whole second checkout under .worktrees/. Watching either feeds the
-      // running app's own disk churn back in as source changes.
+      // test_sandbox/ (make dev-sandbox) or test_fixtures/ (make dev,
+      // dev-account, dev-buddy) while the dev server is up, and a git worktree
+      // nests a whole second checkout under .worktrees/. Watching any of them
+      // feeds the running app's own disk churn back in as source changes.
+      //
+      // The worktrees pattern is anchored to this checkout: patterns match
+      // absolute paths, so a bare '**/.worktrees/**' would make a dev server
+      // running *inside* a worktree ignore its own sources (serving fine, HMR
+      // silently dead).
       ignored: [
         '**/src-tauri/**',
         '**/build-agent/**',
         '**/test_sandbox/**',
-        '**/.worktrees/**',
+        '**/test_fixtures/**',
+        `${fileURLToPath(new URL('.', import.meta.url)).replaceAll('\\', '/')}.worktrees/**`,
       ],
     },
   },


### PR DESCRIPTION
## Summary

Two dev sandboxes could not run at the same time, and one branch in thirty-one could never boot at all. This PR removes the three obstacles standing between the parallel-agent sandbox design and the first observed two-agents-at-once run.

- **Before:** the second sandbox handed its argv to the first and exited (silently — it wrote its handle, started its MCP bridge, then never logged in). Separately, any branch whose port index derived to 30 rendered a white screen forever.
- **After:** two sandboxes in two worktrees pass all eight dev-world gates concurrently — verified live, both exiting 0 in under a minute, then reclaimed cleanly.

## Changes

- **Single-instance guard skipped for sandboxes.** The guard is keyed on the app identifier, so it cannot tell two sandboxes apart. It is skipped only when a sandbox root is configured, and the predicate (`multi_instance_allowed`) is debug-only by construction — a release build stays single-instance no matter what the environment says.
- **Port sets browsers refuse are never derived.** Index 30 resolves devServer 1720 / hmr 1721 — the legacy H.323 cluster on the browser unsafe-port blocklist. Chromium fails such fetches with `ERR_UNSAFE_PORT` and WebKit keeps the same list, so vite served curl happily while the webview rendered nothing. `resolvePortSet` now advances past any browser-unsafe index, probed or not, checking the whole blocklist so a stride change cannot quietly reintroduce the bug.
- **The dev server no longer watches the sandbox or worktree trees.** A running sandbox writes its log, SQLite database and MLS store under `test_sandbox/`, and a git worktree nests a second checkout under `.worktrees/`; neither belongs in vite's watcher.

## Test plan

- `cargo test --lib` — 649 passed (includes three new `multi_instance_allowed` cases).
- `pnpm test src/lib/dev/dev-ports.test.ts` — 18 passed, including: index 30 is on the blocklist, a branch deriving it advances (probed and unprobed) without claiming it.
- `pnpm check` and `pnpm lint` clean.
- Live: two concurrent `dev-world` runs (main checkout + worktree, two personas) each passed all eight gates and exited 0; the same run previously wedged at app-launch every time.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
