### PR TITLE
feat(pacto-app-a7r.21): convert root layout to svelte 5 runes

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, type Snippet } from 'svelte';
   import '../app.css';
   import Login from '../components/auth/Login.svelte';
   import UpdateGate from '../components/updater/UpdateGate.svelte';
@@ -12,15 +12,19 @@
   import { loadAppConfig } from '../stores/app-config';
   import { runDevAutologin } from '../lib/dev/autologin';
 
+  let { children }: { children: Snippet } = $props();
+
   // Before first paint: clear any leftover auth state. The backend session check on mount
   // is the authoritative source of truth, so never assume the session is still valid.
   isAuthenticated.set(false);
   currentUser.set(null);
 
-  $: if ($locale) {
-    document.documentElement.lang = $locale;
-    document.documentElement.dir = 'ltr';
-  }
+  $effect(() => {
+    if ($locale) {
+      document.documentElement.lang = $locale;
+      document.documentElement.dir = 'ltr';
+    }
+  });
 
   onMount(() => {
     // The storage-format probe must precede any account enumeration -
@@ -46,7 +50,7 @@
   <UpdateGate>
     {#if $isAuthenticated && $currentUser}
       <div class="layout-root">
-        <slot />
+        {@render children()}
       </div>
     {:else}
       <Login />


### PR DESCRIPTION
## What
Converts `src/routes/+layout.svelte` — the SvelteKit root layout — to Svelte 5 runes mode, the last non-god-shell file in the runes migration sweep (unblocks U21/U22).

## Why
- Adds `$props()` with a typed `Snippet` for `children`, replacing the Svelte 4 `<slot />` with `{@render children()}`.
- Converts the reactive `$: if ($locale) { ... }` block, which synchronizes `document.documentElement.lang`/`dir` with an external store, to a bare `$effect` — genuine external DOM synchronization per the KTD3 rubric, not a derivable value or user-action handler.
- `onMount` and its auth/session/theme bootstrapping logic are untouched — no behavioral change there.

`src/routes/+page.svelte` (passed in by SvelteKit's generated root as this layout's `children`) is intentionally left on legacy syntax; it is out of scope for this unit.

## Risk
Low — mechanical rune conversion of a 47-line file with no branching logic beyond the existing `$isAuthenticated`/`$currentUser` gate, which is unchanged.

## Verification
- `pnpm check` — 0 errors, 0 warnings
- `pnpm lint` — 0 problems
- `pnpm test` — 240 files / 2185 tests passing
- Manual QA follow-up: no automated coverage exists for verifying `+page.svelte` still renders through `{@render children()}` at runtime (would require a running app/e2e pass); recommend a quick manual smoke check in a dev build.

Closes pacto-app-a7r.21