### PR TITLE
refactor: convert ui/ to Svelte 5 runes

### DIFF
--- a/src/components/ui/EditIconButton.svelte
+++ b/src/components/ui/EditIconButton.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
-  export let disabled = false;
-  export let ariaLabel = 'Edit';
-  export let title: string | undefined = undefined;
-  /** Extra class names for the button element. */
-  export let className = '';
-  export let onclick: (() => void) | undefined = undefined;
+  let {
+    disabled = false,
+    ariaLabel = 'Edit',
+    title = undefined,
+    className = '',
+    onclick = undefined,
+  }: {
+    disabled?: boolean;
+    ariaLabel?: string;
+    title?: string;
+    /** Extra class names for the button element. */
+    className?: string;
+    onclick?: () => void;
+  } = $props();
 </script>
 
 <button

--- a/src/components/ui/Modal.svelte
+++ b/src/components/ui/Modal.svelte
@@ -3,15 +3,25 @@
    * Shared modal: overlay, content box, Escape to close, click-outside to close,
    * focus trap + restore focus on destroy.
    */
-  import { onMount, tick } from 'svelte';
+  import { onMount, tick, type Snippet } from 'svelte';
 
-  export let titleId: string;
-  export let descriptionId: string | undefined = undefined;
-  export let onClose: () => void;
-  /** When false, overlay click and Escape do not close (e.g. in-flight async work). */
-  export let dismissible = true;
-  /** Extra class on the inner dialog panel (e.g. wider layout). */
-  export let contentClass = '';
+  let {
+    titleId,
+    descriptionId = undefined,
+    onClose,
+    dismissible = true,
+    contentClass = '',
+    children,
+  }: {
+    titleId: string;
+    descriptionId?: string;
+    onClose: () => void;
+    /** When false, overlay click and Escape do not close (e.g. in-flight async work). */
+    dismissible?: boolean;
+    /** Extra class on the inner dialog panel (e.g. wider layout). */
+    contentClass?: string;
+    children: Snippet;
+  } = $props();
 
   let dialogEl: HTMLDivElement;
 
@@ -83,7 +93,8 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="modal-overlay" onclick={handleOverlayClick}>
   <div
     bind:this={dialogEl}
@@ -97,7 +108,7 @@
     onclick={(e) => e.stopPropagation()}
     onkeydown={handleContentKeydown}
   >
-    <slot />
+    {@render children()}
   </div>
 </div>
 

--- a/src/components/ui/RefreshIconButton.svelte
+++ b/src/components/ui/RefreshIconButton.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-  export let disabled = false;
-  export let spinning = false;
-  export let ariaLabel = 'Refresh';
-  export let title: string | undefined = undefined;
-  /** Extra class names for the button element. */
-  export let className = '';
-  export let onclick: (() => void) | undefined = undefined;
+  let {
+    disabled = false,
+    spinning = false,
+    ariaLabel = 'Refresh',
+    title = undefined,
+    className = '',
+    onclick = undefined,
+  }: {
+    disabled?: boolean;
+    spinning?: boolean;
+    ariaLabel?: string;
+    title?: string;
+    /** Extra class names for the button element. */
+    className?: string;
+    onclick?: () => void;
+  } = $props();
 </script>
 
 <button

--- a/src/components/ui/ResizableSidebar.svelte
+++ b/src/components/ui/ResizableSidebar.svelte
@@ -1,24 +1,36 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack, type Snippet } from 'svelte';
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
   /**
    * Resizable sidebar: owns width state, resize handle, and window listeners.
-   * Parent supplies content via default slot and a class for the wrapper (e.g. squad-navbar, network-navbar).
+   * Parent supplies content via the children snippet and a class for the wrapper (e.g. squad-navbar, network-navbar).
    */
-  export let sidebarClass = '';
-  /** Leading: pixels from left of viewport to the left edge of this sidebar. Trailing: unused. */
-  export let leftOffset = 64;
-  /** Leading: handle on the right. Trailing: handle on the left; drag left widens the panel. */
-  export let edge: 'leading' | 'trailing' = 'leading';
-  /** If set, width is restored and saved across sessions. */
-  export let persistKey: string | undefined = undefined;
-  export let minWidth = 180;
-  export let maxWidth = 400;
-  export let initialWidth = 240;
+  let {
+    sidebarClass = '',
+    leftOffset = 64,
+    edge = 'leading',
+    persistKey = undefined,
+    minWidth = 180,
+    maxWidth = 400,
+    initialWidth = 240,
+    children,
+  }: {
+    sidebarClass?: string;
+    /** Leading: pixels from left of viewport to the left edge of this sidebar. Trailing: unused. */
+    leftOffset?: number;
+    /** Leading: handle on the right. Trailing: handle on the left; drag left widens the panel. */
+    edge?: 'leading' | 'trailing';
+    /** If set, width is restored and saved across sessions. */
+    persistKey?: string;
+    minWidth?: number;
+    maxWidth?: number;
+    initialWidth?: number;
+    children: Snippet;
+  } = $props();
 
-  let width = initialWidth;
+  let width = $state(untrack(() => initialWidth));
   let isResizing = false;
   let resizeStartX = 0;
   let resizeStartWidth = 0;
@@ -69,7 +81,7 @@
   class:resizable-sidebar--leading={edge === 'leading'}
   style="width: {width}px;"
 >
-  <slot />
+  {@render children()}
   <button
     class="resize-handle"
     type="button"

--- a/src/components/ui/Tab.svelte
+++ b/src/components/ui/Tab.svelte
@@ -1,21 +1,35 @@
 <script lang="ts">
   import { portal } from '../../lib/utils/portal';
+  import type { Snippet } from 'svelte';
 
-  export let active: boolean = false;
-  export let label: string = "";
-  export let image: string = "";
-  export let icon: string = "";
-  /** Unread indicator (no count) on the server button. */
-  export let hasUnreadDot = false;
+  let {
+    active = false,
+    label = '',
+    image = '',
+    icon = '',
+    hasUnreadDot = false,
+    children,
+  }: {
+    active?: boolean;
+    label?: string;
+    image?: string;
+    icon?: string;
+    /** Unread indicator (no count) on the server button. */
+    hasUnreadDot?: boolean;
+    children?: Snippet;
+  } = $props();
 
-  $: firstLetter = label.charAt(0).toUpperCase();
+  const firstLetter = $derived(label.charAt(0).toUpperCase());
 
   let buttonEl: HTMLButtonElement;
-  let imageBroken = false;
-  $: image, (imageBroken = false);
-  $: showImage = !!image && !imageBroken;
-  let showTooltip = false;
-  let tooltipPos = { x: 0, y: 0 };
+  let imageBroken = $state(false);
+  $effect(() => {
+    image;
+    imageBroken = false;
+  });
+  const showImage = $derived(!!image && !imageBroken);
+  let showTooltip = $state(false);
+  let tooltipPos = $state({ x: 0, y: 0 });
 
   function handleTooltipEnter() {
     const rect = buttonEl.getBoundingClientRect();
@@ -49,7 +63,7 @@
     <img src={icon} alt={label} class="tab-icon" />
   {:else}
     <span class="label">
-      <slot>{firstLetter}</slot>
+      {#if children}{@render children()}{:else}{firstLetter}{/if}
     </span>
   {/if}
 </button>

--- a/src/components/ui/Toast.svelte
+++ b/src/components/ui/Toast.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { toastMessage, clearToast, runToastRetryAction, type ToastGoTo } from '../../stores/toast';
   import { navigateToTarget } from '../../lib/navigation/open-squad-dashboard';

--- a/src/components/ui/cross-mode-interop.test.ts
+++ b/src/components/ui/cross-mode-interop.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+// R27: a permanent regression test proving the assumption U4-U19 batch independence rests on --
+// a legacy-mode parent (not yet converted) still renders and forwards events through a
+// runes-mode child (already converted), so converting a component never requires a
+// coordinated cutover with its as-yet-unconverted consumers.
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import Tab from './Tab.svelte';
+import LegacyRenderHarness from './interop-fixtures/LegacyRenderHarness.svelte';
+import LegacySlotHarness from './interop-fixtures/LegacySlotHarness.svelte';
+import LegacyForwardingHarness from './interop-fixtures/LegacyForwardingHarness.svelte';
+
+describe('cross-mode interop', () => {
+  it('a legacy-mode parent renders content into a runes-mode child through {@render children()}', () => {
+    render(LegacyRenderHarness, { props: { message: 'render-mode content' } });
+    expect(screen.getByTestId('render-content').textContent).toBe('render-mode content');
+  });
+
+  it('a legacy-mode parent renders content into a runes-mode child that still uses <slot />', () => {
+    render(LegacySlotHarness, { props: { message: 'slot-mode content' } });
+    expect(screen.getByTestId('slot-content').textContent).toBe('slot-mode content');
+  });
+
+  it("a runes-mode child's bare on:click forwarding reaches a legacy-mode parent's handler", async () => {
+    const onForwardedClick = vi.fn();
+    render(LegacyForwardingHarness, { props: { onForwardedClick } });
+    await fireEvent.click(screen.getByTestId('forwarding-child'));
+    expect(onForwardedClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Tab renders passed content instead of the firstLetter fallback', () => {
+    const content = createRawSnippet(() => ({
+      render: () => `<span data-testid="tab-passed-content">icon</span>`,
+    }));
+    render(Tab, { props: { label: 'General', children: content } });
+    expect(screen.queryByTestId('tab-passed-content')).not.toBeNull();
+    expect(screen.queryByText('G')).toBeNull();
+  });
+
+  it('Tab renders the firstLetter fallback when no content is passed', () => {
+    render(Tab, { props: { label: 'General' } });
+    expect(screen.queryByText('G')).not.toBeNull();
+  });
+});

--- a/src/components/ui/cross-mode-interop.test.ts
+++ b/src/components/ui/cross-mode-interop.test.ts
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
-// R27: a permanent regression test proving the assumption U4-U19 batch independence rests on --
-// a legacy-mode parent (not yet converted) still renders and forwards events through a
-// runes-mode child (already converted), so converting a component never requires a
-// coordinated cutover with its as-yet-unconverted consumers.
+// Permanent regression test: a legacy-mode parent (not yet converted) still renders and
+// forwards events through a runes-mode child (already converted), so converting a component
+// never requires a coordinated cutover with its as-yet-unconverted consumers.
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
@@ -10,11 +9,21 @@ import Tab from './Tab.svelte';
 import LegacyRenderHarness from './interop-fixtures/LegacyRenderHarness.svelte';
 import LegacySlotHarness from './interop-fixtures/LegacySlotHarness.svelte';
 import LegacyForwardingHarness from './interop-fixtures/LegacyForwardingHarness.svelte';
+import RunesParentHarness from './interop-fixtures/RunesParentHarness.svelte';
+import LegacyModalHarness from './interop-fixtures/LegacyModalHarness.svelte';
+import LegacySidebarHarness from './interop-fixtures/LegacySidebarHarness.svelte';
 
 describe('cross-mode interop', () => {
   it('a legacy-mode parent renders content into a runes-mode child through {@render children()}', () => {
     render(LegacyRenderHarness, { props: { message: 'render-mode content' } });
     expect(screen.getByTestId('render-content').textContent).toBe('render-mode content');
+  });
+
+  it('a legacy-mode parent -> runes-mode child render mechanism survives a prop update, not just initial mount', async () => {
+    const { rerender } = render(LegacyRenderHarness, { props: { message: 'A' } });
+    expect(screen.getByTestId('render-content').textContent).toBe('A');
+    await rerender({ message: 'B' });
+    expect(screen.getByTestId('render-content').textContent).toBe('B');
   });
 
   it('a legacy-mode parent renders content into a runes-mode child that still uses <slot />', () => {
@@ -29,6 +38,21 @@ describe('cross-mode interop', () => {
     expect(onForwardedClick).toHaveBeenCalledTimes(1);
   });
 
+  it('a runes-mode parent renders default slot content into a legacy-mode child that still uses <slot />', () => {
+    render(RunesParentHarness, { props: { message: 'reverse-slot content' } });
+    expect(screen.getByTestId('reverse-slot-content').textContent).toBe('reverse-slot content');
+  });
+
+  it('a legacy-mode parent renders content into runes-mode Modal', () => {
+    render(LegacyModalHarness, { props: { message: 'modal content' } });
+    expect(screen.getByTestId('modal-content').textContent).toBe('modal content');
+  });
+
+  it('a legacy-mode parent renders content into runes-mode ResizableSidebar', () => {
+    render(LegacySidebarHarness, { props: { message: 'sidebar content' } });
+    expect(screen.getByTestId('sidebar-content').textContent).toBe('sidebar content');
+  });
+
   it('Tab renders passed content instead of the firstLetter fallback', () => {
     const content = createRawSnippet(() => ({
       render: () => `<span data-testid="tab-passed-content">icon</span>`,
@@ -41,5 +65,21 @@ describe('cross-mode interop', () => {
   it('Tab renders the firstLetter fallback when no content is passed', () => {
     render(Tab, { props: { label: 'General' } });
     expect(screen.queryByText('G')).not.toBeNull();
+  });
+});
+
+describe('Tab image fallback', () => {
+  it('falls back to the firstLetter on image error, and shows the image again after the image prop changes', async () => {
+    const { rerender } = render(Tab, {
+      props: { label: 'General', image: 'https://example.invalid/broken.png' },
+    });
+    const img = screen.getByAltText('General');
+    await fireEvent.error(img);
+    expect(screen.queryByText('G')).not.toBeNull();
+    expect(screen.queryByAltText('General')).toBeNull();
+
+    await rerender({ label: 'General', image: 'https://example.invalid/new.png' });
+    expect(screen.getByAltText('General')).toBeTruthy();
+    expect(screen.queryByText('G')).toBeNull();
   });
 });

--- a/src/components/ui/interop-fixtures/ForwardingChild.svelte
+++ b/src/components/ui/interop-fixtures/ForwardingChild.svelte
@@ -1,0 +1,12 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  /**
+   * R27 fixture: runes-mode child forwarding a DOM click via the bare on:click directive.
+   * Only valid because this fixture has no onclick=... attributes anywhere in its template --
+   * mixing bare on: forwarding with the new on*= syntax in the same component is a compile error.
+   */
+</script>
+
+<!-- svelte-ignore event_directive_deprecated -->
+<button type="button" data-testid="forwarding-child" aria-label="forward" on:click></button>

--- a/src/components/ui/interop-fixtures/ForwardingChild.svelte
+++ b/src/components/ui/interop-fixtures/ForwardingChild.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   /**
-   * R27 fixture: runes-mode child forwarding a DOM click via the bare on:click directive.
+   * Runes-mode child forwarding a DOM click via the bare on:click directive.
    * Only valid because this fixture has no onclick=... attributes anywhere in its template --
    * mixing bare on: forwarding with the new on*= syntax in the same component is a compile error.
    */

--- a/src/components/ui/interop-fixtures/LegacyForwardingHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacyForwardingHarness.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  /** R27 fixture: legacy-mode parent listening on a runes-mode child's forwarded on:click. */
+  import ForwardingChild from './ForwardingChild.svelte';
+
+  export let onForwardedClick: () => void;
+</script>
+
+<ForwardingChild on:click={onForwardedClick} />

--- a/src/components/ui/interop-fixtures/LegacyForwardingHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacyForwardingHarness.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
-  /** R27 fixture: legacy-mode parent listening on a runes-mode child's forwarded on:click. */
+  /** Legacy-mode parent listening on a runes-mode child's forwarded on:click. */
   import ForwardingChild from './ForwardingChild.svelte';
 
   export let onForwardedClick: () => void;

--- a/src/components/ui/interop-fixtures/LegacyModalHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacyModalHarness.svelte
@@ -1,0 +1,12 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  /** Legacy-mode parent passing default slot content into runes-mode Modal. */
+  import Modal from '../Modal.svelte';
+
+  export let message: string;
+</script>
+
+<Modal titleId="t" onClose={() => {}}>
+  <p data-testid="modal-content">{message}</p>
+</Modal>

--- a/src/components/ui/interop-fixtures/LegacyRenderHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacyRenderHarness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  /** R27 fixture: legacy-mode parent passing default slot content into a runes-mode child. */
+  import RenderChild from './RenderChild.svelte';
+
+  export let message: string;
+</script>
+
+<RenderChild>
+  <p data-testid="render-content">{message}</p>
+</RenderChild>

--- a/src/components/ui/interop-fixtures/LegacyRenderHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacyRenderHarness.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
-  /** R27 fixture: legacy-mode parent passing default slot content into a runes-mode child. */
+  /** Legacy-mode parent passing default slot content into a runes-mode child. */
   import RenderChild from './RenderChild.svelte';
 
   export let message: string;

--- a/src/components/ui/interop-fixtures/LegacySidebarHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacySidebarHarness.svelte
@@ -1,0 +1,12 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  /** Legacy-mode parent passing default slot content into runes-mode ResizableSidebar. */
+  import ResizableSidebar from '../ResizableSidebar.svelte';
+
+  export let message: string;
+</script>
+
+<ResizableSidebar>
+  <p data-testid="sidebar-content">{message}</p>
+</ResizableSidebar>

--- a/src/components/ui/interop-fixtures/LegacySlotChild.svelte
+++ b/src/components/ui/interop-fixtures/LegacySlotChild.svelte
@@ -1,0 +1,7 @@
+<svelte:options runes={false} />
+
+<script lang="ts">
+  /** Legacy-mode child using <slot /> (not deprecated here -- deprecation only applies to runes-mode components). */
+</script>
+
+<div data-testid="reverse-slot-child"><slot /></div>

--- a/src/components/ui/interop-fixtures/LegacySlotHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacySlotHarness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  /** R27 fixture: legacy-mode parent passing default slot content into a still-<slot /> runes child. */
+  import SlotChild from './SlotChild.svelte';
+
+  export let message: string;
+</script>
+
+<SlotChild>
+  <p data-testid="slot-content">{message}</p>
+</SlotChild>

--- a/src/components/ui/interop-fixtures/LegacySlotHarness.svelte
+++ b/src/components/ui/interop-fixtures/LegacySlotHarness.svelte
@@ -1,5 +1,7 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
-  /** R27 fixture: legacy-mode parent passing default slot content into a still-<slot /> runes child. */
+  /** Legacy-mode parent passing default slot content into a still-<slot /> runes child. */
   import SlotChild from './SlotChild.svelte';
 
   export let message: string;

--- a/src/components/ui/interop-fixtures/RenderChild.svelte
+++ b/src/components/ui/interop-fixtures/RenderChild.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  /** R27 fixture: runes-mode child rendering default content via {@render children()}. */
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+<div data-testid="render-child">{@render children()}</div>

--- a/src/components/ui/interop-fixtures/RenderChild.svelte
+++ b/src/components/ui/interop-fixtures/RenderChild.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  /** R27 fixture: runes-mode child rendering default content via {@render children()}. */
+  /** Runes-mode child rendering default content via {@render children()}. */
   import type { Snippet } from 'svelte';
 
   let { children }: { children: Snippet } = $props();

--- a/src/components/ui/interop-fixtures/RunesParentHarness.svelte
+++ b/src/components/ui/interop-fixtures/RunesParentHarness.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  /** Runes-mode parent passing default slot content into a legacy-mode child that still uses <slot />. */
+  import LegacySlotChild from './LegacySlotChild.svelte';
+
+  let { message }: { message: string } = $props();
+</script>
+
+<LegacySlotChild>
+  <p data-testid="reverse-slot-content">{message}</p>
+</LegacySlotChild>

--- a/src/components/ui/interop-fixtures/SlotChild.svelte
+++ b/src/components/ui/interop-fixtures/SlotChild.svelte
@@ -1,7 +1,7 @@
 <svelte:options runes={true} />
 
 <script lang="ts">
-  /** R27 fixture: runes-mode child still using the deprecated <slot /> element. */
+  /** Runes-mode child still using the deprecated <slot /> element. */
 </script>
 
 <!-- svelte-ignore slot_element_deprecated -->

--- a/src/components/ui/interop-fixtures/SlotChild.svelte
+++ b/src/components/ui/interop-fixtures/SlotChild.svelte
@@ -1,0 +1,8 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  /** R27 fixture: runes-mode child still using the deprecated <slot /> element. */
+</script>
+
+<!-- svelte-ignore slot_element_deprecated -->
+<div data-testid="slot-child"><slot /></div>


### PR DESCRIPTION
## Summary

Converts the six shared UI primitives (`Toast`, `Tab`, `Modal`, `ResizableSidebar`, `RefreshIconButton`, `EditIconButton`) to Svelte 5 runes -- Unit U4 of the runes migration, and the reference pattern the remaining 15 batches will copy. Three of these are slot providers (`Modal`, `ResizableSidebar`, `Tab`) moving from `<slot />` to `{@render children()}`.

A permanent regression test (`cross-mode-interop.test.ts`) now proves the assumption the whole batch-by-batch migration strategy depends on: a legacy-mode parent (not yet converted) still renders content into and receives events from a runes-mode child (already converted) -- through the render-children path, the deprecated-slot path, and event forwarding, plus the reverse direction and direct coverage of all three converted slot providers. Without this guarantee, every future batch would need a coordinated cutover with its as-yet-unconverted consumers instead of landing independently.

## Design decisions

- **`Tab`'s fallback stays explicit, not implicit.** The old `<slot>{firstLetter}</slot>` pattern let a bare `{@render children()}` silently blank every tab label if the `{:else}` were ever dropped. It's now `{#if children}{@render children()}{:else}{firstLetter}{/if}` -- all current `Tab` consumers pass no content today, so the fallback branch is what production actually renders, and this keeps it from becoming an easy-to-miss regression later.
- **Explicit `<svelte:options runes={...} />` on every interop fixture, not inference alone.** Svelte 5 infers a file's compile mode per-component; a file with no `$props()`/`$state()` usage silently compiles as legacy. Three fixtures and `Toast.svelte` relied on that inference -- fine today, but Unit U22 (closing the migration gate) forces `runes: true` project-wide, at which point an un-pinned legacy fixture becomes a hard compile error instead of a passing test. All ten interop fixtures now pin their mode explicitly, verified to compile clean under both today's config and a forced `runes: true`.
- **The interop suite covers both directions, not just the one the plan named.** The original test proved legacy-parent-into-runes-child; a second pass added the reverse (runes-parent-into-legacy-child, still relying on `<slot />`) and direct instantiation of `Modal`/`ResizableSidebar`, which no test previously exercised at all -- exactly the kind of green-while-red gap a "permanent" regression guard can't afford.

## New concepts

**Explicit compile-mode pinning during an incremental Svelte 5 migration**

Svelte 5 infers each `.svelte` file's compile mode (legacy vs. runes) from what the file's script actually uses -- `$props()`/`$state()`/etc. force runes mode; plain `export let` with no rune usage stays legacy. That inference is silent and per-file, which is fine in a codebase that's fully on one mode, but during a file-by-file migration a component with no reactive state (like `Toast.svelte` here) can *look* converted in a diff while still compiling legacy, and a fixture deliberately kept in legacy mode for testing can flip to hard-erroring the moment a later, unrelated config change forces runes project-wide.

The fix is `<svelte:options runes={true} />` / `<svelte:options runes={false} />` as the first line of any file where the mode matters but isn't obvious from usage:

```svelte
<svelte:options runes={false} />
<script lang="ts">
  /** Deliberately legacy-mode: proves a not-yet-converted parent still works. */
  export let message: string;
</script>
```

Reach for this only where mode ambiguity is a real risk (empty/near-empty components, or fixtures whose whole purpose is pinning a specific mode) -- most files don't need it, since normal `$props()`/`$state()` usage already forces the right mode unambiguously.

**Cross-mode interop testing**

When a large migration lands file-by-file rather than in one cutover, the risk isn't just "did this file convert correctly" -- it's "does a converted file still work when everything around it hasn't converted yet." `cross-mode-interop.test.ts` answers that with small synthetic fixture pairs, each isolating one bridging mechanism (default-slot content via `{@render children()}`, the deprecated `<slot />` path, and `on:click` event forwarding) rather than relying on incidental coverage from whichever real components happen to touch each other:

```mermaid
flowchart LR
  LP["Legacy-mode parent\n(export let)"] -->|renders content into| RC["Runes-mode child\n({@render children()})"]
  RP["Runes-mode parent\n($props())"] -->|renders content into| LC["Legacy-mode child\n(&lt;slot /&gt;)"]
```

This is what makes "convert one file, land it, convert the next file whenever" safe as an ongoing strategy -- the alternative is a coordinated freeze-and-cutover across every consumer of every component, which this migration explicitly wants to avoid. Not worth it for a migration landing in one atomic sweep; the fixtures are pure test-only overhead if there's no window where converted and unconverted code coexist.

## Validation

`pnpm check`: 0 errors/warnings. `pnpm lint`: clean. `pnpm test`: 2137/2137 passing at the base commit, plus 10/10 in the extended interop suite (up from 5) after the review-driven follow-up commit; full `src/components/ui` + `src/lib/commons` + `src/lib/governance` re-run: 390/390. All ten interop fixtures verified via direct `svelte.compile()` calls to compile warning-free under both the current config and a forced `runes: true` (the state Unit U22 will set repo-wide).

By hand via the Tauri MCP bridge: `RefreshIconButton`/`EditIconButton` click through; `Modal` renders and closes correctly (Escape, backdrop click, not content click) from `settings/`, `commons/`, and `parent/governance/` consumers; `ResizableSidebar` resizes and persists width from both a `persistKey` and a non-`persistKey` consumer; `Tab` renders both its icon branch and its firstLetter fallback in the live squad list.

This PR also went through an internal multi-persona code review (correctness, project-standards, testing, maintainability, adversarial, and a DOM/effect-timing specialist lens) after the initial conversion; all 8 actionable findings it surfaced are folded into the commits above rather than left as follow-up.

Related: #197
