### PR TITLE
refactor: convert announcements/ to Svelte 5 runes

### DIFF
--- a/src/components/announcements/AnnounceCard.svelte
+++ b/src/components/announcements/AnnounceCard.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { t } from 'svelte-i18n';
   import {
@@ -16,12 +18,20 @@
   import { isPactoGovGovernanceProvider } from '../../lib/announcements';
   import { formatMessageTimestamp } from '../../lib/utils/message-formatting';
 
-  export let id: string = '';
-  export let announce: AnnounceMessage;
-  export let authorName: string = '';
-  /** Sender npub (MLS group messages); used for first-person vs third-person copy on signer-share cards. */
-  export let authorNpub: string | undefined = undefined;
-  export let timestamp: string = '';
+  let {
+    id = '',
+    announce,
+    authorName = '',
+    authorNpub = undefined,
+    timestamp = '',
+  }: {
+    id?: string;
+    announce: AnnounceMessage;
+    authorName?: string;
+    /** Sender npub (MLS group messages); used for first-person vs third-person copy on signer-share cards. */
+    authorNpub?: string;
+    timestamp?: string;
+  } = $props();
 
   type SafeAnnounceOnly = Extract<
     AnnounceMessage,
@@ -29,19 +39,23 @@
     | { type: typeof ANNOUNCE_TYPE_SAFE_PROPOSAL }
   >;
 
-  $: safeAnnounceOnly =
+  const safeAnnounceOnly = $derived(
     announce.type === ANNOUNCE_TYPE_SAFE_UPDATED || announce.type === ANNOUNCE_TYPE_SAFE_PROPOSAL
       ? (announce as SafeAnnounceOnly)
-      : null;
+      : null
+  );
 
-  $: signerSharePayload =
-    announce.type === ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE ? announce.payload : null;
+  const signerSharePayload = $derived(
+    announce.type === ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE ? announce.payload : null
+  );
 
-  $: dashboardPollPayload =
-    announce.type === ANNOUNCE_TYPE_DASHBOARD_POLL_CREATED ? announce.payload : null;
+  const dashboardPollPayload = $derived(
+    announce.type === ANNOUNCE_TYPE_DASHBOARD_POLL_CREATED ? announce.payload : null
+  );
 
-  $: governanceUpdatedPayload =
-    announce.type === ANNOUNCE_TYPE_GOVERNANCE_UPDATED ? announce.payload : null;
+  const governanceUpdatedPayload = $derived(
+    announce.type === ANNOUNCE_TYPE_GOVERNANCE_UPDATED ? announce.payload : null
+  );
 </script>
 
 <div class="announce-card" id={id ? `msg-${id}` : undefined} data-announce-type={announce.type}>

--- a/src/components/announcements/AnnounceCard.test.ts
+++ b/src/components/announcements/AnnounceCard.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import AnnounceCard from './AnnounceCard.svelte';
+import {
+  ANNOUNCE_TYPE_SAFE_UPDATED,
+  ANNOUNCE_TYPE_SAFE_PROPOSAL,
+  ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE,
+  ANNOUNCE_TYPE_DASHBOARD_POLL_CREATED,
+  ANNOUNCE_TYPE_GOVERNANCE_UPDATED,
+  ANNOUNCE_TYPE_STICKER_PACK_UPDATED,
+  type AnnounceMessage,
+} from '../../lib/announcements';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AnnounceCard routing', () => {
+  it('renders a dashboard poll body for dashboard_poll_created', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_DASHBOARD_POLL_CREATED,
+      payload: { parent_id: 'squad-1', poll_id: 'poll-1', title: 'Pick a treasurer', options: [] },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Alice', timestamp: '' } });
+    expect(screen.getByText('Pick a treasurer')).toBeTruthy();
+  });
+
+  it('renders a signer-share body for squad_member_evm_share', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_SQUAD_MEMBER_EVM_SHARE,
+      payload: { parent_id: 'squad-1', evm_address: '0x1111111111111111111111111111111111111111' },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Alice', authorNpub: 'npub1alice', timestamp: '' } });
+    expect(screen.getByTitle('0x1111111111111111111111111111111111111111')).toBeTruthy();
+  });
+
+  it('renders a Safe body for safe_updated', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_SAFE_UPDATED,
+      payload: { squad_id: 'squad-1', safe_address: '0x2222222222222222222222222222222222222222', chain: 'sepolia' },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Bob', timestamp: '' } });
+    expect(screen.getByText('Safe address updated')).toBeTruthy();
+  });
+
+  it('renders a Safe body for safe_proposal', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_SAFE_PROPOSAL,
+      payload: {
+        id: 'p1',
+        parent_id: 'squad-1',
+        to: '0x3333333333333333333333333333333333333',
+        amount: '1.5',
+        token: 'ETH',
+        proposer_npub: 'npub1bob',
+      },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Bob', timestamp: '' } });
+    expect(screen.getByText('Safe proposal')).toBeTruthy();
+  });
+
+  it('routes governance_updated with provider pacto_gov to the Pacto Gov deploy body', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_GOVERNANCE_UPDATED,
+      payload: { parent_id: 'squad-1', provider: 'pacto_gov', canonical_ref: '0xhat' },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Carol', timestamp: '' } });
+    expect(screen.getByText('Carol deployed Pacto Gov')).toBeTruthy();
+  });
+
+  it('routes governance_updated with a non-pacto_gov provider to the generic governance body', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_GOVERNANCE_UPDATED,
+      payload: { parent_id: 'squad-1', provider: 'gnosis_safe', canonical_ref: '0xsafe' },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Dana', timestamp: '' } });
+    expect(screen.getByText('Dana linked a treasury Safe')).toBeTruthy();
+  });
+
+  it('falls back to the generic body for an announce type it does not special-case', () => {
+    const announce: AnnounceMessage = {
+      type: ANNOUNCE_TYPE_STICKER_PACK_UPDATED,
+      payload: { squad_id: 'squad-1', pack_id: 'pack-1', name: 'Party', entries: [], updated_at: 0, deleted: false },
+    };
+    render(AnnounceCard, { props: { announce, authorName: 'Eve', timestamp: '' } });
+    expect(screen.getByText('Announcement')).toBeTruthy();
+    expect(screen.getByText('Eve')).toBeTruthy();
+  });
+});

--- a/src/components/announcements/DashboardPollCreatedAnnounceBody.svelte
+++ b/src/components/announcements/DashboardPollCreatedAnnounceBody.svelte
@@ -1,11 +1,19 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { t } from 'svelte-i18n';
   import type { DashboardPollCreatedPayload } from '../../lib/announcements';
   import { formatMessageTimestamp } from '../../lib/utils/message-formatting';
 
-  export let payload: DashboardPollCreatedPayload;
-  export let authorName: string;
-  export let timestamp: string;
+  let {
+    payload,
+    authorName,
+    timestamp,
+  }: {
+    payload: DashboardPollCreatedPayload;
+    authorName: string;
+    timestamp: string;
+  } = $props();
 </script>
 
 <div class="poll-announce-body">

--- a/src/components/announcements/GovernanceUpdatedAnnounceBody.svelte
+++ b/src/components/announcements/GovernanceUpdatedAnnounceBody.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
@@ -12,10 +14,17 @@
   import { profiles } from '../../stores/profiles';
   import { getProfileDisplayName } from '../../lib/utils/profile';
 
-  export let payload: GovernanceUpdatedPayload;
-  export let authorName: string;
-  export let authorNpub: string | undefined = undefined;
-  export let timestamp: string;
+  let {
+    payload,
+    authorName,
+    authorNpub = undefined,
+    timestamp,
+  }: {
+    payload: GovernanceUpdatedPayload;
+    authorName: string;
+    authorNpub?: string;
+    timestamp: string;
+  } = $props();
 
   const tFn = get(t);
 
@@ -52,16 +61,17 @@
     }
   }
 
-  $: displayName =
-    (authorNpub ? getProfileDisplayName($profiles[authorNpub]) : '') || authorName || tFn('announcements.governanceUpdated.aMember');
-  $: chainId = parseSupportedChainId(payload.chain);
-  $: networkLabel = getWalletNetworkDisplayName(chainId);
-  $: contractAddr = payload.canonical_ref?.trim() ?? '';
-  $: explorerUrl = contractAddr ? explorerAddressUrl(chainId, contractAddr) : '';
-  $: explorerLabel = explorerTxLinkLabel(chainId);
-  $: summary = governanceSummary(payload.provider, displayName);
-  $: txHash = txHashFromProviderPayload(payload.provider_payload);
-  $: explorerTxUrl = txHash ? getExplorerTxUrl(chainId, txHash) : null;
+  const displayName = $derived(
+    (authorNpub ? getProfileDisplayName($profiles[authorNpub]) : '') || authorName || tFn('announcements.governanceUpdated.aMember')
+  );
+  const chainId = $derived(parseSupportedChainId(payload.chain));
+  const networkLabel = $derived(getWalletNetworkDisplayName(chainId));
+  const contractAddr = $derived(payload.canonical_ref?.trim() ?? '');
+  const explorerUrl = $derived(contractAddr ? explorerAddressUrl(chainId, contractAddr) : '');
+  const explorerLabel = $derived(explorerTxLinkLabel(chainId));
+  const summary = $derived(governanceSummary(payload.provider, displayName));
+  const txHash = $derived(txHashFromProviderPayload(payload.provider_payload));
+  const explorerTxUrl = $derived(txHash ? getExplorerTxUrl(chainId, txHash) : null);
 </script>
 
 <div class="gov-updated-body">

--- a/src/components/announcements/GovernanceUpdatedAnnounceBody.test.ts
+++ b/src/components/announcements/GovernanceUpdatedAnnounceBody.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import GovernanceUpdatedAnnounceBody from './GovernanceUpdatedAnnounceBody.svelte';
+import { profiles } from '../../stores/profiles';
+import type { GovernanceUpdatedPayload } from '../../lib/announcements';
+
+afterEach(() => {
+  cleanup();
+  profiles.set({});
+});
+
+describe('GovernanceUpdatedAnnounceBody', () => {
+  it('renders a provider summary, network, and shortened contract address with an explorer link', () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'squad_admin',
+      canonical_ref: '0x1111111111111111111111111111111111111111',
+      chain: 'sepolia',
+    };
+    render(GovernanceUpdatedAnnounceBody, {
+      props: { payload, authorName: 'Alice', timestamp: '2026-01-01T00:00:00.000Z' },
+    });
+    expect(screen.getByText('Alice deployed Squad Admin')).toBeTruthy();
+    expect(screen.getByText('Sepolia')).toBeTruthy();
+    const link = screen.getByRole('link', { name: 'View on sepolia.etherscan.io' });
+    expect(link.getAttribute('href')).toContain('0x1111111111111111111111111111111111111111');
+  });
+
+  it('picks up a display name from the profiles store when the store updates after mount, without a prop change', async () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'pacto_gov',
+      canonical_ref: '0x2222222222222222222222222222222222222222',
+    };
+    render(GovernanceUpdatedAnnounceBody, {
+      props: { payload, authorName: '', authorNpub: 'npub1alice', timestamp: '' },
+    });
+    // No cached profile yet: getProfileDisplayName(undefined) resolves to 'Unknown', which wins over authorName/aMember.
+    expect(screen.getByText('Unknown deployed Pacto Gov')).toBeTruthy();
+
+    profiles.set({ npub1alice: { id: 'npub1alice', name: 'Alice' } as never });
+    expect(await screen.findByText('Alice deployed Pacto Gov')).toBeTruthy();
+  });
+
+  it('does not render a transaction link when the provider payload carries no tx hash', () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'sponsor',
+      canonical_ref: '0x3333333333333333333333333333333333333333',
+    };
+    render(GovernanceUpdatedAnnounceBody, { props: { payload, authorName: 'Bob', timestamp: '' } });
+    expect(screen.queryByText('View deployment transaction')).toBeNull();
+  });
+
+  it('renders a transaction link when the provider payload carries a tx hash', () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'sponsor',
+      canonical_ref: '0x4444444444444444444444444444444444444444',
+      provider_payload: JSON.stringify({ txHash: '0xdeadbeef' }),
+    };
+    render(GovernanceUpdatedAnnounceBody, { props: { payload, authorName: 'Bob', timestamp: '' } });
+    expect(screen.getByText('View deployment transaction')).toBeTruthy();
+  });
+});

--- a/src/components/announcements/PactoGovDeployedAnnounceBody.svelte
+++ b/src/components/announcements/PactoGovDeployedAnnounceBody.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
@@ -9,16 +11,24 @@
   import { getProfileDisplayName } from '../../lib/utils/profile';
   import PactoGovInfraList from '../parent/governance/PactoGovInfraList.svelte';
 
-  export let payload: GovernanceUpdatedPayload;
-  export let authorName: string;
-  export let authorNpub: string | undefined = undefined;
-  export let timestamp: string;
+  let {
+    payload,
+    authorName,
+    authorNpub = undefined,
+    timestamp,
+  }: {
+    payload: GovernanceUpdatedPayload;
+    authorName: string;
+    authorNpub?: string;
+    timestamp: string;
+  } = $props();
 
   const tFn = get(t);
 
-  $: displayName =
-    (authorNpub ? getProfileDisplayName($profiles[authorNpub]) : '') || authorName || tFn('announcements.governanceUpdated.aMember');
-  $: networkLabel = getWalletNetworkDisplayName(parseSupportedChainId(payload.chain));
+  const displayName = $derived(
+    (authorNpub ? getProfileDisplayName($profiles[authorNpub]) : '') || authorName || tFn('announcements.governanceUpdated.aMember')
+  );
+  const networkLabel = $derived(getWalletNetworkDisplayName(parseSupportedChainId(payload.chain)));
 </script>
 
 <div class="pacto-gov-deploy-body">

--- a/src/components/announcements/PactoGovDeployedAnnounceBody.test.ts
+++ b/src/components/announcements/PactoGovDeployedAnnounceBody.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import PactoGovDeployedAnnounceBody from './PactoGovDeployedAnnounceBody.svelte';
+import { profiles } from '../../stores/profiles';
+import type { GovernanceUpdatedPayload } from '../../lib/announcements';
+
+afterEach(() => {
+  cleanup();
+  profiles.set({});
+});
+
+describe('PactoGovDeployedAnnounceBody', () => {
+  it('picks up a display name from the profiles store when the store updates after mount, without a prop change', async () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'pacto_gov',
+      canonical_ref: '0x1111111111111111111111111111111111111111',
+    };
+    render(PactoGovDeployedAnnounceBody, {
+      props: { payload, authorName: '', authorNpub: 'npub1alice', timestamp: '' },
+    });
+    // No cached profile yet: getProfileDisplayName(undefined) resolves to 'Unknown', which wins over authorName/aMember.
+    expect(screen.getByText('Unknown deployed Pacto Gov')).toBeTruthy();
+
+    profiles.set({ npub1alice: { id: 'npub1alice', name: 'Alice' } as never });
+    expect(await screen.findByText('Alice deployed Pacto Gov')).toBeTruthy();
+  });
+
+  it('renders the network label for a payload with chain set', () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'pacto_gov',
+      canonical_ref: '0x2222222222222222222222222222222222222222',
+      chain: 'mainnet',
+    };
+    render(PactoGovDeployedAnnounceBody, { props: { payload, authorName: 'Bob', timestamp: '' } });
+    expect(screen.getByText('Ethereum')).toBeTruthy();
+  });
+
+  it('defaults the network label to Sepolia when the payload carries no chain', () => {
+    const payload: GovernanceUpdatedPayload = {
+      parent_id: 'squad-1',
+      provider: 'pacto_gov',
+      canonical_ref: '0x3333333333333333333333333333333333333333',
+    };
+    render(PactoGovDeployedAnnounceBody, { props: { payload, authorName: 'Carol', timestamp: '' } });
+    expect(screen.getByText('Sepolia')).toBeTruthy();
+  });
+});

--- a/src/components/announcements/Safe/SafeAnnounceBody.svelte
+++ b/src/components/announcements/Safe/SafeAnnounceBody.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
@@ -14,11 +16,17 @@
   import { formatMessageTimestamp } from '../../../lib/utils/message-formatting';
 
   /** Safe-related announcement (address updated or proposal). */
-  export let announce:
-    | { type: typeof ANNOUNCE_TYPE_SAFE_UPDATED; payload: SafeUpdatedPayload }
-    | { type: typeof ANNOUNCE_TYPE_SAFE_PROPOSAL; payload: SafeProposalPayload };
-  export let authorName: string = '';
-  export let timestamp: string = '';
+  let {
+    announce,
+    authorName = '',
+    timestamp = '',
+  }: {
+    announce:
+      | { type: typeof ANNOUNCE_TYPE_SAFE_UPDATED; payload: SafeUpdatedPayload }
+      | { type: typeof ANNOUNCE_TYPE_SAFE_PROPOSAL; payload: SafeProposalPayload };
+    authorName?: string;
+    timestamp?: string;
+  } = $props();
 
   const tFn = get(t);
 
@@ -27,17 +35,18 @@
     return addr.slice(0, 6) + '…' + addr.slice(-4);
   }
 
-  $: safePayload = announce.type === ANNOUNCE_TYPE_SAFE_UPDATED ? announce.payload : null;
-  $: chainId = safePayload ? parseSupportedChainId(safePayload.chain) : parseSupportedChainId('sepolia');
-  $: txHash =
-    safePayload?.tx_hash?.trim() && safePayload.tx_hash.trim().length > 0
-      ? safePayload.tx_hash.trim()
-      : '';
-  $: explorerTx =
-    safePayload?.explorer_tx_url?.trim() ||
-    (txHash ? getExplorerTxUrl(chainId, txHash) : null);
-  $: safeExplorerUrl = safePayload ? explorerAddressUrl(chainId, safePayload.safe_address) : '';
-  $: safeAppUrl = safePayload ? safeAppHomeUrl(chainId, safePayload.safe_address) : '';
+  const safePayload = $derived(announce.type === ANNOUNCE_TYPE_SAFE_UPDATED ? announce.payload : null);
+  const chainId = $derived(
+    safePayload ? parseSupportedChainId(safePayload.chain) : parseSupportedChainId('sepolia')
+  );
+  const txHash = $derived(
+    safePayload?.tx_hash?.trim() && safePayload.tx_hash.trim().length > 0 ? safePayload.tx_hash.trim() : ''
+  );
+  const explorerTx = $derived(
+    safePayload?.explorer_tx_url?.trim() || (txHash ? getExplorerTxUrl(chainId, txHash) : null)
+  );
+  const safeExplorerUrl = $derived(safePayload ? explorerAddressUrl(chainId, safePayload.safe_address) : '');
+  const safeAppUrl = $derived(safePayload ? safeAppHomeUrl(chainId, safePayload.safe_address) : '');
 
   async function copySafeAddress(addr: string) {
     const ok = await copyTextToClipboard(addr);

--- a/src/components/announcements/Safe/SafeAnnounceBody.test.ts
+++ b/src/components/announcements/Safe/SafeAnnounceBody.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import SafeAnnounceBody from './SafeAnnounceBody.svelte';
+import { toastMessage } from '../../../stores/toast';
+import { ANNOUNCE_TYPE_SAFE_UPDATED, ANNOUNCE_TYPE_SAFE_PROPOSAL } from '../../../lib/announcements';
+
+afterEach(() => {
+  cleanup();
+  toastMessage.set(null);
+});
+
+describe('SafeAnnounceBody (safe_updated)', () => {
+  const address = '0x1111111111111111111111111111111111111111';
+
+  it('renders the deployment fields for a Safe deployed via factory (tx hash present)', () => {
+    render(SafeAnnounceBody, {
+      props: {
+        announce: {
+          type: ANNOUNCE_TYPE_SAFE_UPDATED,
+          payload: { squad_id: 'squad-1', safe_address: address, chain: 'sepolia', tx_hash: '0xdeadbeef' },
+        },
+        authorName: 'Alice',
+        timestamp: '',
+      },
+    });
+    expect(screen.getByText('Safe deployed')).toBeTruthy();
+    expect(screen.getByTitle(address)).toBeTruthy();
+    expect(screen.getByTitle('0xdeadbeef')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'View transaction' })).toBeTruthy();
+  });
+
+  it('renders the updated title (no deploy tx) for a Safe address change', () => {
+    render(SafeAnnounceBody, {
+      props: {
+        announce: { type: ANNOUNCE_TYPE_SAFE_UPDATED, payload: { squad_id: 'squad-1', safe_address: address, chain: 'sepolia' } },
+        authorName: 'Alice',
+        timestamp: '',
+      },
+    });
+    expect(screen.getByText('Safe address updated')).toBeTruthy();
+    expect(screen.queryByText('Copy tx hash')).toBeNull();
+  });
+
+  it('re-derives the explorer links when the chain in the announce payload changes', async () => {
+    const { rerender } = render(SafeAnnounceBody, {
+      props: {
+        announce: { type: ANNOUNCE_TYPE_SAFE_UPDATED, payload: { squad_id: 'squad-1', safe_address: address, chain: 'sepolia' } },
+        authorName: 'Alice',
+        timestamp: '',
+      },
+    });
+    expect(screen.getByRole('link', { name: 'View on explorer' }).getAttribute('href')).toBe(
+      `https://sepolia.etherscan.io/address/${address}`,
+    );
+
+    await rerender({
+      announce: { type: ANNOUNCE_TYPE_SAFE_UPDATED, payload: { squad_id: 'squad-1', safe_address: address, chain: 'mainnet' } },
+      authorName: 'Alice',
+      timestamp: '',
+    });
+    expect(screen.getByRole('link', { name: 'View on explorer' }).getAttribute('href')).toBe(
+      `https://etherscan.io/address/${address}`,
+    );
+  });
+
+  it('copies the Safe address to the clipboard and shows a confirmation toast', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+
+    render(SafeAnnounceBody, {
+      props: {
+        announce: { type: ANNOUNCE_TYPE_SAFE_UPDATED, payload: { squad_id: 'squad-1', safe_address: address, chain: 'sepolia' } },
+        authorName: 'Alice',
+        timestamp: '',
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Copy full Safe address' }));
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(address));
+    await vi.waitFor(() => expect(get(toastMessage)?.text).toBe('Safe address copied'));
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('SafeAnnounceBody (safe_proposal)', () => {
+  it('renders the transfer detail and disabled sign/execute actions', () => {
+    render(SafeAnnounceBody, {
+      props: {
+        announce: {
+          type: ANNOUNCE_TYPE_SAFE_PROPOSAL,
+          payload: {
+            id: 'p1',
+            parent_id: 'squad-1',
+            to: '0x2222222222222222222222222222222222222222',
+            amount: '2.5',
+            token: 'ETH',
+            proposer_npub: 'npub1bob',
+          },
+        },
+        authorName: 'Bob',
+        timestamp: '',
+      },
+    });
+    expect(screen.getByText('Safe proposal')).toBeTruthy();
+    expect(screen.getByText(/Send 2\.5 ETH to/)).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Sign' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Execute' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/announcements/SignerShareAnnounceBody.svelte
+++ b/src/components/announcements/SignerShareAnnounceBody.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
@@ -5,21 +7,29 @@
   import { currentUser } from '../../stores/auth';
   import { formatMessageTimestamp } from '../../lib/utils/message-formatting';
 
-  export let payload: SquadMemberEvmSharePayload;
-  export let authorName: string;
-  export let authorNpub: string | undefined = undefined;
-  export let timestamp: string;
+  let {
+    payload,
+    authorName,
+    authorNpub = undefined,
+    timestamp,
+  }: {
+    payload: SquadMemberEvmSharePayload;
+    authorName: string;
+    authorNpub?: string;
+    timestamp: string;
+  } = $props();
 
   const tFn = get(t);
 
-  $: isMine =
-    Boolean(authorNpub && $currentUser?.npub && authorNpub === $currentUser.npub);
+  const isMine = $derived(Boolean(authorNpub && $currentUser?.npub && authorNpub === $currentUser.npub));
 
-  $: summary = isMine
-    ? tFn('announcements.signerShare.mine')
-    : tFn('announcements.signerShare.theirs', { values: { authorName: authorName || tFn('announcements.signerShare.aMember') } });
+  const summary = $derived(
+    isMine
+      ? tFn('announcements.signerShare.mine')
+      : tFn('announcements.signerShare.theirs', { values: { authorName: authorName || tFn('announcements.signerShare.aMember') } })
+  );
 
-  $: evmAddress = payload.evm_address?.trim() ?? '';
+  const evmAddress = $derived(payload.evm_address?.trim() ?? '');
 
   function shortAddr(addr: string): string {
     const a = addr.trim();

--- a/src/components/announcements/SignerShareAnnounceBody.test.ts
+++ b/src/components/announcements/SignerShareAnnounceBody.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import SignerShareAnnounceBody from './SignerShareAnnounceBody.svelte';
+import { currentUser } from '../../stores/auth';
+import type { SquadMemberEvmSharePayload } from '../../lib/announcements';
+
+afterEach(() => {
+  cleanup();
+  currentUser.set(null);
+});
+
+describe('SignerShareAnnounceBody', () => {
+  it('renders the first-person summary when the announcing author is the current user', () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const payload: SquadMemberEvmSharePayload = {
+      parent_id: 'squad-1',
+      evm_address: '0x1111111111111111111111111111111111111111',
+    };
+    render(SignerShareAnnounceBody, {
+      props: { payload, authorName: 'Alice', authorNpub: 'npub1alice', timestamp: '' },
+    });
+    expect(screen.getByText('You updated your EVM key for this Squad')).toBeTruthy();
+  });
+
+  it('renders the third-person summary with the author name when the announcing author is not the current user', () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const payload: SquadMemberEvmSharePayload = {
+      parent_id: 'squad-1',
+      evm_address: '0x2222222222222222222222222222222222222222',
+    };
+    render(SignerShareAnnounceBody, {
+      props: { payload, authorName: 'Bob', authorNpub: 'npub1bob', timestamp: '' },
+    });
+    expect(screen.getByText('Bob updated their EVM key for this Squad')).toBeTruthy();
+  });
+
+  it('flips the summary from third-person to first-person when the current user store updates after mount, without a prop change', async () => {
+    currentUser.set(null);
+    const payload: SquadMemberEvmSharePayload = {
+      parent_id: 'squad-1',
+      evm_address: '0x3333333333333333333333333333333333333333',
+    };
+    render(SignerShareAnnounceBody, {
+      props: { payload, authorName: 'Carol', authorNpub: 'npub1carol', timestamp: '' },
+    });
+    expect(screen.getByText('Carol updated their EVM key for this Squad')).toBeTruthy();
+
+    currentUser.set({ npub: 'npub1carol', pubkey: 'pk' });
+    expect(await screen.findByText('You updated your EVM key for this Squad')).toBeTruthy();
+  });
+});

--- a/src/components/announcements/SquadBotAnnounceCard.svelte
+++ b/src/components/announcements/SquadBotAnnounceCard.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
@@ -6,18 +8,25 @@
   import { currentUser } from '../../stores/auth';
   import { formatMessageTimestamp } from '../../lib/utils/message-formatting';
 
-  export let id: string = '';
-  export let announce: SquadBotAnnounceMessage;
-  export let authorName: string = '';
-  export let authorNpub: string | undefined = undefined;
-  export let timestamp: string = '';
+  let {
+    id = '',
+    announce,
+    authorName = '',
+    authorNpub = undefined,
+    timestamp = '',
+  }: {
+    id?: string;
+    announce: SquadBotAnnounceMessage;
+    authorName?: string;
+    authorNpub?: string;
+    timestamp?: string;
+  } = $props();
 
   const tFn = get(t);
 
-  $: isMine =
-    Boolean(authorNpub && $currentUser?.npub && authorNpub === $currentUser.npub);
+  const isMine = $derived(Boolean(authorNpub && $currentUser?.npub && authorNpub === $currentUser.npub));
 
-  $: title =
+  const title = $derived(
     announce.kind === 'meta'
       ? isMine
         ? tFn('announcements.squadBot.rosterMine')
@@ -26,20 +35,18 @@
         ? isMine
           ? tFn('announcements.squadBot.rotatedMine')
           : tFn('announcements.squadBot.rotatedTheirs', { values: { authorName: authorName || tFn('announcements.squadBot.aMember') } })
-        : tFn('announcements.squadBot.updateTitle');
+        : tFn('announcements.squadBot.updateTitle')
+  );
 
-  $: holderCount =
-    announce.kind === 'meta' ? announce.payload.holders.length : null;
+  const holderCount = $derived(announce.kind === 'meta' ? announce.payload.holders.length : null);
 
-  $: botNpub =
-    announce.kind === 'meta' || announce.kind === 'key_rotated'
-      ? announce.payload.botNpub
-      : '';
+  const botNpub = $derived(
+    announce.kind === 'meta' || announce.kind === 'key_rotated' ? announce.payload.botNpub : ''
+  );
 
-  $: keyEpoch =
-    announce.kind === 'meta' || announce.kind === 'key_rotated'
-      ? announce.payload.keyEpoch
-      : null;
+  const keyEpoch = $derived(
+    announce.kind === 'meta' || announce.kind === 'key_rotated' ? announce.payload.keyEpoch : null
+  );
 </script>
 
 <div class="announce-card" id={id ? `msg-${id}` : undefined} data-squad-bot-announce={announce.kind}>

--- a/src/components/announcements/SquadBotAnnounceCard.test.ts
+++ b/src/components/announcements/SquadBotAnnounceCard.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import SquadBotAnnounceCard from './SquadBotAnnounceCard.svelte';
+import { currentUser } from '../../stores/auth';
+import type { SquadBotAnnounceMessage } from '../../lib/squad/squad-bot-announce';
+
+afterEach(() => {
+  cleanup();
+  currentUser.set(null);
+});
+
+describe('SquadBotAnnounceCard', () => {
+  it('renders a first-person roster title and holder count for the current user\'s own meta update', () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const announce: SquadBotAnnounceMessage = {
+      kind: 'meta',
+      payload: { squadId: 'squad-1', botNpub: 'npub1bot', holders: ['npub1alice', 'npub1bob'], keyEpoch: 3, updatedAt: 0 },
+    };
+    render(SquadBotAnnounceCard, { props: { announce, authorNpub: 'npub1alice', timestamp: '' } });
+    expect(screen.getByText('You updated the Join inbox holders')).toBeTruthy();
+    expect(screen.getByText('2 holders')).toBeTruthy();
+    expect(screen.getByText('Key epoch 3')).toBeTruthy();
+  });
+
+  it('renders a third-person roster title for another member\'s meta update', () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const announce: SquadBotAnnounceMessage = {
+      kind: 'meta',
+      payload: { squadId: 'squad-1', botNpub: 'npub1bot', holders: ['npub1bob'], keyEpoch: 1, updatedAt: 0 },
+    };
+    render(SquadBotAnnounceCard, { props: { announce, authorName: 'Bob', authorNpub: 'npub1bob', timestamp: '' } });
+    expect(screen.getByText('Bob updated the Join inbox holders')).toBeTruthy();
+  });
+
+  it('renders the key-rotated title for the current user', () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const announce: SquadBotAnnounceMessage = {
+      kind: 'key_rotated',
+      payload: { squadId: 'squad-1', botNpub: 'npub1bot', keyEpoch: 4, rotatedByNpub: 'npub1alice', updatedAt: 0 },
+    };
+    render(SquadBotAnnounceCard, { props: { announce, authorNpub: 'npub1alice', timestamp: '' } });
+    expect(screen.getByText('You rotated the Join inbox key')).toBeTruthy();
+    expect(screen.getByText('Key epoch 4')).toBeTruthy();
+    // holderCount is null for key_rotated: no holders line rendered.
+    expect(screen.queryByText(/holders?$/)).toBeNull();
+  });
+
+  it('recomputes every derived field from the new payload on rerender, not the previous render\'s values', async () => {
+    currentUser.set({ npub: 'npub1alice', pubkey: 'pk' });
+    const { rerender } = render(SquadBotAnnounceCard, {
+      props: {
+        announce: {
+          kind: 'meta',
+          payload: { squadId: 'squad-1', botNpub: 'npub1bot', holders: ['npub1bob'], keyEpoch: 1, updatedAt: 0 },
+        } satisfies SquadBotAnnounceMessage,
+        authorNpub: 'npub1alice',
+        timestamp: '',
+      },
+    });
+    expect(screen.getByText('1 holder')).toBeTruthy();
+
+    await rerender({
+      announce: {
+        kind: 'meta',
+        payload: { squadId: 'squad-1', botNpub: 'npub1bot', holders: ['npub1bob', 'npub1carol', 'npub1dave'], keyEpoch: 2, updatedAt: 0 },
+      } satisfies SquadBotAnnounceMessage,
+      authorNpub: 'npub1alice',
+      timestamp: '',
+    });
+    expect(screen.getByText('3 holders')).toBeTruthy();
+    expect(screen.getByText('Key epoch 2')).toBeTruthy();
+    expect(screen.queryByText('1 holder')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Converts `src/components/announcements/` (7 files: `AnnounceCard`, `SquadBotAnnounceCard`, and the five announcement body components) to Svelte 5 runes — Unit U5 of the runes migration, following the U4 conversion shape (`export let` → `$props()`, `$:` → `$derived`, `<svelte:options runes={true} />` pinned explicitly per file).

## Plan vs. reality

The migration plan estimated 13 side-effect reactive statements in this batch needing the KTD3 four-way triage (derived / handler-move / guarded-effect / bare-effect). Rereading the actual source found none: all 29 `$:` statements across the 7 files are pure presentation computeds — type-narrowing an announcement payload, formatting an address, resolving a display name from a store. Every one converts straight to `$derived`; there is no `$effect` anywhere in this batch. (Same kind of plan/reality drift as U1a earlier in this migration — verified against current code rather than trusted from the plan text.)

## New test coverage

Four new jsdom component test files (20 tests), following the `src/components/dm/*.test.ts` pattern:

- **`AnnounceCard.test.ts`** — routing coverage: all 6 typed announcement variants plus the untyped fallback each render the correct child body.
- **`GovernanceUpdatedAnnounceBody.test.ts`** — proves the `displayName` `$derived` re-subscribes to the `profiles` store and re-renders after an update *post-mount*, not just on a prop change (the store-dependency case most likely to silently break in a `$:` → `$derived` conversion).
- **`Safe/SafeAnnounceBody.test.ts`** — deployed vs. address-updated vs. proposal rendering; a rerender test proving the explorer links recompute when the announce payload's chain changes; and a real clipboard-copy round trip asserting the confirmation toast.
- **`SquadBotAnnounceCard.test.ts`** — mine/theirs copy for both `meta` and `key_rotated`; a rerender test proving holder count and key epoch track the current payload, not a stale one.

## Verification

`pnpm check` (0 errors/warnings), `pnpm lint` (0 problems), full suite `pnpm test` — 237 files, 2152 tests, all green (20 new). No `svelte/legacy` import, no `createEventDispatcher`, no plan-ID breadcrumbs in the diff.

No live Tauri/MCP walkthrough this batch: the diff is markup- and CSS-identical to before (same conditionals, same classes, only the reactivity primitive changed), no Rust was touched, and the dev-sandbox harness has no seed fixtures for any of these 6 announcement wire types (`governance_updated`, `safe_updated`, `safe_proposal`, `squad_member_evm_share`, `dashboard_poll_created`, squad-bot `meta`/`key_rotated`) — confirmed by grep, not assumed. The jsdom suite substitutes: it renders the real component tree with realistic payloads and asserts exact DOM output, which is more precise than a manual scroll-through for a change with zero visual surface.

Related: #197
