### PR TITLE
fix: seed a reachable squad and add a one-command dev sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install relay-free-harness-seed dev dev-sandbox dev-sandbox-fresh dev-account dev-buddy dev-world dev-world-reclaim build preview test validate check lint format rust-test rust-check rust-fmt rust-clippy new-migration e2e e2e-install e2e-tauri release-symbol-check clean distclean tauri-info signer-key
+.PHONY: help install relay-free-harness-seed dev dev-sandbox dev-sandbox-fresh dev-sandbox-seeded dev-account dev-buddy dev-world dev-world-reclaim build preview test validate check lint format rust-test rust-check rust-fmt rust-clippy new-migration e2e e2e-install e2e-tauri release-symbol-check clean distclean tauri-info signer-key
 
 # Default target shows available commands.
 help:
@@ -7,6 +7,7 @@ help:
 	@echo "  install      install Node/Rust dependencies"
 	@echo "  dev          run the desktop app in development mode (auto-isolated per branch, except main)"
 	@echo "  dev-sandbox  run the desktop app against a throwaway account for MCP-driven UI verification"
+	@echo "  dev-sandbox-seeded  dev-sandbox, pre-seeded and already logged in -- no env vars to remember"
 	@echo "  dev-account  run the desktop app against the persistent, reusable primary test account"
 	@echo "  dev-buddy    run the desktop app against the persistent, reusable secondary test account"
 	@echo "  dev-world          populate this worktree's sandbox with a joined squad via the sibling pacto-dev-env orchestrator"
@@ -121,6 +122,20 @@ relay-free-harness-seed:
 	mkdir -p "$$root"; \
 	echo "relay-free-harness-seed: $$root"; \
 	cd src-tauri && cargo run --no-default-features --features relay-free-harness --bin relay-free-harness -- --sandbox-root "$$root"
+
+# One-command populated + authenticated sandbox: seeds (idempotent, ~instant
+# on a rerun) then launches dev-sandbox pinned to the relay-free-harness
+# persona with its public fixture mnemonic and a local-only relay set
+# already wired in -- the exact combination `dev_login` requires to
+# authenticate a sandbox-only identity (KD9/R25 refusal). Deliberately a
+# separate target from `dev-sandbox`: that one stays blank-slate by default
+# so it still serves onboarding-UI testing and multi-persona MLS checks,
+# where different personas must NOT collapse onto the same identity.
+dev-sandbox-seeded: relay-free-harness-seed
+	@PERSONA=relay-free-harness \
+	PACTO_TRUSTED_RELAYS=wss://localhost:7001 \
+	PACTO_DEV_LOGIN_MNEMONIC="test test test test test test test test test test test junk" \
+	$(MAKE) dev-sandbox
 
 # Persistent reusable test identities (docs/TAURI_MCP_INTEGRATION.md). Unlike
 # dev-sandbox, these keep the same PIN-protected account, DM history, and

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pacto"
+default-run = "pacto"
 version = "0.5.5"
 description = "A Tauri App"
 authors = ["daopunk"]

--- a/src-tauri/src/harness.rs
+++ b/src-tauri/src/harness.rs
@@ -41,8 +41,9 @@ const HARNESS_EPOCH_SECS: u64 = 1_735_000_000;
 /// `SEED_MARKER_VERSION` means "already seeded, do nothing" on a rerun --
 /// the harness's primary idempotency guard.
 const SEED_MARKER_KEY: &str = "harness_seed_complete";
-/// Bumped when seed semantics change (sandbox-only stamp, local-only relays).
-const SEED_MARKER_VERSION: &str = "2";
+/// Bumped when seed semantics change (sandbox-only stamp, local-only relays,
+/// `squads` catalog row for the seeded squad).
+const SEED_MARKER_VERSION: &str = "3";
 
 /// Anvil/Hardhat's well-known public test mnemonic -- already the default
 /// local chain this repo's sandboxes point at. A fine default: this identity
@@ -450,6 +451,54 @@ async fn persist_dm_text<R: Runtime>(
     }
 }
 
+/// Default channel rows for a freshly seeded squad -- mirrors
+/// `src/lib/squad/hub-channel-rows.ts::defaultChannelRowsForGroupId`: the
+/// `announcements` channel *is* the squad root MLS group, plus the virtual
+/// `polls` channel routed through that same group.
+fn harness_squad_channels(group_id: &str) -> Vec<crate::squad_catalog::SquadChannelRow> {
+    vec![
+        crate::squad_catalog::SquadChannelRow {
+            name: "announcements".to_string(),
+            group_id: group_id.to_string(),
+            order: 0,
+            access: None,
+        },
+        crate::squad_catalog::SquadChannelRow {
+            name: "polls".to_string(),
+            group_id: group_id.to_string(),
+            order: 1,
+            access: None,
+        },
+    ]
+}
+
+/// Upsert the `squads` catalog row the frontend's Squads UI actually reads
+/// (`list_squads` -> `hydrateSquadsFromDb`). `mls_groups`/`chats` rows alone
+/// leave the seeded squad unreachable through the app -- the Squads store
+/// never learns about it without this row.
+fn ensure_squad_catalog_row<R: Runtime>(
+    handle: &AppHandle<R>,
+    group_id: &str,
+    name: &str,
+) -> Result<(), String> {
+    let row = crate::squad_catalog::SquadRow {
+        id: group_id.to_string(),
+        name: name.to_string(),
+        icon_url: None,
+        channels: harness_squad_channels(group_id),
+        kind: "squad".to_string(),
+        paired_squads: None,
+        visibility: "private".to_string(),
+        commons_tags: None,
+        created_at_ms: (HARNESS_EPOCH_SECS as i64) * 1000,
+        updated_at_ms: (HARNESS_EPOCH_SECS as i64) * 1000,
+    };
+    let conn = account_manager::get_db_connection(handle)?;
+    let result = crate::squad_catalog::upsert_squad_inner(&conn, &row);
+    account_manager::return_db_connection(conn);
+    result
+}
+
 /// Seed the squad slice. A second, ephemeral in-process MLS engine plays the
 /// inviter -- it creates the group against the sandbox identity's real,
 /// locally-stored keypackage, produces a real welcome, and the harness feeds
@@ -471,6 +520,7 @@ async fn seed_squad_slice<R: Runtime>(
         .into_iter()
         .find(|g| g.name == SQUAD_NAME)
     {
+        ensure_squad_catalog_row(handle, &existing.group_id, &existing.name)?;
         return Ok(Some(existing.group_id));
     }
 
@@ -594,6 +644,7 @@ async fn seed_squad_slice<R: Runtime>(
         nostr_group_id.clone(),
         vec![sandbox_npub, inviter_npub],
     );
+    ensure_squad_catalog_row(handle, &nostr_group_id, &group_name)?;
     chat.metadata.set_name(group_name);
     db::save_chat(handle.clone(), &chat).await?;
 
@@ -677,6 +728,7 @@ async fn recover_squad_from_mls_store<R: Runtime>(
     };
     db::save_mls_group(handle.clone(), &metadata).await?;
 
+    ensure_squad_catalog_row(handle, &nostr_group_id, &group_name)?;
     let mut chat = Chat::new_mls_group(nostr_group_id.clone(), vec![]);
     chat.metadata.set_name(group_name);
     db::save_chat(handle.clone(), &chat).await?;


### PR DESCRIPTION
## Summary

The relay-free harness (`make relay-free-harness-seed`) seeds a DM thread, a squad, and a wallet entirely offline through the real ingest path — but the squad it created was invisible in the app. It wrote `mls_groups`/`chats` rows directly; the Squads UI reads exclusively from a separate `squads` catalog table (`list_squads` → `hydrateSquadsFromDb`), which the harness never populated. The MLS group, welcome, and messages all existed in SQLite; nothing in the UI could reach them.

`harness.rs` now upserts a `squads` catalog row (mirroring the real squad-creation shape: `announcements` + `polls` channels routed through the root MLS group) from every code path that can produce the seeded squad — fresh create, crash recovery, and the idempotent already-exists check. `SEED_MARKER_VERSION` bumps `2` → `3` so a stale-marked root refuses silent reseeding rather than staying broken; existing roots need a wipe (`make relay-free-harness-seed` fails loudly with instructions).

Separately, getting a populated, already-authenticated sandbox required three env vars nobody remembers (`PERSONA`, `PACTO_TRUSTED_RELAYS`, `PACTO_DEV_LOGIN_MNEMONIC`) — those stay deliberately un-defaulted on the general `dev-sandbox` target so it still serves onboarding-UI testing and multi-persona MLS checks. `make dev-sandbox-seeded` is a new target that chains the harness seed into `dev-sandbox` with that exact combination wired in, so a dev gets a populated, logged-in app with zero env vars to remember.

Also carries a pre-existing one-line `Cargo.toml` fix (`default-run = "pacto"`) so plain `cargo run` targets the app binary rather than the harness binary.

## Validation

- `cargo test --lib harness::` and `cargo check`/`cargo build` for both the `pacto` and `relay-free-harness` targets — clean.
- Wiped a seeded root and reran `make relay-free-harness-seed`: `squads` table now has the expected row (verified via direct SQLite query); rerun is idempotent (marker v3, no-op).
- Live UI via the Tauri MCP bridge: `make dev-sandbox-seeded` from a wiped root lands already authenticated with "Relay-Free Harness Squad" visible in the Squads tab, `#announcements`/`#polls` channels present, and both seeded messages rendering.
- Confirmed no live relay is required for any of this: relaunched pointed at an unreachable local port (`wss://localhost:19191`) — squad, channels, and messages still rendered from local SQLite with authentication unaffected.
