### PR TITLE
feat: convert parent dashboard poll/deploy widgets to svelte 5 runes

### DIFF
--- a/src/components/parent/CreatePollModal.svelte
+++ b/src/components/parent/CreatePollModal.svelte
@@ -6,20 +6,24 @@
   import type { ParentPoll, ParentPollOption } from '../../lib/parent/parent-polls';
   import { getInvokeErrorMessage } from '../../lib/utils/tauri-errors';
 
-  export let open: boolean;
-  export let parentId: string;
-  export let onClose: () => void;
-  export let onCreate: (poll: ParentPoll) => void | Promise<void>;
+  interface Props {
+    open: boolean;
+    parentId: string;
+    onClose: () => void;
+    onCreate: (poll: ParentPoll) => void | Promise<void>;
+  }
+
+  let { open, parentId, onClose, onCreate }: Props = $props();
 
   const titleId = 'create-poll-title';
   const descId = 'create-poll-desc';
 
-  let title = '';
-  let description = '';
+  let title = $state('');
+  let description = $state('');
   /** Editable labels; trimmed non-empty become options */
-  let optionRows: string[] = ['', ''];
-  let saving = false;
-  let error = '';
+  let optionRows = $state<string[]>(['', '']);
+  let saving = $state(false);
+  let error = $state('');
 
   function reset() {
     title = '';
@@ -29,7 +33,9 @@
     saving = false;
   }
 
-  $: if (!open) reset();
+  $effect(() => {
+    if (!open) reset();
+  });
 
   function addOption() {
     optionRows = [...optionRows, ''];
@@ -121,7 +127,6 @@
             value={optionRows[i]}
             oninput={(e) => {
               optionRows[i] = e.currentTarget.value;
-              optionRows = optionRows;
             }}
             disabled={saving}
             placeholder={$t('governance.createPoll.optionPlaceholder', { values: { n: i + 1 } })}

--- a/src/components/parent/DashboardPollsPanel.svelte
+++ b/src/components/parent/DashboardPollsPanel.svelte
@@ -20,21 +20,25 @@
   import { getPollBallotMap, pollReferenceToken, setPollBallot } from '../../lib/parent/parent-polls';
   import { getInvokeErrorMessage } from '../../lib/utils/tauri-errors';
 
-  /** Squad/network id (announcements MLS group id). */
-  export let parentId: string;
-  /** MLS group for poll create/vote rumors (`resolvePollsMlsGroupId` — announcements scope). */
-  export let pollsMlsGroupId: string | null;
-  /** Dashboard tab vs `#polls` channel chrome. */
-  export let variant: 'dashboard' | 'channel' = 'dashboard';
-  /** When true in channel variant, fill the parent split pane instead of a fixed max height. */
-  export let fillParent = false;
+  interface Props {
+    /** Squad/network id (announcements MLS group id). */
+    parentId: string;
+    /** MLS group for poll create/vote rumors (`resolvePollsMlsGroupId` — announcements scope). */
+    pollsMlsGroupId: string | null;
+    /** Dashboard tab vs `#polls` channel chrome. */
+    variant?: 'dashboard' | 'channel';
+    /** When true in channel variant, fill the parent split pane instead of a fixed max height. */
+    fillParent?: boolean;
+  }
 
-  let showCreatePollModal = false;
-  let parentPollsList: ParentPoll[] = [];
-  let pollsScrollEl: HTMLDivElement | null = null;
-  let pollBallotRefresh = 0;
-  let pollVoteSendingPollId: string | null = null;
-  let pollVoteSendingOptionId: string | null = null;
+  let { parentId, pollsMlsGroupId, variant = 'dashboard', fillParent = false }: Props = $props();
+
+  let showCreatePollModal = $state(false);
+  let parentPollsList = $state<ParentPoll[]>([]);
+  let pollsScrollEl = $state<HTMLDivElement | null>(null);
+  let pollBallotRefresh = $state(0);
+  let pollVoteSendingPollId = $state<string | null>(null);
+  let pollVoteSendingOptionId = $state<string | null>(null);
 
   function dashboardPollDtoToParentPoll(d: DashboardPollDto): ParentPoll {
     return {
@@ -66,18 +70,21 @@
     }
   }
 
-  $: viewerNpub = $currentUser?.npub ?? '';
+  const viewerNpub = $derived($currentUser?.npub ?? '');
 
-  $: pollReplicaNonceForParent = parentId?.trim()
-    ? ($dashboardPollReplicaNonceByParentId[parentId.trim()] ?? 0)
-    : 0;
+  const pollReplicaNonceForParent = $derived(
+    parentId?.trim() ? ($dashboardPollReplicaNonceByParentId[parentId.trim()] ?? 0) : 0,
+  );
 
-  $: if (parentId?.trim()) {
+  $effect(() => {
+    if (!parentId?.trim()) return;
     void pollReplicaNonceForParent;
     void refreshDashboardPollsList();
-  }
+  });
 
-  $: pollsFeedScrollKey = `${parentId ?? ''}:${parentPollsList.length}:${parentPollsList.at(-1)?.id ?? ''}`;
+  const pollsFeedScrollKey = $derived(
+    `${parentId ?? ''}:${parentPollsList.length}:${parentPollsList.at(-1)?.id ?? ''}`,
+  );
 
   async function scrollPollsFeedToBottom() {
     await tick();
@@ -86,16 +93,16 @@
     el.scrollTop = el.scrollHeight;
   }
 
-  $: {
+  $effect(() => {
     void pollsFeedScrollKey;
     void scrollPollsFeedToBottom();
-  }
+  });
 
-  $: pollBallotMap = (() => {
+  const pollBallotMap = $derived.by(() => {
     void pollBallotRefresh;
     if (!viewerNpub || !parentId) return {} as Record<string, string>;
     return getPollBallotMap(viewerNpub, parentId);
-  })();
+  });
 
   function openCreatePollModal() {
     if (!viewerNpub?.trim()) {
@@ -185,10 +192,11 @@
     showToast(ok ? tFn('governance.polls.copiedChatRef') : tFn('governance.polls.copyFailed'));
   }
 
-  $: tallyHint =
+  const tallyHint = $derived(
     variant === 'channel'
       ? $t('governance.polls.tallyChannelHint')
-      : $t('governance.polls.tallyDashboardHint');
+      : $t('governance.polls.tallyDashboardHint'),
+  );
 </script>
 
 <div

--- a/src/components/parent/DeploySafeModal.svelte
+++ b/src/components/parent/DeploySafeModal.svelte
@@ -2,7 +2,7 @@
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store';
   const tFn = get(t);
-  import { onMount, tick } from 'svelte';
+  import { onMount, tick, untrack } from 'svelte';
   import { invoke } from '@tauri-apps/api/core';
   import Modal from '../ui/Modal.svelte';
   import { getMlsGroupMembers } from '../../lib/api/nostr';
@@ -22,35 +22,44 @@
   import { listSquadMemberEvmInvokeArgs } from '../../lib/squad/squad-member-evm-share';
   import { runOnChainInBackground } from '../../lib/evm/on-chain-background';
 
-  export let parentId: string;
-  export let announcementsGroupId: string | null;
-  export let treasurySafeCount: number;
-  /** Established squad network; when set the picker is pinned to it. */
-  export let squadNetwork: SupportedChainId | null = null;
-  export let onClose: () => void;
-  export let onSuccess: (params: {
-    safeAddress: string;
-    chain: string;
-    label: string;
-    entryId: string;
-    txHash?: string;
-  }) => Promise<void>;
+  let {
+    parentId,
+    announcementsGroupId,
+    treasurySafeCount,
+    squadNetwork = null,
+    onClose,
+    onSuccess,
+  }: {
+    parentId: string;
+    announcementsGroupId: string | null;
+    treasurySafeCount: number;
+    /** Established squad network; when set the picker is pinned to it. */
+    squadNetwork?: SupportedChainId | null;
+    onClose: () => void;
+    onSuccess: (params: {
+      safeAddress: string;
+      chain: string;
+      label: string;
+      entryId: string;
+      txHash?: string;
+    }) => Promise<void>;
+  } = $props();
 
   const titleId = 'deploy-safe-title';
   const descId = 'deploy-safe-desc';
 
-  let loading = true;
-  let channelMembers: string[] = [];
+  let loading = $state(true);
+  let channelMembers = $state<string[]>([]);
   type SquadMemberEvmRow = { memberNpub: string; evmAddress: string; updatedAtMs: number };
-  let roster: Record<string, string> = {};
-  let myEvm: string | null = null;
+  let roster = $state<Record<string, string>>({});
+  let myEvm = $state<string | null>(null);
 
-  let deployNetwork: SupportedChainId | '' = squadNetwork ?? '';
-  let selectedMemberNpubs: string[] = [];
-  let includeMeAsOwner = true;
-  let deployLabel = '';
-  let thresholdInput = '1';
-  let deployError = '';
+  let deployNetwork = $state<SupportedChainId | ''>(untrack(() => squadNetwork ?? ''));
+  let selectedMemberNpubs = $state<string[]>([]);
+  let includeMeAsOwner = $state(true);
+  let deployLabel = $state('');
+  let thresholdInput = $state('1');
+  let deployError = $state('');
 
   function shortAddress(addr: string): string {
     if (!addr || addr.length < 12) return addr;
@@ -84,18 +93,16 @@
     });
   }
 
-  $: sortedMembers = sortedMemberNpubs(channelMembers);
+  const sortedMembers = $derived(sortedMemberNpubs(channelMembers));
   /** #announcements peers who shared a squad roster address (excludes you; use "Include me"). */
-  $: signersListNpubs = sortedMembers.filter((n) => {
-    if (n === ($currentUser?.npub ?? '')) return false;
-    return !!roster[n]?.trim();
-  });
+  const signersListNpubs = $derived(
+    sortedMembers.filter((n) => {
+      if (n === ($currentUser?.npub ?? '')) return false;
+      return !!roster[n]?.trim();
+    }),
+  );
 
-  /**
-   * Inline map (no helper fn): Svelte 5 reactive statements may not register deps read inside nested
-   * functions, so owner count stayed 0 after async `myEvm` assignment.
-   */
-  $: ownerAddresses = (() => {
+  const ownerAddresses = $derived.by(() => {
     const m = new Map<string, string>();
     for (const n of selectedMemberNpubs) {
       const a = effectiveEvm(n);
@@ -105,12 +112,12 @@
       m.set(myEvm.toLowerCase(), myEvm);
     }
     return [...m.values()];
-  })();
-  $: ownerCount = ownerAddresses.length;
-  $: thresholdNum = Math.max(1, parseInt(thresholdInput, 10) || 1);
-  $: thresholdValid = ownerCount > 0 && thresholdNum >= 1 && thresholdNum <= ownerCount;
-  $: maxSafeSigners = $appConfig.deploySafeMaxSigners;
-  $: ownerOverMax = ownerCount > maxSafeSigners;
+  });
+  const ownerCount = $derived(ownerAddresses.length);
+  const thresholdNum = $derived(Math.max(1, parseInt(thresholdInput, 10) || 1));
+  const thresholdValid = $derived(ownerCount > 0 && thresholdNum >= 1 && thresholdNum <= ownerCount);
+  const maxSafeSigners = $derived($appConfig.deploySafeMaxSigners);
+  const ownerOverMax = $derived(ownerCount > maxSafeSigners);
 
   function toggleMember(npub: string): void {
     const evm = effectiveEvm(npub);

--- a/src/components/parent/MyDashboard.svelte
+++ b/src/components/parent/MyDashboard.svelte
@@ -16,20 +16,21 @@
   import { persistSquadMemberEvmForParent } from '../../lib/dashboard/squad-member-evm-cache';
   import { currentUser } from '../../stores/auth';
 
-  export let parent: Squad;
+  let { parent }: { parent: Squad } = $props();
 
   const VIEWS: MyDashboardChannelMode[] = [
     'status',
     'alerts',
   ];
 
-  $: dashboardView = $myDashboardChannelMode;
-  $: parentId = parent?.id ?? '';
-  $: announcementsGroupId =
+  const dashboardView = $derived($myDashboardChannelMode);
+  const parentId = $derived(parent?.id ?? '');
+  const announcementsGroupId = $derived(
     parent?.channels?.find((c) => c.name === ANNOUNCEMENTS_CHANNEL_NAME)?.groupId ??
-    parent?.channels?.[0]?.groupId ??
-    null;
-  $: squadMemberEvmByNpub = parentId ? ($squadMemberEvmByParentId[parentId] ?? {}) : {};
+      parent?.channels?.[0]?.groupId ??
+      null,
+  );
+  const squadMemberEvmByNpub = $derived(parentId ? ($squadMemberEvmByParentId[parentId] ?? {}) : {});
 
   async function loadSquadMemberEvm() {
     if (!parentId) return;
@@ -41,7 +42,10 @@
     if (npub) persistSquadMemberEvmForParent(npub, loadParentId, rows);
   }
 
-  $: if (parentId) void loadSquadMemberEvm();
+  $effect(() => {
+    void parentId;
+    void loadSquadMemberEvm();
+  });
 
   function selectView(id: MyDashboardChannelMode) {
     myDashboardChannelMode.set(id);

--- a/src/components/parent/ParentSettingUp.svelte
+++ b/src/components/parent/ParentSettingUp.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
-  /** Optional id for the error element (for aria-describedby on retry button). */
-  export let errorId: string | undefined = undefined;
-  export let error: string | undefined = undefined;
-  export let canRetry = false;
-  export let retrying = false;
-  export let onRetry: (() => void) | undefined = undefined;
-  export let canDiscard = false;
-  export let onDiscard: (() => void) | undefined = undefined;
+
+  interface Props {
+    /** Optional id for the error element (for aria-describedby on retry button). */
+    errorId?: string;
+    error?: string;
+    canRetry?: boolean;
+    retrying?: boolean;
+    onRetry?: () => void;
+    canDiscard?: boolean;
+    onDiscard?: () => void;
+  }
+
+  let {
+    errorId,
+    error,
+    canRetry = false,
+    retrying = false,
+    onRetry,
+    canDiscard = false,
+    onDiscard,
+  }: Props = $props();
 </script>
 
 <div class="parent-setting-up" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary

Converts five components hosted inside the legacy `ParentDashboard.svelte` shell — `DeploySafeModal`, `DashboardPollsPanel`, `CreatePollModal`, `MyDashboard`, and `ParentSettingUp` — from Svelte 4 `export let`/reactive-statement syntax to Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`). `ParentDashboard.svelte` itself is untouched and continues to host these as children (the interop direction already proven in earlier units of this migration).

No behavior change is intended. Every reactive statement was triaged individually:

- **Pure computations** (poll tally text, threshold validity, owner counts, sorted signer lists, `pollBallotMap`, `pollsFeedScrollKey`, etc.) became `$derived` / `$derived.by`.
- **Genuine side effects** (poll list reload on parent id/replica-nonce change, feed auto-scroll, form reset on modal close, squad-member EVM address load) became guarded `$effect`s, following the existing repo idiom of reading each dependency explicitly then calling the load function inside the effect body, so tracked dependencies match the original statement's dependency set exactly (see `SquadSponsoredFeeUsagePanel.svelte` / `DashboardSettingsTab.svelte` for the precedent).

`DeploySafeModal.svelte` was the highest-risk file (8 reactive statements over a deployment form): all 8 turned out to be pure derivations (owner list dedupe, threshold math, signer filtering) with no reactive statement actually driving the on-chain deployment flow — that flow already runs as a plain async function (`confirmDeploy`) triggered by a button click, so it required no `$effect` at all. Fixed a latent `state_referenced_locally` warning by wrapping the prop-seeded `deployNetwork` initial value in `untrack()`, matching the pattern already used in `ResizableSidebar.svelte`.

## Changes

- `DashboardPollsPanel.svelte` — props to `$props()`; poll list load, ballot map, and feed-scroll reactivity converted (2 `$effect`s + 5 `$derived`).
- `CreatePollModal.svelte` — props to `$props()`; form-reset-on-close converted to a guarded `$effect`; dropped a now-redundant array reassignment (deep-reactive `$state` array no longer needs the legacy re-assignment trick to trigger updates).
- `DeploySafeModal.svelte` — props to `$props()`; all 8 reactive statements converted to `$derived`/`$derived.by` (no `$effect` needed — the deployment flow was already a plain function, not reactive-statement-driven).
- `MyDashboard.svelte` — props to `$props()`; view/parentId/announcements-group derivations converted; squad-member EVM address load converted to a guarded `$effect`.
- `ParentSettingUp.svelte` — trivial props-only conversion (no reactive statements, no slots).

## Test plan

- `pnpm check` — 0 errors, 0 warnings (2933 files).
- `pnpm lint` — 0 problems.
- `pnpm test` — 240 test files / 2185 tests passing.
- Manual/mental verification against acceptance criteria:
  - `DashboardPollsPanel`'s load-poll-list `$effect` depends only on `parentId` (primitive-value tracked) and the replica nonce, so it fires once per distinct parent id, not on every re-render from the legacy dashboard shell.
  - `CreatePollModal.submit()` still rejects fewer than 2 non-empty option labels before any network call (unchanged, untouched function).
  - `DeploySafeModal`'s confirm button's `disabled` expression (owner count / threshold validity / owner cap / network selected) is unchanged; the modal closes synchronously on confirm before the background deploy job starts, so there's no "stuck enabled while in-flight" state to introduce a regression in.

## Manual QA follow-up for reviewer

- No jsdom component tests were added. None of the converted `$effect`s guard a secret reveal, a transaction/capability submission, or a capability gate — the actual poll-creation validation and safe-deploy submission live in plain functions that were not reactive statements to begin with, so they were out of scope for this conversion and untouched.
- Live network-dependent flows (poll create/vote round-trip via MLS, Safe deploy background job, squad-member EVM address resolution) were not exercised against a live backend — recommend a manual pass in a running app if not already covered by the epic's end-to-end QA pass.

Closes pacto-app-a7r.15

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
