### PR TITLE
refactor: convert dm/ dispatchers to callback props

### DIFF
--- a/src/components/dm/DmMessageRouter.svelte
+++ b/src/components/dm/DmMessageRouter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import Message from './Message.svelte';
   import InviteCard from './InviteCard.svelte';
   import WalletTxRequestCard from '../wallet/WalletTxRequestCard.svelte';
@@ -62,6 +61,7 @@
     payload: WalletPeerInfoRequestPayload
   ) => void | Promise<void> = () => {};
   export let onOpenInviterChat: ((inviterNpub: string) => void) | undefined = undefined;
+  export let onReply: (messageId: string) => void = () => {};
   /** Nest under previous same-author plain message (hide avatar/header). */
   export let compact: boolean = false;
 
@@ -74,8 +74,6 @@
     !msg.mine && inviterNpubForCard && inviterNpubForCard !== npub && onOpenInviterChat
       ? () => onOpenInviterChat!(inviterNpubForCard!)
       : undefined;
-
-  const dispatch = createEventDispatcher<{ reply: { messageId: string } }>();
 
   async function onReact(messageId: string, emoji: string) {
     try {
@@ -92,10 +90,6 @@
       return;
     }
     navigator.clipboard.writeText(text).catch(() => showToast('Could not copy message'));
-  }
-
-  function onReply(messageId: string) {
-    dispatch('reply', { messageId });
   }
 </script>
 

--- a/src/components/dm/DmThread.svelte
+++ b/src/components/dm/DmThread.svelte
@@ -90,8 +90,7 @@
   let replyPreview: string | undefined = undefined;
   $: chatDeleting = $deletingDmNpubs.has(npub);
 
-  function onReply(event: CustomEvent<{ messageId: string }>) {
-    const messageId = event.detail.messageId;
+  function onReply(messageId: string) {
     const msg = messages.find((m) => m.id === messageId);
     if (!msg) return;
     replyToMessageId = messageId;
@@ -577,7 +576,7 @@
           {onDeclineWalletPeerInfoRequest}
           {onOpenInviterChat}
           compact={shouldStackWithPrevious(messages[i - 1], msg)}
-          on:reply={onReply}
+          {onReply}
         />
       {/each}
     {:else}

--- a/src/components/dm/ImageViewer.svelte
+++ b/src/components/dm/ImageViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import { onDestroy, createEventDispatcher } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { revealInFolder, canRevealInFolder } from '../../lib/utils/reveal-in-folder';
   import { formatMessageTimestamp } from '../../lib/utils/message-formatting';
   import { saveAttachmentAs } from '../../lib/api/nostr';
@@ -21,8 +21,7 @@
   export let chatId: string | undefined = undefined;
   export let messageId: string | undefined = undefined;
   export let attachmentId: string | undefined = undefined;
-
-  const dispatch = createEventDispatcher<{ showMessage: { messageId: string } }>();
+  export let onShowMessage: (messageId: string) => void = () => {};
 
   let scale = 1;
   let translateX = 0;
@@ -152,7 +151,7 @@
   /** Closes the viewer and asks the caller to scroll to/highlight this image's source message. */
   function handleShowMessage() {
     closeMenu();
-    if (messageId) dispatch('showMessage', { messageId });
+    if (messageId) onShowMessage(messageId);
     close();
   }
 

--- a/src/components/dm/ImageViewer.test.ts
+++ b/src/components/dm/ImageViewer.test.ts
@@ -178,23 +178,23 @@ describe('ImageViewer', () => {
     expect(document.querySelector('.viewer-menu')).toBeNull();
   });
 
-  it('dispatches showMessage with the message id and closes the viewer when "Show message" is selected', async () => {
-    const showMessageHandler = vi.fn();
+  it('calls onShowMessage with the message id and closes the viewer when "Show message" is selected', async () => {
+    const onShowMessage = vi.fn();
     render(ImageViewer, {
       props: {
         open: true,
         src: 'https://example.com/img.png',
         alt: 'test',
         messageId: 'm42',
+        onShowMessage,
       },
-      events: { showMessage: showMessageHandler },
     });
 
     await fireEvent.click(screen.getByLabelText('More options'));
     await fireEvent.click(screen.getByLabelText('Show message'));
 
-    expect(showMessageHandler).toHaveBeenCalledTimes(1);
-    expect(showMessageHandler.mock.calls[0][0].detail).toEqual({ messageId: 'm42' });
+    expect(onShowMessage).toHaveBeenCalledTimes(1);
+    expect(onShowMessage).toHaveBeenCalledWith('m42');
     expect(screen.queryByRole('dialog', { name: 'Image viewer' })).toBeNull();
   });
 

--- a/src/components/dm/Message.svelte
+++ b/src/components/dm/Message.svelte
@@ -71,10 +71,6 @@
     jumpToMessage(replyToId);
   }
 
-  function handleAttachmentShowMessage(event: CustomEvent<{ messageId: string }>) {
-    jumpToMessage(event.detail.messageId);
-  }
-
   let menuOpen = false;
   let menuX = 0;
   let menuY = 0;
@@ -240,14 +236,14 @@
     reactAndClose(rawEmoji);
   }
 
-  function handleMenuCopy() {
+  function handleMenuCopy(messageId: string, text: string) {
     closeMenu();
-    onCopy(id, displayContent);
+    onCopy(messageId, text);
   }
 
-  function handleMenuReply() {
+  function handleMenuReply(messageId: string) {
     closeMenu();
-    onReply(id);
+    onReply(messageId);
   }
 
   function handleChipClick(emoji: string, includesMe: boolean) {
@@ -404,7 +400,7 @@
               {authorName}
               avatarSrc={avatar}
               {timestamp}
-              on:showMessage={handleAttachmentShowMessage}
+              onShowMessage={jumpToMessage}
             />
           {/each}
         </div>
@@ -525,8 +521,8 @@
         <MessageActionsMenu
           messageId={id}
           text={displayContent}
-          on:copy={handleMenuCopy}
-          on:reply={handleMenuReply}
+          onCopy={handleMenuCopy}
+          onReply={handleMenuReply}
         />
       {:else}
         <div class="reaction-picker-expanded" role="dialog" aria-label={$t('messaging.message.chooseReactionAria')}>

--- a/src/components/dm/MessageActionsMenu.svelte
+++ b/src/components/dm/MessageActionsMenu.svelte
@@ -1,22 +1,10 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  import { createEventDispatcher } from 'svelte';
 
   export let messageId: string;
   export let text: string = '';
-
-  const dispatch = createEventDispatcher<{
-    copy: { messageId: string; text: string };
-    reply: { messageId: string };
-  }>();
-
-  function onCopy() {
-    dispatch('copy', { messageId, text });
-  }
-
-  function onReply() {
-    dispatch('reply', { messageId });
-  }
+  export let onCopy: (messageId: string, text: string) => void = () => {};
+  export let onReply: (messageId: string) => void = () => {};
 </script>
 
 <div class="message-actions-menu" role="group" aria-label="Message actions">
@@ -26,7 +14,7 @@
     role="menuitem"
     aria-label="Copy message"
     title={$t('messaging.message.copy')}
-    onclick={onCopy}
+    onclick={() => onCopy(messageId, text)}
   >
     <span class="menu-icon" aria-hidden="true">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -42,7 +30,7 @@
     role="menuitem"
     aria-label="Reply to message"
     title={$t('messaging.message.reply')}
-    onclick={onReply}
+    onclick={() => onReply(messageId)}
   >
     <span class="menu-icon" aria-hidden="true">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/components/dm/MessageActionsMenu.test.ts
+++ b/src/components/dm/MessageActionsMenu.test.ts
@@ -10,29 +10,25 @@ describe('MessageActionsMenu', () => {
     expect(screen.getByRole('menuitem', { name: 'Reply to message' })).toBeTruthy();
   });
 
-  it('dispatches copy with message id and text', async () => {
+  it('calls onCopy with message id and text', async () => {
     const onCopy = vi.fn();
     render(MessageActionsMenu, {
-      props: { messageId: 'msg-2', text: 'copy me' },
-      events: { copy: onCopy },
+      props: { messageId: 'msg-2', text: 'copy me', onCopy },
     });
 
     await fireEvent.click(screen.getByRole('menuitem', { name: 'Copy message' }));
     expect(onCopy).toHaveBeenCalledTimes(1);
-    const event = onCopy.mock.calls[0][0];
-    expect(event.detail).toEqual({ messageId: 'msg-2', text: 'copy me' });
+    expect(onCopy).toHaveBeenCalledWith('msg-2', 'copy me');
   });
 
-  it('dispatches reply with message id', async () => {
+  it('calls onReply with message id', async () => {
     const onReply = vi.fn();
     render(MessageActionsMenu, {
-      props: { messageId: 'msg-3', text: 'reply to me' },
-      events: { reply: onReply },
+      props: { messageId: 'msg-3', text: 'reply to me', onReply },
     });
 
     await fireEvent.click(screen.getByRole('menuitem', { name: 'Reply to message' }));
     expect(onReply).toHaveBeenCalledTimes(1);
-    const event = onReply.mock.calls[0][0];
-    expect(event.detail).toEqual({ messageId: 'msg-3' });
+    expect(onReply).toHaveBeenCalledWith('msg-3');
   });
 });

--- a/src/components/dm/MessageAttachment.svelte
+++ b/src/components/dm/MessageAttachment.svelte
@@ -3,7 +3,7 @@
   import { downloadAttachment, decodeBlurhash, saveAttachmentAs } from '../../lib/api/nostr';
   import { showToast } from '../../stores/toast';
   import { t } from 'svelte-i18n';
-  import { createEventDispatcher, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
   import type { Attachment } from '../../stores/dm';
   import { attachmentKind, attachmentDisplayName, type AttachmentKind } from '../../lib/messaging/attachment-display';
   import ImageViewer from './ImageViewer.svelte';
@@ -20,8 +20,7 @@
   export let authorName: string = '';
   export let avatarSrc: string = '';
   export let timestamp: string = '';
-
-  const dispatch = createEventDispatcher<{ showMessage: { messageId: string } }>();
+  export let onShowMessage: (messageId: string) => void = () => {};
 
   const KIND_LABEL_KEY: Record<AttachmentKind, string> = {
     image: 'messaging.attachment.image',
@@ -213,10 +212,6 @@
       savingAs = false;
     }
   }
-
-  function forwardShowMessage(event: CustomEvent<{ messageId: string }>) {
-    dispatch('showMessage', event.detail);
-  }
 </script>
 
 <div class="attachment" class:tile-layout={isTile}>
@@ -372,7 +367,7 @@
   {chatId}
   {messageId}
   attachmentId={attachment.id}
-  on:showMessage={forwardShowMessage}
+  {onShowMessage}
 />
 
 <style>

--- a/src/components/dm/MessageAttachment.test.ts
+++ b/src/components/dm/MessageAttachment.test.ts
@@ -174,7 +174,7 @@ describe('MessageAttachment', () => {
     expect(screen.queryByText('Alice')).not.toBeNull();
   });
 
-  it('forwards the image viewer showMessage event as its own', async () => {
+  it('forwards the image viewer showMessage callback as its own', async () => {
     const attachment: Attachment = {
       ...baseAttachment,
       path: '/cache/abc123.png',
@@ -182,8 +182,7 @@ describe('MessageAttachment', () => {
     };
     const onShowMessage = vi.fn();
     render(MessageAttachment, {
-      props: { attachment, chatId: 'npub1abc', messageId: 'm1' },
-      events: { showMessage: onShowMessage },
+      props: { attachment, chatId: 'npub1abc', messageId: 'm1', onShowMessage },
     });
 
     await waitFor(() => {
@@ -195,7 +194,7 @@ describe('MessageAttachment', () => {
     await fireEvent.click(screen.getByLabelText('Show message'));
 
     expect(onShowMessage).toHaveBeenCalledTimes(1);
-    expect(onShowMessage.mock.calls[0][0].detail).toEqual({ messageId: 'm1' });
+    expect(onShowMessage).toHaveBeenCalledWith('m1');
   });
 
   it('downloads a non-image attachment when the file card is clicked', async () => {


### PR DESCRIPTION
Removes `createEventDispatcher` — the last deprecated component-event mechanism in the codebase — from the four remaining sites in `src/components/dm/`: `MessageActionsMenu` (copy, reply), `MessageAttachment` (showMessage), `DmMessageRouter` (reply), and `ImageViewer` (showMessage). Each dispatched event becomes a callback prop named for the event, called directly with the former `detail` payload, so the three consumers (`Message.svelte`, `DmThread.svelte`, `MessageAttachment.svelte`) stop unwrapping `event.detail`. Deletes three now-dead wrapper functions that existed only to bridge into a dispatch call — the incoming prop threads straight through instead.

Pre-migration cleanup for the Svelte 5 runes conversion (U3 in the migration plan) — no behavior change, copy/reply/jump-to-message resolve to the same calls with the same arguments as before. Unblocks the two `dm/` runes-conversion batches (U9, U10).

`pnpm check`: 0 errors/warnings. `pnpm lint`: clean. All 4 affected jsdom test files updated from `events:`-dispatch assertions to plain callback-prop assertions; full `dm/` suite: 96/96 passing.

Related: #197
