### PR TITLE
feat: convert channel modals and roster row to svelte 5 runes

### DIFF
--- a/src/components/channel/Channel.svelte
+++ b/src/components/channel/Channel.svelte
@@ -2,12 +2,16 @@
   import { formatUnreadBadgeCount } from '../../lib/dm/dm-unread';
   import { t } from 'svelte-i18n';
 
-  export let name: string = "";
-  export let active: boolean = false;
-  /** Unread / action-needed count; hidden when 0 or channel is active. */
-  export let alertCount = 0;
+  interface Props {
+    name?: string;
+    active?: boolean;
+    /** Unread / action-needed count; hidden when 0 or channel is active. */
+    alertCount?: number;
+  }
 
-  $: alertLabel = formatUnreadBadgeCount(alertCount);
+  let { name = '', active = false, alertCount = 0 }: Props = $props();
+
+  let alertLabel = $derived(formatUnreadBadgeCount(alertCount));
 </script>
 
 <button
@@ -80,4 +84,3 @@
     text-align: center;
   }
 </style>
-

--- a/src/components/channel/CreateChannelModal.svelte
+++ b/src/components/channel/CreateChannelModal.svelte
@@ -1,35 +1,59 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
   import { appConfig } from '../../stores/app-config';
-  export let open = false;
-  export let parentName = '';
-  export let subtitle = '';
-  export let membersLabel = '';
-  export let channelName = '';
-  export let memberList: string[] = [];
-  export let loading = false;
-  export let selectedNpubs: string[] = [];
-  export let emptyMessage = '';
-  export let error = '';
-  export let creating = false;
-  /** When true, show closed-channel member picker. */
-  export let showMemberPicker = false;
-  export let canCreateClosed = false;
-  export let inputId: string | undefined = undefined;
 
-  export let onClose: () => void = () => {};
-  export let onOpenChannel: () => void = () => {};
-  export let onChooseClosed: () => void = () => {};
-  export let onCreateClosed: () => void = () => {};
-  export let onToggleMember: (npub: string) => void = () => {};
-  export let getMemberDisplayName: (npub: string) => string = (npub) => npub;
+  interface Props {
+    open?: boolean;
+    parentName?: string;
+    subtitle?: string;
+    membersLabel?: string;
+    channelName?: string;
+    memberList?: string[];
+    loading?: boolean;
+    selectedNpubs?: string[];
+    emptyMessage?: string;
+    error?: string;
+    creating?: boolean;
+    /** When true, show closed-channel member picker. */
+    showMemberPicker?: boolean;
+    canCreateClosed?: boolean;
+    inputId?: string;
+    onClose?: () => void;
+    onOpenChannel?: () => void;
+    onChooseClosed?: () => void;
+    onCreateClosed?: () => void;
+    onToggleMember?: (npub: string) => void;
+    getMemberDisplayName?: (npub: string) => string;
+  }
 
-  $: maxChannelNameLength = $appConfig.channelNameMaxLength;
+  let {
+    open = false,
+    parentName = '',
+    subtitle = '',
+    membersLabel = '',
+    channelName = $bindable(''),
+    memberList = [],
+    loading = false,
+    selectedNpubs = $bindable([]),
+    emptyMessage = '',
+    error = '',
+    creating = false,
+    showMemberPicker = false,
+    canCreateClosed = false,
+    inputId,
+    onClose = () => {},
+    onOpenChannel = () => {},
+    onChooseClosed = () => {},
+    onCreateClosed = () => {},
+    onToggleMember = () => {},
+    getMemberDisplayName = (npub) => npub,
+  }: Props = $props();
 
   const titleId = 'create-channel-modal-title';
-  const resolvedInputId = inputId ?? 'create-channel-name';
+  let resolvedInputId = $derived(inputId ?? 'create-channel-name');
 
-  $: nameReady = channelName.trim().length > 0;
+  let maxChannelNameLength = $derived($appConfig.channelNameMaxLength);
+  let nameReady = $derived(channelName.trim().length > 0);
 </script>
 
 {#if open}

--- a/src/components/channel/ExitParentModal.svelte
+++ b/src/components/channel/ExitParentModal.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
 
-  export let open = false;
-  export let parentName = '';
-  export let error = '';
-  export let exiting = false;
+  interface Props {
+    open?: boolean;
+    parentName?: string;
+    error?: string;
+    exiting?: boolean;
+    onClose?: () => void;
+    onConfirm?: () => void;
+  }
 
-  export let onClose: () => void = () => {};
-  export let onConfirm: () => void = () => {};
+  let {
+    open = false,
+    parentName = '',
+    error = '',
+    exiting = false,
+    onClose = () => {},
+    onConfirm = () => {},
+  }: Props = $props();
 
   const titleId = 'exit-parent-modal-title';
-  $: title = $t('messaging.exitParent.title');
-  $: confirmLabel = $t('messaging.exitParent.confirm');
-  $: message = parentName
-    ? $t('messaging.exitParent.messageNamed', { values: { parentName } })
-    : $t('messaging.exitParent.messageUnnamed');
+  let title = $derived($t('messaging.exitParent.title'));
+  let confirmLabel = $derived($t('messaging.exitParent.confirm'));
+  let message = $derived(
+    parentName
+      ? $t('messaging.exitParent.messageNamed', { values: { parentName } })
+      : $t('messaging.exitParent.messageUnnamed')
+  );
 </script>
 
 {#if open}

--- a/src/components/channel/InviteToParentModal.svelte
+++ b/src/components/channel/InviteToParentModal.svelte
@@ -1,35 +1,57 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
 
-  export let open = false;
-  export let parentName = '';
-  export let title = '';
-  export let subtitle = '';
-  export let candidates: string[] = [];
-  export let selectedNpubs: string[] = [];
-  export let inviteByNpub = '';
-  export let loading = false;
-  export let emptyMessage = '';
-  export let error = '';
-  export let inviting = false;
+  interface Props {
+    open?: boolean;
+    parentName?: string;
+    title?: string;
+    subtitle?: string;
+    candidates?: string[];
+    selectedNpubs?: string[];
+    inviteByNpub?: string;
+    loading?: boolean;
+    emptyMessage?: string;
+    error?: string;
+    inviting?: boolean;
+    onClose?: () => void;
+    onInvite?: () => void;
+    onToggleCandidate?: (npub: string) => void;
+    /** Used to display each candidate's name in the list. */
+    getCandidateDisplayName?: (npub: string) => string;
+  }
 
-  export let onClose: () => void = () => {};
-  export let onInvite: () => void = () => {};
-  export let onToggleCandidate: (npub: string) => void = () => {};
-  /** Used to display each candidate's name in the list. */
-  export let getCandidateDisplayName: (npub: string) => string = (npub) => npub;
-
-  $: canInvite =
-    (selectedNpubs.length > 0 || inviteByNpub.trim().length > 0) && !inviting;
+  let {
+    open = false,
+    parentName = '',
+    title = '',
+    subtitle = '',
+    candidates = [],
+    selectedNpubs = $bindable([]),
+    inviteByNpub = $bindable(''),
+    loading = false,
+    emptyMessage = '',
+    error = '',
+    inviting = false,
+    onClose = () => {},
+    onInvite = () => {},
+    onToggleCandidate = () => {},
+    getCandidateDisplayName = (npub) => npub,
+  }: Props = $props();
 
   const titleId = 'invite-to-parent-modal-title';
-  $: resolvedTitle = title || $t('messaging.inviteParent.title');
-  $: ariaLabel = $t('messaging.inviteParent.forAria', {
-    values: {
-      title: resolvedTitle,
-      parentName: parentName || $t('messaging.inviteParent.defaultParent'),
-    },
-  });
+
+  let canInvite = $derived(
+    (selectedNpubs.length > 0 || inviteByNpub.trim().length > 0) && !inviting
+  );
+  let resolvedTitle = $derived(title || $t('messaging.inviteParent.title'));
+  let ariaLabel = $derived(
+    $t('messaging.inviteParent.forAria', {
+      values: {
+        title: resolvedTitle,
+        parentName: parentName || $t('messaging.inviteParent.defaultParent'),
+      },
+    })
+  );
 </script>
 
 {#if open}


### PR DESCRIPTION
## Summary

Converts the four channel-panel components not covered by the god-shell exclusion — `Channel.svelte` (sidebar roster row), `CreateChannelModal.svelte`, `InviteToParentModal.svelte`, and `ExitParentModal.svelte` — to Svelte 5 runes mode. `ChatView.svelte` is untouched and stays legacy per R16/U20; it only ever hosts these modals through plain props, so this batch has no impact on its mode.

Before this change these files used `export let` props and `$:` reactive statements (Svelte 4 legacy syntax). After this change they use `$props()`/`$bindable()` and `$derived`, matching the target runes-mode architecture for the migration epic.

All 9 `$:` statements in this batch were pure derivations from props/state (char counts, validation flags, aria labels, i18n strings) — none needed `$effect`; converting them straight to `$effect` would have reproduced Svelte-4-style timing bugs the KTD3 rubric exists to avoid.

`CreateChannelModal.svelte` carries 20 props, consolidated into one `Props` interface (per the epic's guidance) instead of inlining every field in `$props<...>()`.

Two of the four components are still bound to from a legacy (non-runes) parent, `ParentNavbar.svelte` (`bind:channelName`, `bind:selectedNpubs` on the create-channel modal; `bind:selectedNpubs`, `bind:inviteByNpub` on the invite modal). Runes-mode components support `bind:` from a legacy parent as long as the bound prop is declared with `$bindable()`, which this PR does for exactly those four props — everything else stays one-way.

## Changes

- `Channel.svelte`: `export let` → `$props()`, `$: alertLabel` → `$derived`.
- `CreateChannelModal.svelte`: 20 `export let` props consolidated into one `Props` interface; `channelName` and `selectedNpubs` made `$bindable()` (still bound two-way from `ParentNavbar.svelte`); `maxChannelNameLength`, `nameReady`, and `resolvedInputId` converted to `$derived`.
- `InviteToParentModal.svelte`: props consolidated into a `Props` interface; `selectedNpubs` and `inviteByNpub` made `$bindable()`; `canInvite`, `resolvedTitle`, `ariaLabel` converted to `$derived`.
- `ExitParentModal.svelte`: props consolidated into a `Props` interface; `title`, `confirmLabel`, `message` converted to `$derived`.
- No markup, styling, or behavioral changes — this is a pure syntax migration.

## Test plan

- `pnpm check` — 0 errors, 0 warnings.
- `pnpm lint` — 0 problems.
- `pnpm test` — 240 test files / 2185 tests passing.
- Manually traced the three acceptance scenarios against the converted code and existing `ParentNavbar.svelte` wiring (no direct jsdom tests were added — none of this batch's `$:` conversions guard a secret reveal, tx submission, or capability gate, so R20 does not apply here):
  - Create-channel flow: `nameReady` gates the create/open buttons on a trimmed non-empty `channelName`; a blank name leaves the modal open with the button disabled, a valid name calls `onOpenChannel`/`onCreateClosed` (parent closes the modal and creates the channel) exactly once per click.
  - Invite modal opens from legacy `ParentNavbar.svelte`: `bind:selectedNpubs` / `bind:inviteByNpub` two-way bindings still work into a runes-mode child via `$bindable()`.
  - Exit-parent modal: `onClose` fires on cancel/backdrop/Escape and simply flips `showExitModal` back to `false` in the (untouched) parent — no state is mutated inside the modal itself.

Closes pacto-app-a7r.12

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
