### PR TITLE
fix: stop 0.5.x upgrades from tripping the storage-format gate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6126,6 +6126,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3 0.10.9",
+ "siphasher",
  "symphonia",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,6 +90,11 @@ symphonia = { version = "0.5.5", features = ["mp3", "wav", "flac", "pcm"] }
 # stock SQLite, so existing `pacto.db` files are unaffected.
 rusqlite = { version = "0.37", features = ["bundled-sqlcipher-vendored-openssl"] }
 refinery = { version = "0.9", features = ["rusqlite", "int8-versions"] }
+# Same hasher refinery-core uses for migration checksums (SipHasher13).
+# Direct dependency so storage_format::legacy_i32_checksum can reproduce a
+# pre-int8-versions build's checksum for recognition, without depending on
+# refinery-core's private internals.
+siphasher = "1"
 log = "0.4"
 rand = "0.8"
 url = "2.5"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod account_manager;
 
 mod mls;
 pub use mls::MlsService;
+mod mls_legacy_checksum;
 mod mls_store_reset;
 mod mls_store_reset_state;
 

--- a/src-tauri/src/migrations/mod.rs
+++ b/src-tauri/src/migrations/mod.rs
@@ -639,4 +639,91 @@ mod tests {
             .expect("history should exist");
         assert_eq!(last_version, embedded_ceiling());
     }
+
+    /// `v1_database_with_legacy_checksum_reconciles_and_migrates` above only
+    /// stamps a single row with a legacy checksum. A real 0.5.x history has
+    /// every applied migration on the legacy digest, so this proves the
+    /// reconciliation loop rewrites all of them, not just the first --
+    /// while leaving a row that matches neither checksum untouched.
+    #[test]
+    fn reconcile_legacy_checksums_for_table_rewrites_every_stamped_row() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE refinery_schema_history (
+                version INTEGER PRIMARY KEY,
+                name VARCHAR(255),
+                applied_on VARCHAR(255),
+                checksum VARCHAR(255)
+            );",
+        )
+        .expect("create history table");
+
+        let runner = embedded::migrations::runner();
+        let all_migrations = runner.get_migrations();
+        let sample: Vec<&Migration> = all_migrations
+            .iter()
+            .filter(|m| m.sql().is_some())
+            .take(5)
+            .collect();
+        assert!(
+            sample.len() >= 2,
+            "need at least two real migrations to prove the loop, not just the first"
+        );
+
+        let applied_on = OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .expect("format timestamp");
+        for migration in &sample {
+            let legacy_checksum = crate::storage_format::legacy_i32_checksum(
+                migration.name(),
+                migration.version(),
+                migration.sql().expect("sample only has migrations with sql"),
+            )
+            .to_string();
+            conn.execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![migration.version(), migration.name(), &applied_on, legacy_checksum],
+            )
+            .expect("stamp legacy row");
+        }
+        // A genuinely divergent row -- neither legacy nor current -- must be left alone.
+        let last = all_migrations.last().expect("embedded set is non-empty");
+        let divergent_version = last.version() + 1_000_000;
+        conn.execute(
+            "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) VALUES (?1, 'divergent-fixture', ?2, 'not-a-real-checksum')",
+            rusqlite::params![divergent_version, &applied_on],
+        )
+        .expect("stamp divergent row");
+
+        reconcile_legacy_checksums_for_table(&conn, "refinery_schema_history", all_migrations)
+            .expect("reconciliation should not error");
+
+        for migration in &sample {
+            let stored: String = conn
+                .query_row(
+                    "SELECT checksum FROM refinery_schema_history WHERE version = ?1",
+                    [migration.version()],
+                    |row| row.get(0),
+                )
+                .expect("row should exist");
+            assert_eq!(
+                stored,
+                migration.checksum().to_string(),
+                "version {} should be rewritten to the current checksum",
+                migration.version()
+            );
+        }
+
+        let divergent_checksum: String = conn
+            .query_row(
+                "SELECT checksum FROM refinery_schema_history WHERE version = ?1",
+                [divergent_version],
+                |row| row.get(0),
+            )
+            .expect("divergent row should exist");
+        assert_eq!(
+            divergent_checksum, "not-a-real-checksum",
+            "a row matching neither checksum must be left alone"
+        );
+    }
 }

--- a/src-tauri/src/migrations/mod.rs
+++ b/src-tauri/src/migrations/mod.rs
@@ -53,11 +53,11 @@ pub(crate) fn embedded_migration_set() -> Vec<refinery::Migration> {
 /// baselined by stamping the full migration history without re-running it.
 ///
 /// A database that already has a history table goes through
-/// `reconcile_legacy_checksums` first: a pre-0.6.0 build stamped it with
-/// checksums computed under a narrower `SchemaVersion` type, which
+/// `reconcile_legacy_checksums_for_table` first: a pre-0.6.0 build stamped
+/// it with checksums computed under a narrower `SchemaVersion` type, which
 /// `embedded::migrations::runner().run` below -- refinery's own
 /// checksum-verifying apply -- would otherwise reject as divergent. See
-/// `reconcile_legacy_checksums` for why.
+/// `reconcile_legacy_checksums_for_table` for why.
 pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
     let history_exists: bool = conn
         .query_row(
@@ -82,7 +82,11 @@ pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
             baseline_existing_account(conn)?;
         }
     } else {
-        reconcile_legacy_checksums(conn)?;
+        reconcile_legacy_checksums_for_table(
+            conn,
+            "refinery_schema_history",
+            &embedded::migrations::runner().get_migrations().clone(),
+        )?;
     }
 
     embedded::migrations::runner()
@@ -92,18 +96,22 @@ pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
     Ok(())
 }
 
-/// One-time repair for a database whose `refinery_schema_history.checksum`
-/// values were stamped by a build compiled without the `int8-versions`
-/// Cargo feature -- every Pacto release before 0.6.0. Enabling that feature
-/// changed `refinery::SchemaVersion` from `i32` to `i64` (needed so a
-/// 14-digit UTC-timestamp migration version fits); refinery hashes
-/// `(name, version, sql)` together, and hashing an `i32` vs an `i64` for the
-/// identical numeric value feeds a different byte width into the hasher --
-/// silently changing the checksum of every migration a pre-0.6.0 install
-/// had already applied, even though nothing about the migration's content
-/// changed. Left unreconciled, `embedded::migrations::runner().run` --
-/// called right after this in `run_migrations` -- aborts with
-/// `DivergentVersion` on the first such row.
+/// Idempotent repair for a database whose refinery history table's
+/// `checksum` values were stamped by a build compiled without the
+/// `int8-versions` Cargo feature -- every Pacto release before 0.6.0, for
+/// `refinery_schema_history` in `pacto.db`; every release before
+/// `int8-versions` propagated through Cargo's unified feature resolution,
+/// for `_refinery_schema_history_nostr_mls` in the MLS store (see
+/// `mls_store_reset::reconcile_mls_store_legacy_checksums`, the other
+/// caller). Enabling that feature changed `refinery::SchemaVersion` from
+/// `i32` to `i64` (needed so a 14-digit UTC-timestamp migration version
+/// fits); refinery hashes `(name, version, sql)` together, and hashing an
+/// `i32` vs an `i64` for the identical numeric value feeds a different
+/// byte width into the hasher -- silently changing the checksum of every
+/// migration a pre-`int8-versions` build had already applied, even though
+/// nothing about the migration's content changed. Left unreconciled, the
+/// refinery `Runner::run` that follows this call for either table aborts
+/// with `DivergentVersion` on the first such row.
 ///
 /// Rewrites the stored checksum to this build's current value wherever it
 /// exactly matches the legacy (i32-schema-version) checksum for that
@@ -111,10 +119,14 @@ pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
 /// ever touched by an exact legacy-checksum match. A row that matches
 /// neither checksum is a genuine divergence and is left alone --
 /// `Runner::run` (and `storage_format::classify_history`'s read-only
-/// probe, which tolerates the same legacy checksum) still catch that for
-/// real.
-fn reconcile_legacy_checksums(conn: &rusqlite::Connection) -> Result<(), String> {
-    for migration in embedded::migrations::runner().get_migrations() {
+/// probe, which tolerates the same legacy checksum for `pacto.db`) still
+/// catch that for real.
+pub(crate) fn reconcile_legacy_checksums_for_table(
+    conn: &rusqlite::Connection,
+    table_name: &str,
+    migrations: &[refinery::Migration],
+) -> Result<(), String> {
+    for migration in migrations {
         let Some(sql) = migration.sql() else {
             continue;
         };
@@ -126,9 +138,11 @@ fn reconcile_legacy_checksums(conn: &rusqlite::Connection) -> Result<(), String>
             continue;
         }
         conn.execute(
-            "UPDATE refinery_schema_history \
-             SET checksum = ?1 \
-             WHERE version = ?2 AND name = ?3 AND checksum = ?4",
+            &format!(
+                "UPDATE \"{table_name}\" \
+                 SET checksum = ?1 \
+                 WHERE version = ?2 AND name = ?3 AND checksum = ?4"
+            ),
             rusqlite::params![
                 current_checksum,
                 migration.version(),
@@ -138,7 +152,7 @@ fn reconcile_legacy_checksums(conn: &rusqlite::Connection) -> Result<(), String>
         )
         .map_err(|e| {
             format!(
-                "Failed to reconcile legacy checksum for {}: {}",
+                "Failed to reconcile legacy checksum for {} in {table_name}: {}",
                 migration, e
             )
         })?;
@@ -571,7 +585,7 @@ mod tests {
     }
 
     /// Regression test for the checksum break the `int8-versions` Cargo
-    /// feature introduced (see `reconcile_legacy_checksums`): a V1 row
+    /// feature introduced (see `reconcile_legacy_checksums_for_table`): a V1 row
     /// stamped with the *legacy* i32-schema-version checksum -- what every
     /// pre-0.6.0 build actually wrote -- must still let `run_migrations`
     /// proceed instead of refinery aborting with `DivergentVersion`, and

--- a/src-tauri/src/migrations/mod.rs
+++ b/src-tauri/src/migrations/mod.rs
@@ -51,6 +51,13 @@ pub(crate) fn embedded_migration_set() -> Vec<refinery::Migration> {
 /// Existing pre-refinery databases are detected by the absence of
 /// `refinery_schema_history` and the presence of `settings`, and are
 /// baselined by stamping the full migration history without re-running it.
+///
+/// A database that already has a history table goes through
+/// `reconcile_legacy_checksums` first: a pre-0.6.0 build stamped it with
+/// checksums computed under a narrower `SchemaVersion` type, which
+/// `embedded::migrations::runner().run` below -- refinery's own
+/// checksum-verifying apply -- would otherwise reject as divergent. See
+/// `reconcile_legacy_checksums` for why.
 pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
     let history_exists: bool = conn
         .query_row(
@@ -74,12 +81,68 @@ pub fn run_migrations(conn: &mut rusqlite::Connection) -> Result<(), String> {
         if has_settings {
             baseline_existing_account(conn)?;
         }
+    } else {
+        reconcile_legacy_checksums(conn)?;
     }
 
     embedded::migrations::runner()
         .run(conn)
         .map_err(|e| format!("Migration failed: {}", e))?;
 
+    Ok(())
+}
+
+/// One-time repair for a database whose `refinery_schema_history.checksum`
+/// values were stamped by a build compiled without the `int8-versions`
+/// Cargo feature -- every Pacto release before 0.6.0. Enabling that feature
+/// changed `refinery::SchemaVersion` from `i32` to `i64` (needed so a
+/// 14-digit UTC-timestamp migration version fits); refinery hashes
+/// `(name, version, sql)` together, and hashing an `i32` vs an `i64` for the
+/// identical numeric value feeds a different byte width into the hasher --
+/// silently changing the checksum of every migration a pre-0.6.0 install
+/// had already applied, even though nothing about the migration's content
+/// changed. Left unreconciled, `embedded::migrations::runner().run` --
+/// called right after this in `run_migrations` -- aborts with
+/// `DivergentVersion` on the first such row.
+///
+/// Rewrites the stored checksum to this build's current value wherever it
+/// exactly matches the legacy (i32-schema-version) checksum for that
+/// migration, via raw SQL rather than the refinery API, so a row is only
+/// ever touched by an exact legacy-checksum match. A row that matches
+/// neither checksum is a genuine divergence and is left alone --
+/// `Runner::run` (and `storage_format::classify_history`'s read-only
+/// probe, which tolerates the same legacy checksum) still catch that for
+/// real.
+fn reconcile_legacy_checksums(conn: &rusqlite::Connection) -> Result<(), String> {
+    for migration in embedded::migrations::runner().get_migrations() {
+        let Some(sql) = migration.sql() else {
+            continue;
+        };
+        let current_checksum = migration.checksum().to_string();
+        let legacy_checksum =
+            crate::storage_format::legacy_i32_checksum(migration.name(), migration.version(), sql)
+                .to_string();
+        if legacy_checksum == current_checksum {
+            continue;
+        }
+        conn.execute(
+            "UPDATE refinery_schema_history \
+             SET checksum = ?1 \
+             WHERE version = ?2 AND name = ?3 AND checksum = ?4",
+            rusqlite::params![
+                current_checksum,
+                migration.version(),
+                migration.name(),
+                legacy_checksum
+            ],
+        )
+        .map_err(|e| {
+            format!(
+                "Failed to reconcile legacy checksum for {}: {}",
+                migration, e
+            )
+        })?;
+    }
     Ok(())
 }
 
@@ -154,6 +217,17 @@ mod tests {
     use refinery::Migration;
 
     fn stamp_migration(conn: &mut rusqlite::Connection, migration: &Migration) {
+        stamp_migration_with_checksum(conn, migration, &migration.checksum().to_string());
+    }
+
+    /// Like `stamp_migration`, but with an explicit checksum -- used to
+    /// simulate a row stamped by a pre-0.6.0 build (a legacy i32-schema-
+    /// version checksum) instead of this build's own.
+    fn stamp_migration_with_checksum(
+        conn: &mut rusqlite::Connection,
+        migration: &Migration,
+        checksum: &str,
+    ) {
         let applied_on = OffsetDateTime::now_utc()
             .format(&Rfc3339)
             .expect("format baseline timestamp");
@@ -168,12 +242,7 @@ mod tests {
         .expect("create history table");
         conn.execute(
             "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) VALUES (?1, ?2, ?3, ?4)",
-            rusqlite::params![
-                migration.version(),
-                migration.name(),
-                &applied_on,
-                migration.checksum().to_string()
-            ],
+            rusqlite::params![migration.version(), migration.name(), &applied_on, checksum],
         )
         .expect("stamp migration");
     }
@@ -389,10 +458,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn v1_database_migrates_to_latest() {
-        let mut conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
-        // Apply the V1 schema manually to simulate an account created at that version.
+    /// The V1 schema (`profiles`, `chats`, `messages`, `settings`,
+    /// `mls_groups`, `mls_keypackages`, `mls_event_cursors`) as it existed
+    /// before any migration ran, for simulating an account created at that
+    /// version.
+    fn seed_v1_schema(conn: &rusqlite::Connection) {
         conn.execute_batch(
             r#"
             CREATE TABLE profiles (
@@ -442,6 +512,13 @@ mod tests {
             "#,
         )
         .expect("v1 schema");
+    }
+
+    #[test]
+    fn v1_database_migrates_to_latest() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        // Apply the V1 schema manually to simulate an account created at that version.
+        seed_v1_schema(&conn);
 
         // Seed V1 with a message so the V7 migration path has real data to transform.
         conn.execute(
@@ -491,5 +568,61 @@ mod tests {
             })
             .expect("count events");
         assert_eq!(migrated_event, 1, "V1 message should be migrated to events");
+    }
+
+    /// Regression test for the checksum break the `int8-versions` Cargo
+    /// feature introduced (see `reconcile_legacy_checksums`): a V1 row
+    /// stamped with the *legacy* i32-schema-version checksum -- what every
+    /// pre-0.6.0 build actually wrote -- must still let `run_migrations`
+    /// proceed instead of refinery aborting with `DivergentVersion`, and
+    /// the stored checksum must come out reconciled to this build's
+    /// current value afterward.
+    #[test]
+    fn v1_database_with_legacy_checksum_reconciles_and_migrates() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        seed_v1_schema(&conn);
+
+        let runner = embedded::migrations::runner();
+        let migrations = runner.get_migrations();
+        let v1 = migrations
+            .iter()
+            .find(|m| m.version() == 1)
+            .expect("V1 migration should be embedded");
+        let legacy_checksum = crate::storage_format::legacy_i32_checksum(
+            v1.name(),
+            v1.version(),
+            v1.sql().expect("embedded migration has sql"),
+        )
+        .to_string();
+        assert_ne!(
+            legacy_checksum,
+            v1.checksum().to_string(),
+            "test fixture must actually exercise a checksum mismatch"
+        );
+        stamp_migration_with_checksum(&mut conn, v1, &legacy_checksum);
+
+        run_migrations(&mut conn).expect("legacy checksum should not block migration");
+
+        let reconciled_checksum: String = conn
+            .query_row(
+                "SELECT checksum FROM refinery_schema_history WHERE version = 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("V1 history row should exist");
+        assert_eq!(
+            reconciled_checksum,
+            v1.checksum().to_string(),
+            "legacy checksum should be rewritten to this build's current checksum"
+        );
+
+        let last_version: i64 = conn
+            .query_row(
+                "SELECT MAX(version) FROM refinery_schema_history",
+                [],
+                |row| row.get(0),
+            )
+            .expect("history should exist");
+        assert_eq!(last_version, embedded_ceiling());
     }
 }

--- a/src-tauri/src/mls_legacy_checksum.rs
+++ b/src-tauri/src/mls_legacy_checksum.rs
@@ -1,0 +1,79 @@
+//! Vendored copy of `mdk-sqlite-storage` 0.8.0's own migration set
+//! (`src/mls_migrations/*.sql`, copied byte-for-byte from that crate's
+//! `migrations/` directory), used only to compute this build's current and
+//! legacy (pre-`int8-versions`) checksums for the MLS store's
+//! `_refinery_schema_history_nostr_mls` history table.
+//!
+//! `mdk_sqlite_storage::run_migrations` owns its own refinery `Runner`
+//! (default `abort_divergent: true`) over that table, independent of
+//! `crate::migrations::run_migrations`'s `pacto.db` runner -- but both
+//! runners resolve to the *same* `refinery-core`, and Cargo unifies feature
+//! flags per dependency across the whole build, so enabling `int8-versions`
+//! for `pacto` also enables it for `mdk-sqlite-storage`. `mdk-sqlite-storage`
+//! 0.8.0 was already pinned before Pacto added that feature (shipped
+//! unchanged in 0.5.4 and 0.5.5), so every account that opened its MLS
+//! store under a pre-0.6.0 build stamped `_refinery_schema_history_nostr_mls`
+//! with the same narrower-`SchemaVersion` checksums `pacto.db` had --
+//! see `crate::storage_format::legacy_i32_checksum` for the mechanism.
+//! Left unreconciled, `MdkSqliteStorage::new_with_key` (called from
+//! `MlsService::new_persistent_inner`, right after
+//! `mls_store_reset::ensure_store_ready` classifies the store as `Current`
+//! and does nothing further) aborts with `DivergentVersion` on every such
+//! account, even after the `pacto.db` gate and migration are fixed.
+//!
+//! `mdk_sqlite_storage` doesn't expose its embedded migration set publicly,
+//! so this is a deliberate vendored copy, not a shared source of truth --
+//! `mdk_sqlite_storage_version_matches_vendored_migrations` below fails
+//! loudly if `Cargo.lock` ever pins a different `mdk-sqlite-storage`
+//! version than the one these files were copied from, so a version bump
+//! that adds or changes migrations can't silently go stale here.
+
+mod embedded {
+    use refinery::embed_migrations;
+    embed_migrations!("src/mls_migrations");
+}
+
+/// The migration-table name `mdk_sqlite_storage::run_migrations` hard-codes
+/// via `set_migration_table_name` -- kept in sync manually since it's not
+/// part of that crate's public API either.
+pub(crate) const MLS_HISTORY_TABLE_NAME: &str = "_refinery_schema_history_nostr_mls";
+
+pub(crate) fn embedded_migration_set() -> Vec<refinery::Migration> {
+    embedded::migrations::runner().get_migrations().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `mdk-sqlite-storage` version `src/mls_migrations/*.sql` was
+    /// copied from. Keep in sync with `Cargo.lock`'s pinned version.
+    const VENDORED_MDK_SQLITE_STORAGE_VERSION: &str = "0.8.0";
+
+    /// Fails loudly if `Cargo.lock` pins a `mdk-sqlite-storage` version
+    /// other than the one `src/mls_migrations/*.sql` was copied from --
+    /// silently drifting would leave a version bump's new/changed
+    /// migrations unreconciled with no compile error and no test failure
+    /// anywhere else.
+    #[test]
+    fn mdk_sqlite_storage_version_matches_vendored_migrations() {
+        let lock = include_str!("../Cargo.lock");
+        let name_idx = lock
+            .find("name = \"mdk-sqlite-storage\"")
+            .expect("mdk-sqlite-storage package present in Cargo.lock");
+        let after_name = &lock[name_idx..];
+        let version_line = after_name
+            .lines()
+            .nth(1)
+            .expect("version line immediately follows the name line");
+        assert!(
+            version_line.contains(VENDORED_MDK_SQLITE_STORAGE_VERSION),
+            "Cargo.lock pins a different mdk-sqlite-storage version ({version_line}) than the \
+             vendored src/mls_migrations/ copy (expected {VENDORED_MDK_SQLITE_STORAGE_VERSION}) \
+             -- re-copy that crate's migrations/ directory byte-for-byte, update \
+             VENDORED_MDK_SQLITE_STORAGE_VERSION, and re-verify \
+             mls_store_reset::reconcile_mls_store_legacy_checksums still applies, or a version \
+             bump's migrations silently stop being checksum-reconciled"
+        );
+    }
+}

--- a/src-tauri/src/mls_migrations/V001__initial_schema.sql
+++ b/src-tauri/src/mls_migrations/V001__initial_schema.sql
@@ -1,0 +1,222 @@
+-- Unified initial schema for MDK SQLite Storage
+-- This schema combines both OpenMLS storage tables and MDK-specific tables
+-- in a single migration to enable atomic transactions across all MLS state.
+
+-- ============================================================================
+-- OpenMLS Storage Tables
+-- ============================================================================
+
+-- Group data: polymorphic storage for various group-related data types
+CREATE TABLE IF NOT EXISTS openmls_group_data (
+    provider_version INTEGER NOT NULL,
+    group_id BLOB NOT NULL,
+    data_type TEXT NOT NULL CHECK (data_type IN (
+        'join_group_config',
+        'tree',
+        'interim_transcript_hash',
+        'context',
+        'confirmation_tag',
+        'group_state',
+        'message_secrets',
+        'resumption_psk_store',
+        'own_leaf_index',
+        'group_epoch_secrets'
+    )),
+    group_data BLOB NOT NULL,
+    PRIMARY KEY (group_id, data_type)
+);
+
+-- Proposals: queued proposals for groups
+CREATE TABLE IF NOT EXISTS openmls_proposals (
+    provider_version INTEGER NOT NULL,
+    group_id BLOB NOT NULL,
+    proposal_ref BLOB NOT NULL,
+    proposal BLOB NOT NULL,
+    PRIMARY KEY (group_id, proposal_ref)
+);
+
+-- Own leaf nodes: list of own leaf nodes per group
+CREATE TABLE IF NOT EXISTS openmls_own_leaf_nodes (
+    provider_version INTEGER NOT NULL,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id BLOB NOT NULL,
+    leaf_node BLOB NOT NULL
+);
+
+-- Key packages: stored key packages indexed by hash reference
+CREATE TABLE IF NOT EXISTS openmls_key_packages (
+    provider_version INTEGER NOT NULL,
+    key_package_ref BLOB PRIMARY KEY,
+    key_package BLOB NOT NULL
+);
+
+-- PSKs: pre-shared keys indexed by PSK ID
+CREATE TABLE IF NOT EXISTS openmls_psks (
+    provider_version INTEGER NOT NULL,
+    psk_id BLOB PRIMARY KEY,
+    psk_bundle BLOB NOT NULL
+);
+
+-- Signature keys: signature key pairs indexed by public key
+CREATE TABLE IF NOT EXISTS openmls_signature_keys (
+    provider_version INTEGER NOT NULL,
+    public_key BLOB PRIMARY KEY,
+    signature_key BLOB NOT NULL
+);
+
+-- Encryption keys: HPKE key pairs indexed by public key
+CREATE TABLE IF NOT EXISTS openmls_encryption_keys (
+    provider_version INTEGER NOT NULL,
+    public_key BLOB PRIMARY KEY,
+    key_pair BLOB NOT NULL
+);
+
+-- Epoch key pairs: HPKE key pairs for specific epochs
+CREATE TABLE IF NOT EXISTS openmls_epoch_key_pairs (
+    provider_version INTEGER NOT NULL,
+    group_id BLOB NOT NULL,
+    epoch_id BLOB NOT NULL,
+    leaf_index INTEGER NOT NULL,
+    key_pairs BLOB NOT NULL,
+    PRIMARY KEY (group_id, epoch_id, leaf_index)
+);
+
+-- ============================================================================
+-- MDK Storage Tables
+-- ============================================================================
+
+-- Groups: MDK group metadata
+CREATE TABLE IF NOT EXISTS groups (
+    mls_group_id BLOB PRIMARY KEY,
+    nostr_group_id BLOB NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    admin_pubkeys JSONB NOT NULL,
+    last_message_id BLOB,
+    last_message_at INTEGER,
+    epoch INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    image_hash BLOB,
+    image_key BLOB,
+    image_nonce BLOB
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_groups_nostr_group_id ON groups(nostr_group_id);
+
+-- Group relays: relay URLs associated with groups
+CREATE TABLE IF NOT EXISTS group_relays (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id BLOB NOT NULL,
+    relay_url TEXT NOT NULL,
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE,
+    UNIQUE(mls_group_id, relay_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_relays_mls_group_id ON group_relays(mls_group_id);
+
+-- Group exporter secrets: epoch-specific secrets for groups
+CREATE TABLE IF NOT EXISTS group_exporter_secrets (
+    mls_group_id BLOB NOT NULL,
+    epoch INTEGER NOT NULL,
+    secret BLOB NOT NULL,
+    PRIMARY KEY (mls_group_id, epoch),
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_exporter_secrets_mls_group_id ON group_exporter_secrets(mls_group_id);
+
+-- Messages: decrypted MLS messages
+CREATE TABLE IF NOT EXISTS messages (
+    mls_group_id BLOB NOT NULL,
+    id BLOB NOT NULL,
+    pubkey BLOB NOT NULL,
+    kind INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    tags JSONB NOT NULL,
+    event JSONB NOT NULL,
+    wrapper_event_id BLOB NOT NULL,
+    state TEXT NOT NULL,
+    epoch INTEGER,
+    PRIMARY KEY (mls_group_id, id),
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_mls_group_id ON messages(mls_group_id);
+CREATE INDEX IF NOT EXISTS idx_messages_wrapper_event_id ON messages(wrapper_event_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_pubkey ON messages(pubkey);
+CREATE INDEX IF NOT EXISTS idx_messages_kind ON messages(kind);
+CREATE INDEX IF NOT EXISTS idx_messages_state ON messages(state);
+CREATE INDEX IF NOT EXISTS idx_messages_epoch ON messages(mls_group_id, epoch);
+
+-- Processed messages: tracking of processed wrapper events
+CREATE TABLE IF NOT EXISTS processed_messages (
+    wrapper_event_id BLOB PRIMARY KEY,
+    message_event_id BLOB,
+    processed_at INTEGER NOT NULL,
+    epoch INTEGER,
+    mls_group_id BLOB,
+    state TEXT NOT NULL,
+    failure_reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_processed_messages_message_event_id ON processed_messages(message_event_id);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_state ON processed_messages(state);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_processed_at ON processed_messages(processed_at);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_epoch ON processed_messages(mls_group_id, epoch);
+
+-- Welcomes: pending welcome messages
+CREATE TABLE IF NOT EXISTS welcomes (
+    id BLOB PRIMARY KEY,
+    event JSONB NOT NULL,
+    mls_group_id BLOB NOT NULL,
+    nostr_group_id BLOB NOT NULL,
+    group_name TEXT NOT NULL,
+    group_description TEXT NOT NULL,
+    group_admin_pubkeys JSONB NOT NULL,
+    group_relays JSONB NOT NULL,
+    welcomer BLOB NOT NULL,
+    member_count INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    wrapper_event_id BLOB NOT NULL,
+    group_image_hash BLOB,
+    group_image_key BLOB,
+    group_image_nonce BLOB
+);
+
+CREATE INDEX IF NOT EXISTS idx_welcomes_mls_group_id ON welcomes(mls_group_id);
+CREATE INDEX IF NOT EXISTS idx_welcomes_wrapper_event_id ON welcomes(wrapper_event_id);
+CREATE INDEX IF NOT EXISTS idx_welcomes_state ON welcomes(state);
+CREATE INDEX IF NOT EXISTS idx_welcomes_nostr_group_id ON welcomes(nostr_group_id);
+
+-- Processed welcomes: tracking of processed welcome events
+CREATE TABLE IF NOT EXISTS processed_welcomes (
+    wrapper_event_id BLOB PRIMARY KEY,
+    welcome_event_id BLOB,
+    processed_at INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    failure_reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_welcome_event_id ON processed_welcomes(welcome_event_id);
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_state ON processed_welcomes(state);
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_processed_at ON processed_welcomes(processed_at);
+
+-- ============================================================================
+-- Group State Snapshots (MIP-03 Commit Race Resolution)
+-- ============================================================================
+-- Instead of SQLite savepoints (which have stack-ordering issues where
+-- releasing an old savepoint destroys all newer ones), we copy group-specific
+-- rows to this table for later restoration.
+
+CREATE TABLE IF NOT EXISTS group_state_snapshots (
+    snapshot_name TEXT NOT NULL,
+    group_id BLOB NOT NULL,
+    table_name TEXT NOT NULL,
+    row_key BLOB NOT NULL,      -- Serialized primary key (JSON)
+    row_data BLOB NOT NULL,     -- Serialized row data (JSON)
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (snapshot_name, group_id, table_name, row_key),
+    FOREIGN KEY (group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);

--- a/src-tauri/src/mls_migrations/V002__add_processed_at_to_messages.sql
+++ b/src-tauri/src/mls_migrations/V002__add_processed_at_to_messages.sql
@@ -1,0 +1,19 @@
+-- Add processed_at column to messages table
+-- This timestamp records when this client processed/received the message,
+-- which is useful for consistent message ordering across devices with clock skew.
+-- For existing rows, we default to created_at as the best available approximation.
+ALTER TABLE messages ADD COLUMN processed_at INTEGER;
+UPDATE messages SET processed_at = created_at WHERE processed_at IS NULL;
+
+-- Create a composite index for the new sort order (created_at DESC, processed_at DESC, id DESC)
+-- This ensures stable ordering: by sender's timestamp, then by reception time, then by id for determinism
+CREATE INDEX IF NOT EXISTS idx_messages_sorting ON messages(mls_group_id, created_at DESC, processed_at DESC, id DESC);
+
+-- Add last_message_processed_at column to groups table
+-- This column stores when the last message was processed/received by this client,
+-- enabling consistent message ordering between group.last_message_id and get_messages()[0].
+
+ALTER TABLE groups ADD COLUMN last_message_processed_at INTEGER;
+
+-- Backfill existing rows with last_message_at as a reasonable default
+UPDATE groups SET last_message_processed_at = last_message_at WHERE last_message_processed_at IS NULL AND last_message_at IS NOT NULL;

--- a/src-tauri/src/mls_migrations/V003__add_processed_at_first_sort_index.sql
+++ b/src-tauri/src/mls_migrations/V003__add_processed_at_first_sort_index.sql
@@ -1,0 +1,6 @@
+-- Add a composite index for the processed_at-first sort order
+-- (processed_at DESC, created_at DESC, id DESC) scoped to mls_group_id.
+-- This allows efficient queries when clients request MessageSortOrder::ProcessedAtFirst,
+-- which prioritises local reception time over the sender's timestamp.
+CREATE INDEX IF NOT EXISTS idx_messages_sorting_processed_at
+  ON messages(mls_group_id, processed_at DESC, created_at DESC, id DESC);

--- a/src-tauri/src/mls_migrations/V004__add_self_update_tracking.sql
+++ b/src-tauri/src/mls_migrations/V004__add_self_update_tracking.sql
@@ -1,0 +1,8 @@
+-- Add self-update tracking to groups table.
+-- 0  = self-update required (post-join obligation per MIP-02)
+-- >0 = unix timestamp of last successful self-update (periodic rotation per MIP-00)
+--
+-- Defaults to 0 (Required) for any existing groups, since we cannot know
+-- whether they have performed a self-update before this migration.
+
+ALTER TABLE groups ADD COLUMN last_self_update_at INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/mls_migrations/V005__add_label_to_group_exporter_secrets.sql
+++ b/src-tauri/src/mls_migrations/V005__add_label_to_group_exporter_secrets.sql
@@ -1,0 +1,30 @@
+-- Add label column to group_exporter_secrets to distinguish MIP-03 and MIP-04 exporters.
+--
+-- MIP-03 (kind:445 message encryption): label = 'group-event'
+--   Derived via MLS-Exporter("marmot", "group-event", 32)
+--
+-- MIP-04 (encrypted media): label = 'encrypted-media'
+--   Derived via MLS-Exporter("marmot", "encrypted-media", 32)
+--
+-- IMPORTANT: SQLite cannot change an existing PRIMARY KEY with ALTER TABLE ADD COLUMN.
+-- We must rebuild the table so both labels can coexist for the same (mls_group_id, epoch).
+
+CREATE TABLE group_exporter_secrets_new (
+    mls_group_id BLOB NOT NULL,
+    epoch INTEGER NOT NULL,
+    label TEXT NOT NULL,
+    secret BLOB NOT NULL,
+    PRIMARY KEY (mls_group_id, epoch, label),
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);
+
+-- Existing rows from before this migration are MIP-03 group-event exporter secrets.
+INSERT INTO group_exporter_secrets_new (mls_group_id, epoch, label, secret)
+SELECT mls_group_id, epoch, 'group-event', secret
+FROM group_exporter_secrets;
+
+DROP TABLE group_exporter_secrets;
+ALTER TABLE group_exporter_secrets_new RENAME TO group_exporter_secrets;
+
+CREATE INDEX IF NOT EXISTS idx_group_exporter_secrets_mls_group_id
+ON group_exporter_secrets(mls_group_id);

--- a/src-tauri/src/mls_store_reset.rs
+++ b/src-tauri/src/mls_store_reset.rs
@@ -95,6 +95,51 @@ fn classify_store(store_path: &Path, encryption_key: &[u8; 32]) -> StoreClassifi
     StoreClassification::Legacy
 }
 
+/// Reconciles `_refinery_schema_history_nostr_mls` against
+/// `mls_legacy_checksum`'s vendored `mdk-sqlite-storage` migration set,
+/// before `MdkSqliteStorage::new_with_key` gets a chance to run its own
+/// checksum-verifying refinery `Runner` over that table. Called only from
+/// `reset_with_connection`'s `Current` arm, after `classify_store` has
+/// already confirmed the history table is readable at `store_path`.
+///
+/// Tries a plain (unkeyed) connection first, then falls back to
+/// `encryption_key` -- mirroring `classify_store`'s own plain-then-keyed
+/// order. A real MDK 0.8.0+ store is always SQLCipher-encrypted, so the
+/// plain attempt's `UPDATE`s fail closed with a "file is not a database"
+/// error (SQLCipher rejects an unkeyed read past the header) and the keyed
+/// attempt is what actually reconciles it; a plain attempt succeeding is
+/// reserved for test fixtures that model a `Current` store without real
+/// encryption. See `mls_legacy_checksum` for why this repair exists at all.
+fn reconcile_mls_store_legacy_checksums(
+    store_path: &Path,
+    encryption_key: &[u8; 32],
+) -> Result<(), String> {
+    let migrations = crate::mls_legacy_checksum::embedded_migration_set();
+
+    if let Ok(conn) = Connection::open(store_path) {
+        if crate::migrations::reconcile_legacy_checksums_for_table(
+            &conn,
+            crate::mls_legacy_checksum::MLS_HISTORY_TABLE_NAME,
+            &migrations,
+        )
+        .is_ok()
+        {
+            return Ok(());
+        }
+    }
+
+    let conn = Connection::open(store_path)
+        .map_err(|e| format!("Failed to open MLS store for checksum reconciliation: {e}"))?;
+    let key_hex = hex::encode(encryption_key);
+    conn.execute_batch(&format!("PRAGMA key = \"x'{key_hex}'\";"))
+        .map_err(|e| format!("Failed to key MLS store for checksum reconciliation: {e}"))?;
+    crate::migrations::reconcile_legacy_checksums_for_table(
+        &conn,
+        crate::mls_legacy_checksum::MLS_HISTORY_TABLE_NAME,
+        &migrations,
+    )
+}
+
 fn archive_path(profile_dir: &Path, now: u64) -> PathBuf {
     let base = profile_dir.join(format!("{ARCHIVE_PREFIX}{now}"));
     if !base.exists() {
@@ -380,7 +425,15 @@ fn reset_with_connection(
                 "Unsupported MLS store schema version {version}; refusing to open or archive. Expected 1–5 (current) or ≥100 (legacy)."
             ));
         }
-        StoreClassification::Fresh | StoreClassification::Current => {
+        StoreClassification::Fresh => {
+            put_setting(conn, RESET_MARKER_KEY, "complete")?;
+            if let Err(e) = prune_archives(profile_dir, now) {
+                eprintln!("[MLS Reset] Failed to prune archives: {e}");
+            }
+            return Ok(ResetOutcome::default());
+        }
+        StoreClassification::Current => {
+            reconcile_mls_store_legacy_checksums(store_path, encryption_key)?;
             put_setting(conn, RESET_MARKER_KEY, "complete")?;
             if let Err(e) = prune_archives(profile_dir, now) {
                 eprintln!("[MLS Reset] Failed to prune archives: {e}");
@@ -1320,5 +1373,138 @@ mod tests {
 
             cleanup(&path);
         }
+    }
+
+    /// Regression test for the second half of the checksum-width break
+    /// (see `crate::mls_legacy_checksum`): a `_refinery_schema_history_nostr_mls`
+    /// row stamped with the legacy i32-schema-version checksum -- what
+    /// every pre-0.6.0 build actually wrote, since `mdk-sqlite-storage`
+    /// 0.8.0 was already pinned before Pacto enabled `int8-versions` --
+    /// makes the real `mdk_sqlite_storage` crate's own refinery runner
+    /// abort with `DivergentVersion` on reopen. Proves the failure mode
+    /// `reconcile_mls_store_legacy_checksums` exists to prevent actually
+    /// occurs against the real MDK crate, not just this crate's model of
+    /// it.
+    #[test]
+    fn mls_store_with_legacy_checksums_fails_to_reopen_without_reconciliation() {
+        let root = temp_dir("mls-legacy-checksum-sanity");
+        let store_path = root.join("mls.db");
+        let key = [33u8; 32];
+
+        let storage = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        )
+        .expect("fresh store creates and migrates cleanly");
+        drop(storage);
+
+        let conn = Connection::open(&store_path).unwrap();
+        conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex::encode(key)))
+            .unwrap();
+        for migration in crate::mls_legacy_checksum::embedded_migration_set() {
+            let Some(sql) = migration.sql() else { continue };
+            let legacy = crate::storage_format::legacy_i32_checksum(
+                migration.name(),
+                migration.version(),
+                sql,
+            )
+            .to_string();
+            conn.execute(
+                "UPDATE _refinery_schema_history_nostr_mls SET checksum = ?1 WHERE version = ?2",
+                rusqlite::params![legacy, migration.version()],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        // classify_store only looks at the version number, not the
+        // checksum -- this is exactly why the bug slips past detection.
+        assert_eq!(
+            classify_store(&store_path, &key),
+            StoreClassification::Current
+        );
+
+        let reopened = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        );
+        assert!(
+            reopened.is_err(),
+            "a legacy-checksum-stamped store must fail to reopen without reconciliation -- \
+             otherwise this test no longer reproduces the field bug"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Same legacy-checksum-stamped store as the sanity test above, but run
+    /// through `reconcile_mls_store_legacy_checksums` first -- the actual
+    /// fix. The real `mdk_sqlite_storage` crate must then reopen the store
+    /// cleanly, proving the reconciliation satisfies that crate's own
+    /// checksum verification, not just this crate's read-only model of it.
+    #[test]
+    fn reconcile_mls_store_legacy_checksums_lets_mdk_reopen() {
+        let root = temp_dir("mls-legacy-checksum-fix");
+        let store_path = root.join("mls.db");
+        let key = [34u8; 32];
+
+        let storage = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        )
+        .expect("fresh store creates and migrates cleanly");
+        drop(storage);
+
+        let conn = Connection::open(&store_path).unwrap();
+        conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex::encode(key)))
+            .unwrap();
+        let mut legacy_checksums = Vec::new();
+        for migration in crate::mls_legacy_checksum::embedded_migration_set() {
+            let Some(sql) = migration.sql() else { continue };
+            let legacy = crate::storage_format::legacy_i32_checksum(
+                migration.name(),
+                migration.version(),
+                sql,
+            )
+            .to_string();
+            conn.execute(
+                "UPDATE _refinery_schema_history_nostr_mls SET checksum = ?1 WHERE version = ?2",
+                rusqlite::params![legacy, migration.version()],
+            )
+            .unwrap();
+            legacy_checksums.push((migration.version(), migration.checksum().to_string()));
+        }
+        drop(conn);
+
+        reconcile_mls_store_legacy_checksums(&store_path, &key)
+            .expect("reconciliation should succeed against a legacy-stamped store");
+
+        let verify = Connection::open(&store_path).unwrap();
+        verify
+            .execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex::encode(key)))
+            .unwrap();
+        for (version, expected_current_checksum) in &legacy_checksums {
+            let stored: String = verify
+                .query_row(
+                    "SELECT checksum FROM _refinery_schema_history_nostr_mls WHERE version = ?1",
+                    [version],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(&stored, expected_current_checksum);
+        }
+        drop(verify);
+
+        let reopened = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        );
+        assert!(
+            reopened.is_ok(),
+            "reconciled store must reopen cleanly: {:?}",
+            reopened.err()
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src-tauri/src/mls_store_reset.rs
+++ b/src-tauri/src/mls_store_reset.rs
@@ -98,33 +98,34 @@ fn classify_store(store_path: &Path, encryption_key: &[u8; 32]) -> StoreClassifi
 /// Reconciles `_refinery_schema_history_nostr_mls` against
 /// `mls_legacy_checksum`'s vendored `mdk-sqlite-storage` migration set,
 /// before `MdkSqliteStorage::new_with_key` gets a chance to run its own
-/// checksum-verifying refinery `Runner` over that table. Called only from
-/// `reset_with_connection`'s `Current` arm, after `classify_store` has
-/// already confirmed the history table is readable at `store_path`.
+/// checksum-verifying refinery `Runner` over that table. Called from
+/// `reset_with_connection` on every open of a `Current` store -- both the
+/// one-time `Current` classification and the marker-complete fast path --
+/// so accounts that already carried `mls_store_reset_v1 = complete` before
+/// this repair existed (every 0.5.x account, see `mls_legacy_checksum`)
+/// still get reconciled instead of skipping it forever.
 ///
 /// Tries a plain (unkeyed) connection first, then falls back to
 /// `encryption_key` -- mirroring `classify_store`'s own plain-then-keyed
 /// order. A real MDK 0.8.0+ store is always SQLCipher-encrypted, so the
-/// plain attempt's `UPDATE`s fail closed with a "file is not a database"
-/// error (SQLCipher rejects an unkeyed read past the header) and the keyed
-/// attempt is what actually reconciles it; a plain attempt succeeding is
-/// reserved for test fixtures that model a `Current` store without real
-/// encryption. See `mls_legacy_checksum` for why this repair exists at all.
+/// unkeyed attempt can open the file handle but cannot read
+/// `MLS_HISTORY_TABLE_NAME` through it; only a connection that actually
+/// reads the table is ever used to write to it, so the unkeyed attempt is a
+/// genuine no-op against a real store and only ever proceeds for test
+/// fixtures that model a `Current` store without real encryption. See
+/// `mls_legacy_checksum` for why this repair exists at all.
 fn reconcile_mls_store_legacy_checksums(
     store_path: &Path,
     encryption_key: &[u8; 32],
 ) -> Result<(), String> {
     let migrations = crate::mls_legacy_checksum::embedded_migration_set();
+    let table = crate::mls_legacy_checksum::MLS_HISTORY_TABLE_NAME;
 
     if let Ok(conn) = Connection::open(store_path) {
-        if crate::migrations::reconcile_legacy_checksums_for_table(
-            &conn,
-            crate::mls_legacy_checksum::MLS_HISTORY_TABLE_NAME,
-            &migrations,
-        )
-        .is_ok()
-        {
-            return Ok(());
+        if history_table_readable(&conn, table) {
+            return crate::migrations::reconcile_legacy_checksums_for_table(
+                &conn, table, &migrations,
+            );
         }
     }
 
@@ -133,11 +134,19 @@ fn reconcile_mls_store_legacy_checksums(
     let key_hex = hex::encode(encryption_key);
     conn.execute_batch(&format!("PRAGMA key = \"x'{key_hex}'\";"))
         .map_err(|e| format!("Failed to key MLS store for checksum reconciliation: {e}"))?;
-    crate::migrations::reconcile_legacy_checksums_for_table(
-        &conn,
-        crate::mls_legacy_checksum::MLS_HISTORY_TABLE_NAME,
-        &migrations,
-    )
+    crate::migrations::reconcile_legacy_checksums_for_table(&conn, table, &migrations)
+}
+
+/// True only when `conn` can actually read `table` -- guards against
+/// treating an unkeyed connection to a SQLCipher-encrypted store as
+/// authoritative just because it opened without erroring. A 0-row `UPDATE`
+/// against a table this connection cannot see would otherwise return `Ok`
+/// and be mistaken for "nothing to reconcile."
+fn history_table_readable(conn: &Connection, table: &str) -> bool {
+    conn.query_row(&format!("SELECT COUNT(*) FROM \"{table}\""), [], |row| {
+        row.get::<_, i64>(0)
+    })
+    .is_ok()
 }
 
 fn archive_path(profile_dir: &Path, now: u64) -> PathBuf {
@@ -402,6 +411,16 @@ fn reset_with_connection(
         .ok_or_else(|| "MLS directory has no profile parent".to_string())?;
 
     if setting(conn, RESET_MARKER_KEY)?.as_deref() == Some("complete") {
+        // Runs on every open, not just the one-time `Current` classification
+        // below -- otherwise accounts that already carried this marker
+        // before the checksum-width fix existed (every 0.5.x account, see
+        // `mls_legacy_checksum`) would skip reconciliation forever and
+        // `MdkSqliteStorage::new_with_key` would fail closed with
+        // `DivergentVersion`. A missing `store_path` here just means the
+        // account is fresh and MDK hasn't created it yet.
+        if store_path.exists() {
+            reconcile_mls_store_legacy_checksums(store_path, encryption_key)?;
+        }
         // Best-effort: a stuck archive directory (held-open handle, read-only
         // FS) must never block every future MLS engine acquisition.
         if let Err(e) = prune_archives(profile_dir, now) {
@@ -1502,6 +1521,68 @@ mod tests {
         assert!(
             reopened.is_ok(),
             "reconciled store must reopen cleanly: {:?}",
+            reopened.err()
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Regression test for the bug this fix closes: the marker-complete
+    /// fast path used to skip reconciliation entirely. Every 0.5.x account
+    /// that opened MLS after 6df3f0e7 already has `mls_store_reset_v1 =
+    /// complete` set, so `reset_with_connection` must reconcile a `Current`
+    /// store's legacy checksums on that path too -- not just the one-time
+    /// `Current` classification branch the tests above cover.
+    #[test]
+    fn reset_with_connection_reconciles_current_store_on_marker_complete_fast_path() {
+        let root = temp_dir("mls-legacy-checksum-fast-path");
+        let mls = root.join("mls");
+        std::fs::create_dir_all(&mls).unwrap();
+        let store_path = mls.join("vector-mls.db");
+        let key = [35u8; 32];
+
+        let storage = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        )
+        .expect("fresh store creates and migrates cleanly");
+        drop(storage);
+
+        let conn = Connection::open(&store_path).unwrap();
+        conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex::encode(key)))
+            .unwrap();
+        for migration in crate::mls_legacy_checksum::embedded_migration_set() {
+            let Some(sql) = migration.sql() else { continue };
+            let legacy = crate::storage_format::legacy_i32_checksum(
+                migration.name(),
+                migration.version(),
+                sql,
+            )
+            .to_string();
+            conn.execute(
+                "UPDATE _refinery_schema_history_nostr_mls SET checksum = ?1 WHERE version = ?2",
+                rusqlite::params![legacy, migration.version()],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        // The account was already reset under a build that predates this
+        // repair -- `mls_store_reset_v1` is already `complete`, same as
+        // every 0.5.x account.
+        let app_conn = app_db(&root.join("app.db"));
+        put_setting(&app_conn, RESET_MARKER_KEY, "complete").unwrap();
+
+        let outcome = reset_with_connection(&app_conn, &mls, &store_path, &key, 5).unwrap();
+        assert!(!outcome.reset_performed);
+
+        let reopened = mdk_sqlite_storage::MdkSqliteStorage::new_with_key(
+            &store_path,
+            mdk_sqlite_storage::EncryptionConfig::new(key),
+        );
+        assert!(
+            reopened.is_ok(),
+            "fast path must reconcile a Current store's legacy checksums: {:?}",
             reopened.err()
         );
 

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -116,8 +116,11 @@ pub(crate) enum StorageFormatVerdict {
 /// `refinery_schema_history` for every migration that predates the switch.
 ///
 /// Used only to *recognize* a legacy-stamped row -- in `classify_history`
-/// below and in `migrations::reconcile_legacy_checksums` -- never to write
-/// a checksum this build computes for a migration it applies itself.
+/// below and in `migrations::reconcile_legacy_checksums_for_table`, reused
+/// for both `pacto.db`'s `refinery_schema_history` and the MLS store's
+/// `_refinery_schema_history_nostr_mls` (see
+/// `mls_store_reset::reconcile_mls_store_legacy_checksums`) -- never to
+/// write a checksum this build computes for a migration it applies itself.
 pub(crate) fn legacy_i32_checksum(name: &str, version: i64, sql: &str) -> u64 {
     let mut hasher = SipHasher13::new();
     name.hash(&mut hasher);
@@ -776,6 +779,29 @@ mod tests {
             classify_history(&applied, true, true, std::slice::from_ref(&migration)),
             StorageFormatVerdict::Recognized
         );
+    }
+
+    /// Anchors `legacy_i32_checksum` to a value computed *outside* this
+    /// reproduction: two throwaway crates pinned to the exact
+    /// `refinery-core = 0.9.2` this build resolves to, one built with the
+    /// `int8-versions` feature and one without, both hashing
+    /// `Migration::unapplied("V1__initial_schema", "CREATE TABLE t (id INTEGER);")`.
+    /// Every other test derives its expected legacy digest from
+    /// `legacy_i32_checksum` itself, so a deterministic-but-wrong
+    /// reproduction (wrong field order, hashing the unparsed input name
+    /// instead of refinery's parsed one, a future `siphasher` major-version
+    /// skew against refinery-core's own) would still pass them all. This
+    /// test fails if that ever happens.
+    #[test]
+    fn legacy_i32_checksum_matches_independently_measured_golden_value() {
+        let name = "initial_schema";
+        let sql = "CREATE TABLE t (id INTEGER);";
+        assert_eq!(legacy_i32_checksum(name, 1, sql), 470904781690771365);
+
+        let migration =
+            refinery::Migration::unapplied("V1__initial_schema", sql).expect("unapplied migration");
+        assert_eq!(migration.name(), name);
+        assert_eq!(migration.checksum(), 17539547413937229480);
     }
 
     #[test]

--- a/src-tauri/src/storage_format.rs
+++ b/src-tauri/src/storage_format.rs
@@ -15,6 +15,8 @@
 //! for the gate.
 
 use rusqlite::{Connection, OpenFlags};
+use siphasher::sip::SipHasher13;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -102,6 +104,28 @@ pub(crate) enum StorageFormatVerdict {
     Divergent(i64),
 }
 
+/// Reproduces refinery-core's migration checksum exactly as every Pacto
+/// build before 0.6.0 computed it, when `refinery::SchemaVersion` was `i32`
+/// instead of `i64` (the `int8-versions` Cargo feature, added so a
+/// 14-digit UTC-timestamp migration version fits, was off). Refinery hashes
+/// `(name, version, sql)` through `SipHasher13`; hashing an `i32` vs an
+/// `i64` for the identical numeric `version` feeds a different byte width
+/// into the hasher and produces a different digest, even though the
+/// migration's name and SQL never changed. That silently invalidated the
+/// checksum every pre-0.6.0 install had already stamped into
+/// `refinery_schema_history` for every migration that predates the switch.
+///
+/// Used only to *recognize* a legacy-stamped row -- in `classify_history`
+/// below and in `migrations::reconcile_legacy_checksums` -- never to write
+/// a checksum this build computes for a migration it applies itself.
+pub(crate) fn legacy_i32_checksum(name: &str, version: i64, sql: &str) -> u64 {
+    let mut hasher = SipHasher13::new();
+    name.hash(&mut hasher);
+    (version as i32).hash(&mut hasher);
+    sql.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Pure classification over the read-only probe's outputs. Reproduces
 /// refinery-core 0.9.2's `verify_migrations` (default `abort_missing: true`,
 /// `abort_divergent: true`) read-only, looping over every applied row --
@@ -131,7 +155,15 @@ fn classify_history(
         match embedded.iter().find(|m| m.version() == row.version) {
             None => return StorageFormatVerdict::Unrecognized(row.version),
             Some(migration) => {
-                if migration.name() != row.name || migration.checksum().to_string() != row.checksum
+                if migration.name() != row.name {
+                    return StorageFormatVerdict::Divergent(row.version);
+                }
+                let current_checksum = migration.checksum().to_string();
+                let legacy_checksum = migration.sql().map(|sql| {
+                    legacy_i32_checksum(migration.name(), migration.version(), sql).to_string()
+                });
+                if row.checksum != current_checksum
+                    && Some(&row.checksum) != legacy_checksum.as_ref()
                 {
                     return StorageFormatVerdict::Divergent(row.version);
                 }
@@ -720,6 +752,41 @@ mod tests {
         assert_eq!(
             classify_history(&applied, true, true, &embedded),
             StorageFormatVerdict::Divergent(2)
+        );
+    }
+
+    #[test]
+    fn legacy_i32_schema_version_checksum_is_recognized() {
+        let migration =
+            refinery::Migration::unapplied("V1__initial_schema", "CREATE TABLE t (id INTEGER);")
+                .expect("unapplied migration");
+        let legacy = legacy_i32_checksum(
+            migration.name(),
+            migration.version(),
+            "CREATE TABLE t (id INTEGER);",
+        )
+        .to_string();
+        assert_ne!(
+            legacy,
+            migration.checksum().to_string(),
+            "fixture must actually exercise the i32-vs-i64 checksum difference"
+        );
+        let applied = vec![fixture_row(1, migration.name(), &legacy)];
+        assert_eq!(
+            classify_history(&applied, true, true, std::slice::from_ref(&migration)),
+            StorageFormatVerdict::Recognized
+        );
+    }
+
+    #[test]
+    fn checksum_matching_neither_current_nor_legacy_is_divergent() {
+        let migration =
+            refinery::Migration::unapplied("V1__initial_schema", "CREATE TABLE t (id INTEGER);")
+                .expect("unapplied migration");
+        let applied = vec![fixture_row(1, migration.name(), "not-a-real-checksum")];
+        assert_eq!(
+            classify_history(&applied, true, true, std::slice::from_ref(&migration)),
+            StorageFormatVerdict::Divergent(1)
         );
     }
 


### PR DESCRIPTION
## Summary

Users upgrading from 0.5.x to 0.6.0 (fresh install or in-app update + restart) hit "This build cannot open your data" before they could even unlock their account — a hard, machine-wide block claiming their data was "written by a newer version of Pacto." It wasn't. Enabling refinery's `int8-versions` Cargo feature (`SchemaVersion` `i32` -> `i64`, needed so a 14-digit UTC-timestamp migration version fits) silently changed the checksum of every migration a pre-0.6.0 build had already applied — refinery hashes `(name, version, sql)` together, and hashing an `i32` vs an `i64` for the identical version value feeds a different byte width into `SipHasher13`, producing a different digest with no change to the migration itself. Every account that had applied any migration under a pre-0.6.0 build (i.e. nearly everyone) hit a checksum mismatch on `V1` at cold launch.

`storage_format::legacy_i32_checksum` reproduces the pre-`int8-versions` digest so `classify_history` recognizes a row stamped with either checksum, fixing the pre-auth gate. `migrations::reconcile_legacy_checksums_for_table` runs a raw-SQL repair before refinery's own `Runner::run`, so its internal verification — which enforces only the current checksum — also accepts the legacy history, and rewrites it to the current checksum so the repair only ever runs once per account. A row matching neither checksum is still a genuine divergence and still gates.

**Second commit, from code review on this branch:** the same break also invalidates `_refinery_schema_history_nostr_mls`, the separate refinery history table `mdk-sqlite-storage` 0.8.0 owns on the MLS store (`mls.db`) — Cargo unifies features per dependency across the whole build, so `int8-versions` silently applies there too, and that crate's own `run_migrations` aborts independently of `pacto.db`'s gate. `mdk-sqlite-storage` 0.8.0 predates 0.6.0 (shipped unchanged in 0.5.4/0.5.5), so this hit the exact same upgrade population — and the first commit alone made it *harder* to notice, since it let affected accounts past the pre-auth gate and into a successful login, only to then find their MLS engine permanently unopenable (the store's own `Current`/`Legacy` classification looks only at the history table's version number, never its checksum). `mls_legacy_checksum` vendors a byte-for-byte copy of `mdk-sqlite-storage`'s five migration files (that crate doesn't expose its embedded set publicly) to reconcile the same way, called right before `MdkSqliteStorage::new_with_key`.

## New concepts

**A Cargo feature flag can silently invalidate a stored hash/checksum by changing an integer's type width.**

`refinery-core`'s migration checksum hashes `(name, version, sql)` through `SipHasher13`. Rust's integer `Hash` impls write the value's raw bytes (`write_i32` vs `write_i64`), and `SipHasher13` mixes the total byte length into its finalization — so hashing the *same numeric value* as a different integer type produces a *different* digest, even though nothing about the logical data changed. `refinery`'s `int8-versions` feature retypes `SchemaVersion` from `i32` to `i64`; every migration checksum this build computes shifted the moment that feature turned on, silently breaking equality against every checksum a build without the feature had already written to disk. Cargo's feature unification means this doesn't stay contained to the crate that requests the feature — every dependency sharing that same `refinery-core` resolution gets it too, which is exactly how a change to *this* app's Cargo.toml broke a vendored third-party crate's own migration checksums.

This class of bug is worth watching for anywhere a checksum, hash, or cache key is derived from a value whose declared type can change (a feature flag, a generic parameter, a newtype swap) — the stored artifact and the freshly computed one diverge with no compiler error and no obvious symptom besides "recognized data now looks unrecognized."

Verified independently of this repo's code: two throwaway crates pinned to the exact `refinery-core = 0.9.2`, one with `int8-versions` and one without, hashing the identical `(name, sql)` — different checksums (`470904781690771365` vs `17539547413937229480`). That measured pair is now pinned as a golden-value regression test so the in-repo reproduction can't silently drift from the real algorithm.

Don't reach for this fix pattern (tolerate both digests + reconcile) unless the checksum's *only* job is drift detection, not a security boundary — silently accepting a legacy digest is safe here because a real divergence (wrong name, wrong SQL) still fails both checks.

## Validation

- `v1_database_with_legacy_checksum_reconciles_and_migrates` (pacto.db): stamps a `V1` row with the legacy checksum, confirms `run_migrations` succeeds and reconciles it.
- `mls_store_with_legacy_checksums_fails_to_reopen_without_reconciliation` / `reconcile_mls_store_legacy_checksums_lets_mdk_reopen` (MLS store): builds a *real* store via `mdk_sqlite_storage::MdkSqliteStorage::new_with_key`, stamps it with legacy checksums, proves the real MDK crate refuses to reopen it without the fix and succeeds with it — not just this repo's model of refinery's behavior.
- `legacy_i32_checksum_matches_independently_measured_golden_value`: pins the reproduction to the externally-measured digest pair above.
- `mdk_sqlite_storage_version_matches_vendored_migrations`: fails the build if `Cargo.lock`'s pinned `mdk-sqlite-storage` version ever drifts from the vendored migration copy.
- `cargo test --lib`: 748 passed, 0 failed, 2 ignored (pre-existing).
- `cargo fmt --check` clean on every touched file.

## Follow-up (not in this PR)

This fixes the checksum going forward; every account already stuck on the current 0.6.0 binary needs a build with this fix (0.6.1) to self-heal on next launch — there's no way for an already-bricked install to reconcile itself without one. Worth flagging in the release notes and to anyone already blocked.

