### PR TITLE
fix: restore the pr gate by quoting an unparseable ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,7 +215,9 @@ jobs:
 
       - name: Harness unit tests
         working-directory: src-tauri
-        run: cargo test --lib --no-default-features --features relay-free-harness harness::
+        # Quoted: the trailing `::` module filter would otherwise read as a
+        # YAML mapping key and make this whole file unparseable.
+        run: "cargo test --lib --no-default-features --features relay-free-harness harness::"
 
       - name: Build relay-free harness
         working-directory: src-tauri


### PR DESCRIPTION
## Summary

The PR gate has not been running. Every `ci.yaml` run since the relay-free harness job landed has failed instantly with *"This run likely failed because of a workflow file issue"* — on `main` and on every branch. That covers the last several merges, which went in without CI ever executing.

**Before:** every push and PR produces an instant red X with no jobs, and the run is listed as `.github/workflows/ci.yaml` rather than `CI`.

**After:** the file parses, and the ten jobs actually run.

## Changes

The harness unit-test step ends its command with a `harness::` module filter. Unquoted, that trailing colon is read as a YAML mapping key, so the entire file fails to parse. Quoting the command fixes it.

That listing detail is the tell worth remembering: GitHub could not read `name:`, so it fell back to displaying the file path where every other workflow shows its name.

## Test plan

- The file now parses to `name: CI` with all ten jobs (`typecheck`, `lint`, `frontend-tests`, `e2e-ui`, `tauri-e2e`, `backend-tests`, `relay-free-harness`, `landing-build`, `release-symbol-check`, `scripts-test`) and both triggers (`push` on `main`, `pull_request`) intact.
- The filter still selects real tests rather than silently matching nothing: `cargo test --lib --no-default-features --features relay-free-harness harness::` → `7 passed; 0 failed; 680 filtered out`.
- The real proof is this PR's own checks: it is the first run in a while that should report jobs at all.

## Note on how this slipped through

This failure mode is invisible to the obvious local checks. Searching for tabs or bad indentation finds nothing, and neither `python3 -c "import yaml"` nor Node has a YAML parser available here by default — so "the file looks fine" was not the same as "the file parses". A parse step in the scripts test job would catch the whole class.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
