### PR TITLE
feat: convert governance treasury, roles, and security panels to svelte 5 runes

### DIFF
--- a/src/components/parent/governance/HatsTreeDiagram.svelte
+++ b/src/components/parent/governance/HatsTreeDiagram.svelte
@@ -4,13 +4,25 @@
   import HatsTreeNode from './HatsTreeNode.svelte';
   import { t } from 'svelte-i18n';
 
-  export let root: HatTreeNodeDto;
-  export let roleLabelByHatId: Record<string, string> = {};
-  export let wearerAddressesByHatId: Record<string, string[]> = {};
-  export let executorRolesByAddress: Record<string, string> = {};
-  export let squadMemberEvmByNpub: Record<string, string> = {};
-  export let knownWearerLabels: Record<string, string> = {};
-  export let chainKey: SupportedChainId | null = null;
+  interface Props {
+    root: HatTreeNodeDto;
+    roleLabelByHatId?: Record<string, string>;
+    wearerAddressesByHatId?: Record<string, string[]>;
+    executorRolesByAddress?: Record<string, string>;
+    squadMemberEvmByNpub?: Record<string, string>;
+    knownWearerLabels?: Record<string, string>;
+    chainKey?: SupportedChainId | null;
+  }
+
+  let {
+    root,
+    roleLabelByHatId = {},
+    wearerAddressesByHatId = {},
+    executorRolesByAddress = {},
+    squadMemberEvmByNpub = {},
+    knownWearerLabels = {},
+    chainKey = null,
+  }: Props = $props();
 </script>
 
 <div class="hats-tree-scroll" role="tree" aria-label={$t('governance.title.hatsTree')}>

--- a/src/components/parent/governance/HatsTreeNode.svelte
+++ b/src/components/parent/governance/HatsTreeNode.svelte
@@ -12,31 +12,45 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
   import { localizeRoleLabel } from '../../../lib/governance/governance-privilege';
+  import HatsTreeNode from './HatsTreeNode.svelte';
 
-  export let node: HatTreeNodeDto;
-  export let roleLabelByHatId: Record<string, string> = {};
-  export let wearerAddressesByHatId: Record<string, string[]> = {};
-  export let executorRolesByAddress: Record<string, string> = {};
-  export let squadMemberEvmByNpub: Record<string, string> = {};
-  /** Known protocol module labels keyed by lowercase address. */
-  export let knownWearerLabels: Record<string, string> = {};
-  export let chainKey: SupportedChainId | null = null;
+  interface Props {
+    node: HatTreeNodeDto;
+    roleLabelByHatId?: Record<string, string>;
+    wearerAddressesByHatId?: Record<string, string[]>;
+    executorRolesByAddress?: Record<string, string>;
+    squadMemberEvmByNpub?: Record<string, string>;
+    /** Known protocol module labels keyed by lowercase address. */
+    knownWearerLabels?: Record<string, string>;
+    chainKey?: SupportedChainId | null;
+  }
+
+  let {
+    node,
+    roleLabelByHatId = {},
+    wearerAddressesByHatId = {},
+    executorRolesByAddress = {},
+    squadMemberEvmByNpub = {},
+    knownWearerLabels = {},
+    chainKey = null,
+  }: Props = $props();
 
   const tFn = get(t);
 
-  $: roleLabel = roleLabelByHatId[node.hatId] ?? '';
-  $: wearerAddresses = wearerAddressesByHatId[node.hatId] ?? [];
-  $: npubByAddress = npubByEvmAddressFromSquadRoster(squadMemberEvmByNpub);
-  $: prettyId = prettyHatId(node.hatId) ?? node.hatId;
-  $: humanDetails = humanHatDetails(node.details);
+  const roleLabel = $derived(roleLabelByHatId[node.hatId] ?? '');
+  const wearerAddresses = $derived(wearerAddressesByHatId[node.hatId] ?? []);
+  const npubByAddress = $derived(npubByEvmAddressFromSquadRoster(squadMemberEvmByNpub));
+  const prettyId = $derived(prettyHatId(node.hatId) ?? node.hatId);
+  const humanDetails = $derived(humanHatDetails(node.details));
   /** Extra line only when role label and a distinct human details string both exist. */
-  $: detailsSubtitle =
-    roleLabel && humanDetails && humanDetails !== roleLabel ? humanDetails : '';
-  $: hasWearers = wearerAddresses.length > 0 || node.supply > 0;
-  $: children = node.children ?? [];
-  $: childCount = children.length;
-  $: primaryWearer = wearerAddresses[0] ?? '';
-  $: primaryWearerRoles = primaryWearer ? executorRolesLabel(primaryWearer) : '';
+  const detailsSubtitle = $derived(
+    roleLabel && humanDetails && humanDetails !== roleLabel ? humanDetails : '',
+  );
+  const hasWearers = $derived(wearerAddresses.length > 0 || node.supply > 0);
+  const children = $derived(node.children ?? []);
+  const childCount = $derived(children.length);
+  const primaryWearer = $derived(wearerAddresses[0] ?? '');
+  const primaryWearerRoles = $derived(primaryWearer ? executorRolesLabel(primaryWearer) : '');
 
   function wearerLabel(address: string): string {
     return formatWearerDisplayLabel(
@@ -136,7 +150,7 @@
       {#each children as child (child.hatId)}
         <div class="hats-tree-child">
           <span class="hats-tree-child-stem" aria-hidden="true"></span>
-          <svelte:self
+          <HatsTreeNode
             node={child}
             {roleLabelByHatId}
             {wearerAddressesByHatId}

--- a/src/components/parent/governance/SmartContractSecuritySection.svelte
+++ b/src/components/parent/governance/SmartContractSecuritySection.svelte
@@ -35,40 +35,44 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let parentId = '';
-  export let announcementsGroupId = '';
-  /** Interim v1: Pacto Gov deployed (captain-gated mutation ships with on-chain role check). */
-  export let canManage = false;
-  /** Slimmer chrome for Status (collapsed add form by default). */
-  export let compact = false;
+  interface Props {
+    parentId?: string;
+    announcementsGroupId?: string;
+    /** Interim v1: Pacto Gov deployed (captain-gated mutation ships with on-chain role check). */
+    canManage?: boolean;
+    /** Slimmer chrome for Status (collapsed add form by default). */
+    compact?: boolean;
+  }
+
+  let { parentId = '', announcementsGroupId = '', canManage = false, compact = false }: Props = $props();
 
   const tFn = get(t);
 
-  let rows: SquadContractAllowlistRow[] = [];
-  let loading = true;
-  let loadError = '';
+  let rows = $state<SquadContractAllowlistRow[]>([]);
+  let loading = $state(true);
+  let loadError = $state('');
 
-  let addChain: SupportedChainId = DEFAULT_CHAIN_ID;
-  let addAddress = '';
-  let addLabel = '';
-  let addAbiRef = '';
-  let addBusy = false;
-  let addSectionOpen = false;
+  let addChain = $state<SupportedChainId>(DEFAULT_CHAIN_ID);
+  let addAddress = $state('');
+  let addLabel = $state('');
+  let addAbiRef = $state('');
+  let addBusy = $state(false);
+  let addSectionOpen = $state(false);
 
-  let callChain: SupportedChainId = DEFAULT_CHAIN_ID;
-  let callTo = '';
-  let callValueEth = '0';
-  let callDataHex = '0x';
-  let callAbiRef = 'erc20-minimal';
-  let callFunctionName = '';
-  let callArgsJson = '[]';
-  let callMode: 'raw' | 'abi' = 'raw';
-  let callSimOk: boolean | null = null;
-  let callSimMessage = '';
-  let callSimulating = false;
-  let callSending = false;
-  let squadSigner: string | null = null;
-  let callSectionOpen = false;
+  let callChain = $state<SupportedChainId>(DEFAULT_CHAIN_ID);
+  let callTo = $state('');
+  let callValueEth = $state('0');
+  let callDataHex = $state('0x');
+  let callAbiRef = $state('erc20-minimal');
+  let callFunctionName = $state('');
+  let callArgsJson = $state('[]');
+  let callMode = $state<'raw' | 'abi'>('raw');
+  let callSimOk = $state<boolean | null>(null);
+  let callSimMessage = $state('');
+  let callSimulating = $state(false);
+  let callSending = $state(false);
+  let squadSigner = $state<string | null>(null);
+  let callSectionOpen = $state(false);
 
   const shippedAbis = listShippedAbiRefs();
 
@@ -98,8 +102,12 @@
     });
   });
 
-  $: allowlistNonce = $squadAllowlistNonceByParentId[parentId.trim()] ?? 0;
-  $: parentId, allowlistNonce, void refreshRows();
+  const allowlistNonce = $derived($squadAllowlistNonceByParentId[parentId.trim()] ?? 0);
+  $effect(() => {
+    parentId;
+    allowlistNonce;
+    void refreshRows();
+  });
 
   function shortAddr(a: string): string {
     const t = a.trim();
@@ -247,8 +255,8 @@
     });
   }
 
-  $: callTargetLabel = findAllowlistLabel(rows, callChain, callTo);
-  $: canSendCall = callSimOk === true && !!squadSigner && isAddress(callTo.trim());
+  const callTargetLabel = $derived(findAllowlistLabel(rows, callChain, callTo));
+  const canSendCall = $derived(callSimOk === true && !!squadSigner && isAddress(callTo.trim()));
 </script>
 
 <section

--- a/src/components/parent/governance/SquadRolesModal.svelte
+++ b/src/components/parent/governance/SquadRolesModal.svelte
@@ -18,46 +18,62 @@
   import { showToast } from '../../../stores/toast';
   import { appConfig } from '../../../stores/app-config';
 
-  export let open = false;
-  export let onClose: () => void;
-  export let parentId = '';
-  export let squadAdminProxy: string;
-  export let network: SupportedChainId = 'sepolia';
-  /** EVM address → display label for executor picker. */
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let privilege: GovernancePrivilege | null = null;
+  interface Props {
+    open?: boolean;
+    onClose: () => void;
+    parentId?: string;
+    squadAdminProxy: string;
+    network?: SupportedChainId;
+    /** EVM address → display label for executor picker. */
+    memberEvmOptions?: { address: string; label: string }[];
+    privilege?: GovernancePrivilege | null;
+  }
+
+  let {
+    open = false,
+    onClose,
+    parentId = '',
+    squadAdminProxy,
+    network = 'sepolia',
+    memberEvmOptions = [],
+    privilege = null,
+  }: Props = $props();
 
   const titleId = 'squad-roles-modal-title';
   const descId = 'squad-roles-modal-desc';
 
   const tFn = get(t);
 
-  let roleLabel = '';
-  let executorAddress = '';
-  let grantFullPermission = false;
-  let actionError = '';
-  let loadedPrivilege: GovernancePrivilege | null = null;
-  let privilegeLoadKey = '';
+  let roleLabel = $state('');
+  let executorAddress = $state('');
+  let grantFullPermission = $state(false);
+  let actionError = $state('');
+  let loadedPrivilege = $state<GovernancePrivilege | null>(null);
+  let privilegeLoadKey = $state('');
 
-  $: roleLabelMaxLength = $appConfig.roleLabelMaxLength;
+  const roleLabelMaxLength = $derived($appConfig.roleLabelMaxLength);
 
-  $: effectivePrivilege = privilege ?? loadedPrivilege;
-  $: saGate = effectivePrivilege
-    ? gateSquadAdminWrite(effectivePrivilege)
-    : ({ enabled: true, reason: '' } as const);
+  const effectivePrivilege = $derived(privilege ?? loadedPrivilege);
+  const saGate = $derived(
+    effectivePrivilege ? gateSquadAdminWrite(effectivePrivilege) : ({ enabled: true, reason: '' } as const),
+  );
 
-  $: if (open && !executorAddress && memberEvmOptions.length > 0) {
-    executorAddress = memberEvmOptions[0].address;
-  }
-
-  $: if (open && parentId.trim()) {
-    const pid = parentId.trim();
-    const key = `${pid}|${network}`;
-    if (key !== privilegeLoadKey) {
-      privilegeLoadKey = key;
-      void loadPrivilege(pid);
+  $effect(() => {
+    if (open && !executorAddress && memberEvmOptions.length > 0) {
+      executorAddress = memberEvmOptions[0].address;
     }
-  }
+  });
+
+  $effect(() => {
+    if (open && parentId.trim()) {
+      const pid = parentId.trim();
+      const key = `${pid}|${network}`;
+      if (key !== privilegeLoadKey) {
+        privilegeLoadKey = key;
+        void loadPrivilege(pid);
+      }
+    }
+  });
 
   async function loadPrivilege(pid: string) {
     const key = `${pid}|${network}`;

--- a/src/components/parent/governance/SquadSponsorTreasuryPanel.svelte
+++ b/src/components/parent/governance/SquadSponsorTreasuryPanel.svelte
@@ -39,40 +39,44 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let parentId: string;
-  export let sponsorRow: SquadInfraDto | null = null;
-  export let onOpenDeploy: (() => void) | undefined = undefined;
+  interface Props {
+    parentId: string;
+    sponsorRow?: SquadInfraDto | null;
+    onOpenDeploy?: () => void;
+  }
+
+  let { parentId, sponsorRow = null, onOpenDeploy = undefined }: Props = $props();
 
   const tFn = get(t);
 
-  let summary: SquadSponsorSummaryDto | null = null;
-  let loading = false;
-  let loadError = '';
-  let depositEth = '0.01';
-  let depositing = false;
-  let depositError = '';
-  let showDepositForm = false;
-  let showWithdrawModal = false;
+  let summary = $state<SquadSponsorSummaryDto | null>(null);
+  let loading = $state(false);
+  let loadError = $state('');
+  let depositEth = $state('0.01');
+  let depositing = $state(false);
+  let depositError = $state('');
+  let showDepositForm = $state(false);
+  let showWithdrawModal = $state(false);
   let periodicRefreshTimer: ReturnType<typeof setInterval> | null = null;
-  let hydratedSponsorKey = '';
-  let signerWallet: SquadSponsorDeploySignerWallet = 'default';
-  let addressesLoading = false;
+  let hydratedSponsorKey = $state('');
+  let signerWallet = $state<SquadSponsorDeploySignerWallet>('default');
+  let addressesLoading = $state(false);
   let refreshSeq = 0;
-  let defaultSignerAddress: string | null = null;
-  let squadSignerAddress: string | null = null;
+  let defaultSignerAddress = $state<string | null>(null);
+  let squadSignerAddress = $state<string | null>(null);
 
-  let defaultBalance: SignerBalance = emptyBalance();
-  let squadBalance: SignerBalance = emptyBalance();
-  let feeUsageRefreshToken = 0;
+  let defaultBalance = $state<SignerBalance>(emptyBalance());
+  let squadBalance = $state<SignerBalance>(emptyBalance());
+  let feeUsageRefreshToken = $state(0);
 
-  $: network = parseSupportedChainId(sponsorRow?.chain);
-  $: poolBalanceWei = summary ? BigInt(summary.poolBalanceWei) : null;
-  $: lowBalance =
-    poolBalanceWei != null && poolBalanceWei < SPONSOR_LOW_BALANCE_WEI;
-  $: explorerUrl =
+  const network = $derived(parseSupportedChainId(sponsorRow?.chain));
+  const poolBalanceWei = $derived(summary ? BigInt(summary.poolBalanceWei) : null);
+  const lowBalance = $derived(poolBalanceWei != null && poolBalanceWei < SPONSOR_LOW_BALANCE_WEI);
+  const explorerUrl = $derived(
     summary?.sponsorAddress &&
-    explorerAddressUrl(parseSupportedChainId(summary.chain), summary.sponsorAddress);
-  $: sponsorKey = sponsorRow?.id ?? '';
+      explorerAddressUrl(parseSupportedChainId(summary.chain), summary.sponsorAddress),
+  );
+  const sponsorKey = $derived(sponsorRow?.id ?? '');
 
   function currentCacheKey(): string | null {
     if (!parentId?.trim() || !sponsorRow) return null;
@@ -130,13 +134,15 @@
     void refreshSummary(false);
   }
 
-  $: if (sponsorKey && parentId?.trim()) {
-    const nextKey = `${parentId}:${sponsorKey}:${network}`;
-    if (nextKey !== hydratedSponsorKey) {
-      hydratedSponsorKey = nextKey;
-      hydrateFromSessionCache();
+  $effect(() => {
+    if (sponsorKey && parentId?.trim()) {
+      const nextKey = `${parentId}:${sponsorKey}:${network}`;
+      if (nextKey !== hydratedSponsorKey) {
+        hydratedSponsorKey = nextKey;
+        hydrateFromSessionCache();
+      }
     }
-  }
+  });
 
   onMount(() => {
     periodicRefreshTimer = setInterval(() => {
@@ -178,54 +184,63 @@
     squadBalance = squadBal;
   }
 
-  $: defaultCanonical = canonicalAddress(defaultSignerAddress);
-  $: squadCanonical = canonicalAddress(squadSignerAddress);
-  $: signersAreSame =
-    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical;
+  const defaultCanonical = $derived(canonicalAddress(defaultSignerAddress));
+  const squadCanonical = $derived(canonicalAddress(squadSignerAddress));
+  const signersAreSame = $derived(
+    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical,
+  );
 
-  $: selectedAddress = signersAreSame
-    ? squadCanonical
-    : signerWallet === 'default'
-      ? defaultSignerAddress
-      : squadSignerAddress;
-  $: selectedBalance = signersAreSame
-    ? squadBalance
-    : signerWallet === 'default'
-      ? defaultBalance
-      : squadBalance;
-  $: selectedSymbol = selectedBalance.symbol || 'ETH';
+  const selectedAddress = $derived(
+    signersAreSame
+      ? squadCanonical
+      : signerWallet === 'default'
+        ? defaultSignerAddress
+        : squadSignerAddress,
+  );
+  const selectedBalance = $derived(
+    signersAreSame
+      ? squadBalance
+      : signerWallet === 'default'
+        ? defaultBalance
+        : squadBalance,
+  );
+  const selectedSymbol = $derived(selectedBalance.symbol || 'ETH');
 
-  $: signerUnavailable = signersAreSame
-    ? !squadCanonical
-    : signerWallet === 'default'
-      ? !defaultCanonical
-      : !squadCanonical;
+  const signerUnavailable = $derived(
+    signersAreSame
+      ? !squadCanonical
+      : signerWallet === 'default'
+        ? !defaultCanonical
+        : !squadCanonical,
+  );
 
-  $: depositTrimmed = depositEth.trim();
-  $: depositWeiPreview = (() => {
+  const depositTrimmed = $derived(depositEth.trim());
+  const depositWeiPreview = $derived.by(() => {
     try {
       const wei = parseEther(depositTrimmed.replace(/,/g, ''));
       return wei > 0n ? wei : null;
     } catch {
       return null;
     }
-  })();
+  });
 
-  $: depositExceedsBalance =
+  const depositExceedsBalance = $derived(
     depositWeiPreview != null &&
-    selectedAddress != null &&
-    !addressesLoading &&
-    !selectedBalance.loading &&
-    !selectedBalance.error &&
-    amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw);
+      selectedAddress != null &&
+      !addressesLoading &&
+      !selectedBalance.loading &&
+      !selectedBalance.error &&
+      amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw),
+  );
 
-  $: canConfirmDeposit =
+  const canConfirmDeposit = $derived(
     !depositing &&
-    !addressesLoading &&
-    !signerUnavailable &&
-    depositWeiPreview != null &&
-    !depositExceedsBalance &&
-    !selectedBalance.loading;
+      !addressesLoading &&
+      !signerUnavailable &&
+      depositWeiPreview != null &&
+      !depositExceedsBalance &&
+      !selectedBalance.loading,
+  );
 
   async function openDepositForm() {
     showDepositForm = true;

--- a/src/components/parent/governance/SquadSponsorWithdrawModal.svelte
+++ b/src/components/parent/governance/SquadSponsorWithdrawModal.svelte
@@ -17,52 +17,70 @@
   import { showToast } from '../../../stores/toast';
   import { formatEther } from 'viem';
 
-  export let open = false;
-  export let onClose: () => void = () => {};
-  export let network = 'sepolia';
-  export let parentId = '';
-  export let sponsorAddress = '';
-  export let onSubmitted: () => void = () => {};
+  interface Props {
+    open?: boolean;
+    onClose?: () => void;
+    network?: string;
+    parentId?: string;
+    sponsorAddress?: string;
+    onSubmitted?: () => void;
+  }
+
+  let {
+    open = false,
+    onClose = () => {},
+    network = 'sepolia',
+    parentId = '',
+    sponsorAddress = '',
+    onSubmitted = () => {},
+  }: Props = $props();
 
   const titleId = 'sponsor-withdraw-title';
   const descId = 'sponsor-withdraw-desc';
 
   const tFn = get(t);
 
-  let accounts: EvmAccountRow[] = [];
-  let accountsLoading = false;
-  let selectedAccountId = '';
-  let withdrawableWei: string | null = null;
-  let withdrawableLoading = false;
-  let acting = false;
-  let error = '';
-  let wasOpen = false;
+  let accounts = $state<EvmAccountRow[]>([]);
+  let accountsLoading = $state(false);
+  let selectedAccountId = $state('');
+  let withdrawableWei = $state<string | null>(null);
+  let withdrawableLoading = $state(false);
+  let acting = $state(false);
+  let error = $state('');
+  let wasOpen = $state(false);
 
-  $: selected = accounts.find((a) => a.id === selectedAccountId) ?? null;
-  let lastWithdrawableKey = '';
+  const selected = $derived(accounts.find((a) => a.id === selectedAccountId) ?? null);
+  let lastWithdrawableKey = $state('');
 
-  $: if (open && !wasOpen) {
-    wasOpen = true;
-    error = '';
-    withdrawableWei = null;
-    selectedAccountId = '';
-    lastWithdrawableKey = '';
-    void loadAccounts();
-  }
-  $: if (!open) {
-    wasOpen = false;
-  }
+  $effect(() => {
+    if (open && !wasOpen) {
+      wasOpen = true;
+      error = '';
+      withdrawableWei = null;
+      selectedAccountId = '';
+      lastWithdrawableKey = '';
+      void loadAccounts();
+    }
+  });
+  $effect(() => {
+    if (!open) {
+      wasOpen = false;
+    }
+  });
 
-  $: withdrawableKey =
+  const withdrawableKey = $derived(
     open && selected?.address
       ? `${parentId.trim()}|${selected.address.trim().toLowerCase()}|${sponsorAddress.trim().toLowerCase()}`
-      : '';
-  $: if (withdrawableKey && withdrawableKey !== lastWithdrawableKey) {
-    lastWithdrawableKey = withdrawableKey;
-    if (selected) {
-      void loadWithdrawable(selected.address);
+      : '',
+  );
+  $effect(() => {
+    if (withdrawableKey && withdrawableKey !== lastWithdrawableKey) {
+      lastWithdrawableKey = withdrawableKey;
+      if (selected) {
+        void loadWithdrawable(selected.address);
+      }
     }
-  }
+  });
 
   async function loadAccounts() {
     accountsLoading = true;

--- a/src/components/parent/governance/SquadSponsorWithdrawModal.test.ts
+++ b/src/components/parent/governance/SquadSponsorWithdrawModal.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+
+const withdrawSquadSponsorMock = vi.fn();
+const getSquadSponsorWithdrawableMock = vi.fn();
+
+vi.mock('../../../lib/governance/api', () => ({
+  getSquadSponsorWithdrawable: (...args: unknown[]) => getSquadSponsorWithdrawableMock(...args),
+  withdrawSquadSponsor: (...args: unknown[]) => withdrawSquadSponsorMock(...args),
+}));
+
+const listEvmAccountsMock = vi.fn();
+vi.mock('../../../lib/wallet/evm-accounts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/wallet/evm-accounts')>();
+  return {
+    ...actual,
+    listEvmAccounts: (...args: unknown[]) => listEvmAccountsMock(...args),
+  };
+});
+
+import SquadSponsorWithdrawModal from './SquadSponsorWithdrawModal.svelte';
+import type { EvmAccountRow } from '../../../lib/wallet/evm-accounts';
+
+function account(overrides: Partial<EvmAccountRow> = {}): EvmAccountRow {
+  return {
+    id: 'acct-1',
+    scheme: 'secp256k1',
+    hdIndex: 0,
+    address: '0x1111111111111111111111111111111111111a',
+    label: 'Main',
+    purpose: 'squad',
+    isActive: true,
+    isDefaultShared: true,
+    isActiveAdvanced: false,
+    ...overrides,
+  };
+}
+
+function baseProps(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    open: true,
+    network: 'sepolia',
+    parentId: 'parent-1',
+    sponsorAddress: '0xsponsor00000000000000000000000000000000',
+    onClose: vi.fn(),
+    onSubmitted: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('SquadSponsorWithdrawModal', () => {
+  beforeEach(() => {
+    listEvmAccountsMock.mockReset();
+    withdrawSquadSponsorMock.mockReset();
+    getSquadSponsorWithdrawableMock.mockReset();
+    listEvmAccountsMock.mockResolvedValue([account()]);
+    getSquadSponsorWithdrawableMock.mockResolvedValue('1000000000000000000');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('submits exactly one withdrawal, even under a rapid double confirm click', async () => {
+    let resolveWithdraw: (() => void) | undefined;
+    withdrawSquadSponsorMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWithdraw = resolve;
+        }),
+    );
+    const props = baseProps();
+
+    render(SquadSponsorWithdrawModal, { props });
+
+    const confirm = await screen.findByRole('button', { name: 'Confirm withdraw' });
+    await fireEvent.click(confirm);
+    // Second click lands while the first submission is still in flight (acting guard).
+    await fireEvent.click(confirm);
+
+    expect(withdrawSquadSponsorMock).toHaveBeenCalledTimes(1);
+
+    resolveWithdraw?.();
+    await waitFor(() => expect(props.onSubmitted).toHaveBeenCalledTimes(1));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resubmit a withdrawal when the still-open modal re-renders', async () => {
+    withdrawSquadSponsorMock.mockResolvedValue(undefined);
+    const props = baseProps();
+
+    const { rerender } = render(SquadSponsorWithdrawModal, { props });
+
+    const confirm = await screen.findByRole('button', { name: 'Confirm withdraw' });
+    await fireEvent.click(confirm);
+    await waitFor(() => expect(withdrawSquadSponsorMock).toHaveBeenCalledTimes(1));
+
+    // Parent re-renders the still-open modal (e.g. an unrelated prop refresh). A resubmission
+    // here would mean submission got wired to an effect instead of the confirm handler.
+    await rerender({ ...props, sponsorAddress: props.sponsorAddress });
+    await rerender({ ...props, sponsorAddress: props.sponsorAddress });
+
+    expect(withdrawSquadSponsorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a failed withdrawal error verbatim, with no RPC URL appended by the component', async () => {
+    const backendMessage = 'insufficient funds for withdrawal';
+    withdrawSquadSponsorMock.mockRejectedValue(new Error(backendMessage));
+
+    render(SquadSponsorWithdrawModal, { props: baseProps() });
+
+    const confirm = await screen.findByRole('button', { name: 'Confirm withdraw' });
+    await fireEvent.click(confirm);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent?.trim()).toBe(backendMessage);
+    expect(alert.textContent).not.toMatch(/https?:\/\//);
+  });
+});

--- a/src/components/parent/governance/TreasuryProposalCard.svelte
+++ b/src/components/parent/governance/TreasuryProposalCard.svelte
@@ -11,21 +11,33 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let proposal: TreasuryProposalDto;
-  export let hasVoted: boolean | undefined = undefined;
-  export let voterAddress = '';
-  export let votePending = false;
-  export let voteDisabledReason = '';
-  export let onVoteYea: (() => void) | undefined = undefined;
-  export let onVoteNay: (() => void) | undefined = undefined;
+  interface Props {
+    proposal: TreasuryProposalDto;
+    hasVoted?: boolean | undefined;
+    voterAddress?: string;
+    votePending?: boolean;
+    voteDisabledReason?: string;
+    onVoteYea?: () => void;
+    onVoteNay?: () => void;
+  }
+
+  let {
+    proposal,
+    hasVoted = undefined,
+    voterAddress = '',
+    votePending = false,
+    voteDisabledReason = '',
+    onVoteYea = undefined,
+    onVoteNay = undefined,
+  }: Props = $props();
 
   const tFn = get(t);
 
-  $: voteState = resolveProposalVoteUiState({ proposal, hasVoted, voterAddress });
-  $: isActive = isTreasuryProposalActive(proposal.status);
-  $: isPast = isTreasuryProposalPast(proposal.status);
-  $: outcome = treasuryProposalOutcomeLabel(proposal.status);
-  $: voteLocked = !!voteDisabledReason;
+  const voteState = $derived(resolveProposalVoteUiState({ proposal, hasVoted, voterAddress }));
+  const isActive = $derived(isTreasuryProposalActive(proposal.status));
+  const isPast = $derived(isTreasuryProposalPast(proposal.status));
+  const outcome = $derived(treasuryProposalOutcomeLabel(proposal.status));
+  const voteLocked = $derived(!!voteDisabledReason);
 
   function voteStateLabel(state: ProposalVoteUiState): string {
     switch (state) {

--- a/src/components/parent/governance/TreasurySafeModulePanel.svelte
+++ b/src/components/parent/governance/TreasurySafeModulePanel.svelte
@@ -31,11 +31,15 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let network: string;
-  export let parentId: string;
-  export let safeAddress: string;
-  export let announcementsGroupId = '';
-  export let privilege: GovernancePrivilege;
+  interface Props {
+    network: string;
+    parentId: string;
+    safeAddress: string;
+    announcementsGroupId?: string;
+    privilege: GovernancePrivilege;
+  }
+
+  let { network, parentId, safeAddress, announcementsGroupId = '', privilege }: Props = $props();
 
   type SafeBalancesSnapshot = {
     nativeDecimal: string;
@@ -47,20 +51,22 @@
 
   const tFn = get(t);
 
-  let rows: SquadTrackedTokenRow[] = [];
-  let nativeDecimal = '';
-  let nativeSymbol = '';
-  let tokenBalances: Record<string, string> = {};
-  let loading = false;
-  let refreshing = false;
-  let loadError = '';
-  let addAddress = '';
-  let addBusy = false;
-  let lastLoadKey = '';
+  let rows = $state<SquadTrackedTokenRow[]>([]);
+  let nativeDecimal = $state('');
+  let nativeSymbol = $state('');
+  let tokenBalances = $state<Record<string, string>>({});
+  let loading = $state(false);
+  let refreshing = $state(false);
+  let loadError = $state('');
+  let addAddress = $state('');
+  let addBusy = $state(false);
+  let lastLoadKey = $state('');
 
-  $: manageGate = gateRequiresCaptainOrCrew(privilege);
-  $: chainKey = (parseSupportedChainId(network) ?? network.trim().toLowerCase()) as SupportedChainId;
-  $: safe = safeAddress.trim();
+  const manageGate = $derived(gateRequiresCaptainOrCrew(privilege));
+  const chainKey = $derived(
+    (parseSupportedChainId(network) ?? network.trim().toLowerCase()) as SupportedChainId,
+  );
+  const safe = $derived(safeAddress.trim());
 
   function applySnapshot(snap: SafeBalancesSnapshot) {
     nativeDecimal = snap.nativeDecimal;
@@ -152,15 +158,15 @@
     }
   }
 
-  $: trackedTokensNonce = $squadTrackedTokensNonceByParentId[parentId.trim()] ?? 0;
+  const trackedTokensNonce = $derived($squadTrackedTokensNonceByParentId[parentId.trim()] ?? 0);
 
-  $: {
+  $effect(() => {
     const key = `${parentId.trim()}|${safeAddress.trim()}|${network.trim()}|${trackedTokensNonce}`;
     if (key !== lastLoadKey && parentId.trim() && safeAddress.trim()) {
       lastLoadKey = key;
       void refreshAll(trackedTokensNonce > 0);
     }
-  }
+  });
 
   async function addToken() {
     if (!manageGate.enabled || addBusy) return;


### PR DESCRIPTION
## Summary

Continues the Svelte 5 runes migration (epic pacto-app-a7r) for the governance treasury/roles/security surface: `SquadSponsorTreasuryPanel`, `SmartContractSecuritySection`, `TreasurySafeModulePanel`, `SquadRolesModal`, `HatsTreeNode`, `HatsTreeDiagram`, `SquadSponsorWithdrawModal`, and `TreasuryProposalCard`. No behavior changes — this is a syntax migration from legacy `export let`/`$:` to `$props()`/`$state()`/`$derived()`/`$effect()`, converted in the fixed order (props -> computed -> side effects -> slots).

The one file with an inherent risk (`SquadSponsorWithdrawModal`, which submits an on-chain withdrawal) keeps submission wired to the confirm button's click handler rather than an effect, so re-renders of the still-open modal cannot trigger a duplicate on-chain withdrawal; the existing `acting` guard also blocks a rapid double-click from firing two submissions. `HatsTreeNode` now recurses via a direct self-import (`import HatsTreeNode from './HatsTreeNode.svelte'`) instead of the legacy `<svelte:self>` directive — the Svelte 5 runes-mode replacement — with no change to how deep the tree walk goes (still bounded by the finite `children` array on each hat DTO).

Side-effect blocks that read-and-write the same sentinel (e.g. "load once per computed cache key changes") became `$effect` guarded on that sentinel, with the write kept inside the guard to avoid the effect looping — the remaining `$effect` conversions here are genuine external syncs (refetching allowlist rows / safe balances / sponsor summary / signer privilege on a changed key), matching the same shape the previous Svelte 4 `$:` blocks already had.

## Changes

- Converted all 8 files' props to `$props()`, computed values to `$derived`/`$derived.by`, and side effects to `$effect` per the KTD3 triage rubric (sentinel-guarded effects keep their write inside the guard; genuine external-sync effects stay bare).
- Replaced `HatsTreeNode`'s `<svelte:self>` recursion with a direct self-import, the supported Svelte 5 runes-mode pattern.
- Added `SquadSponsorWithdrawModal.test.ts` (jsdom): asserts exactly one `withdrawSquadSponsor` call under a rapid double confirm-click, asserts no resubmission when the still-open modal re-renders, and asserts a failed withdrawal renders the backend error message verbatim with no RPC URL appended by the component.

## Test plan

- `pnpm check` — 0 errors.
- `pnpm lint` — 0 problems.
- `pnpm test` — 241 test files / 2188 tests passing, including the 3 new withdrawal-guard tests.
- Code read: confirmed no leftover `export let`, `$:`, `<slot>`, or `svelte/legacy` imports in any of the 8 files; confirmed the hats tree recursion depth is unchanged (bounded by the DTO's `children` array, not by the `svelte:self` -> self-import swap); confirmed the withdrawal error path (`getInvokeErrorMessage` + `parseWalletOpError`) is untouched and doesn't concatenate any RPC endpoint into the displayed message.

## Manual QA follow-up for reviewer

Not exercised in this pass (requires a live testnet signer + funded sponsor pool): submitting a real withdrawal end-to-end on testnet and confirming exactly one on-chain transaction lands, and manually expanding a real (not synthetic) hats tree with real API data to full depth in the running app. The automated jsdom test covers the resubmission-guard contract; the testnet transaction itself is unverified here.

Closes pacto-app-a7r.19

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
