### PR TITLE
refactor(commons): convert commons/ components to svelte 5 runes

### DIFF
--- a/src/components/commons/BroadcastSquadModal.svelte
+++ b/src/components/commons/BroadcastSquadModal.svelte
@@ -21,36 +21,44 @@
   import { currentUser } from '../../stores/auth';
   import CommonsTagPicker from './CommonsTagPicker.svelte';
 
-  export let squad: PublicSquadBroadcastTarget;
-  export let onClose: () => void;
-  export let broadcastAllowed = true;
-  export let broadcastDeniedReason = get(t)('commons.broadcast.deniedReason');
+  interface Props {
+    squad: PublicSquadBroadcastTarget;
+    onClose: () => void;
+    broadcastAllowed?: boolean;
+    broadcastDeniedReason?: string;
+  }
+
+  let {
+    squad,
+    onClose,
+    broadcastAllowed = true,
+    broadcastDeniedReason = get(t)('commons.broadcast.deniedReason'),
+  }: Props = $props();
 
   const tFn = get(t);
 
-  let tags: string[] = [];
-  let message = '';
-  let durationHours: CommonsBroadcastDurationHours = 24;
-  let submitError = '';
-  let publishing = false;
-  let cancelling = false;
-  let loadingActive = true;
-  let activeBroadcast: CommonsBroadcastLocalState | null = null;
-  let cooldownLabel = '';
+  let tags: string[] = $state([]);
+  let message = $state('');
+  let durationHours: CommonsBroadcastDurationHours = $state(24);
+  let submitError = $state('');
+  let publishing = $state(false);
+  let cancelling = $state(false);
+  let loadingActive = $state(true);
+  let activeBroadcast: CommonsBroadcastLocalState | null = $state(null);
+  let cooldownLabel = $state('');
   let cooldownTimer: ReturnType<typeof setInterval> | null = null;
 
-  $: hasActiveBroadcast = !!activeBroadcast;
-  $: roleAllowed =
-    broadcastAllowed &&
-    canBroadcastSquad({ userNpub: $currentUser?.npub, squad });
-  $: canSubmit =
+  const hasActiveBroadcast = $derived(!!activeBroadcast);
+  const roleAllowed = $derived(broadcastAllowed && canBroadcastSquad({ userNpub: $currentUser?.npub, squad }));
+  const canSubmit = $derived(
     roleAllowed &&
     !hasActiveBroadcast &&
     message.trim().length > 0 &&
     tags.length === 3 &&
     !publishing &&
-    !cancelling;
-  $: busy = publishing || cancelling;
+    !cancelling
+  );
+  const busy = $derived(publishing || cancelling);
 
   function updateCooldownLabel() {
     if (!activeBroadcast) {

--- a/src/components/commons/CommonsBroadcastCard.svelte
+++ b/src/components/commons/CommonsBroadcastCard.svelte
@@ -18,13 +18,17 @@
   } from '../../lib/commons/message-preview';
   import CommonsBroadcastDetailModal from './CommonsBroadcastDetailModal.svelte';
 
-  export let broadcast: CommonsBroadcastDto;
+  interface Props {
+    broadcast: CommonsBroadcastDto;
+  }
+
+  let { broadcast }: Props = $props();
 
   const tFn = get(t);
 
-  let detailOpen = false;
-  let messageBusy = false;
-  let actionError = '';
+  let detailOpen = $state(false);
+  let messageBusy = $state(false);
+  let actionError = $state('');
 
   function formatExpiry(expiresAt: number): string {
     const ms = expiresAt * 1000 - Date.now();
@@ -37,29 +41,28 @@
     return tFn('commons.duration.daysLeft', { values: { days: d } });
   }
 
-  $: ({
-    isSquad,
-    isUser,
-    title,
-    subtitle,
-    coverImage,
-    coverSeed,
-    squadLabel,
-    joinBlockReason,
-    joinInFlight,
-    canMessage,
-    canJoin,
-    greetingName,
-  } = (() => {
+  const presentation = $derived.by(() => {
     $commonsJoinRequestRevision;
     return computeBroadcastPresentation(broadcast, $profiles, $squads, $currentUser?.npub, tFn);
-  })());
-  $: localSquadIds = $squads.map((s) => s.id);
-  $: myNpub = $currentUser?.npub;
-  $: messageTruncated = isCommonsMessageTruncated(broadcast.message, COMMONS_MESSAGE_PREVIEW_MAX);
-  $: previewMessage = messageTruncated
-    ? truncateCommonsMessage(broadcast.message, COMMONS_MESSAGE_PREVIEW_MAX)
-    : broadcast.message;
+  });
+  const isSquad = $derived(presentation.isSquad);
+  const isUser = $derived(presentation.isUser);
+  const title = $derived(presentation.title);
+  const subtitle = $derived(presentation.subtitle);
+  const coverImage = $derived(presentation.coverImage);
+  const coverSeed = $derived(presentation.coverSeed);
+  const squadLabel = $derived(presentation.squadLabel);
+  const joinBlockReason = $derived(presentation.joinBlockReason);
+  const joinInFlight = $derived(presentation.joinInFlight);
+  const canMessage = $derived(presentation.canMessage);
+  const canJoin = $derived(presentation.canJoin);
+  const greetingName = $derived(presentation.greetingName);
+  const localSquadIds = $derived($squads.map((s) => s.id));
+  const myNpub = $derived($currentUser?.npub);
+  const messageTruncated = $derived(isCommonsMessageTruncated(broadcast.message, COMMONS_MESSAGE_PREVIEW_MAX));
+  const previewMessage = $derived(
+    messageTruncated ? truncateCommonsMessage(broadcast.message, COMMONS_MESSAGE_PREVIEW_MAX) : broadcast.message
+  );
 
   function openDetail() {
     detailOpen = true;

--- a/src/components/commons/CommonsBroadcastDetailModal.svelte
+++ b/src/components/commons/CommonsBroadcastDetailModal.svelte
@@ -13,13 +13,17 @@
   import { commonsTagGradient } from '../../lib/commons/tag-catalog';
   import SquadAvatar from '../squad/SquadAvatar.svelte';
 
-  export let broadcast: CommonsBroadcastDto;
-  export let onClose: () => void;
+  interface Props {
+    broadcast: CommonsBroadcastDto;
+    onClose: () => void;
+  }
+
+  let { broadcast, onClose }: Props = $props();
 
   const tFn = get(t);
 
-  let messageBusy = false;
-  let actionError = '';
+  let messageBusy = $state(false);
+  let actionError = $state('');
 
   function formatExpiry(expiresAt: number): string {
     const ms = expiresAt * 1000 - Date.now();
@@ -32,24 +36,23 @@
     return tFn('commons.duration.daysLeft', { values: { days: d } });
   }
 
-  $: ({
-    isSquad,
-    title,
-    subtitle,
-    coverImage,
-    coverSeed,
-    squadLabel,
-    joinBlockReason,
-    joinInFlight,
-    canMessage,
-    canJoin,
-    greetingName,
-  } = (() => {
+  const presentation = $derived.by(() => {
     $commonsJoinRequestRevision;
     return computeBroadcastPresentation(broadcast, $profiles, $squads, $currentUser?.npub, tFn);
-  })());
-  $: localSquadIds = $squads.map((s) => s.id);
-  $: myNpub = $currentUser?.npub;
+  });
+  const isSquad = $derived(presentation.isSquad);
+  const title = $derived(presentation.title);
+  const subtitle = $derived(presentation.subtitle);
+  const coverImage = $derived(presentation.coverImage);
+  const coverSeed = $derived(presentation.coverSeed);
+  const squadLabel = $derived(presentation.squadLabel);
+  const joinBlockReason = $derived(presentation.joinBlockReason);
+  const joinInFlight = $derived(presentation.joinInFlight);
+  const canMessage = $derived(presentation.canMessage);
+  const canJoin = $derived(presentation.canJoin);
+  const greetingName = $derived(presentation.greetingName);
+  const localSquadIds = $derived($squads.map((s) => s.id));
+  const myNpub = $derived($currentUser?.npub);
 
   function handleRequestDm() {
     if (!canMessage || messageBusy) return;

--- a/src/components/commons/CommonsCategoryFocus.svelte
+++ b/src/components/commons/CommonsCategoryFocus.svelte
@@ -7,18 +7,29 @@
     localizeCommonsTagCategory,
   } from '../../lib/commons/tag-catalog';
 
-  export let categoryId: string;
-  /** True while filtering ANY tag in the category (ALL chip). */
-  export let categoryAllMode = false;
-  export let activeTags: string[] = [];
-  export let countsByTag: Record<string, number> = {};
-  export let onToggleTag: (tag: string) => void = () => {};
-  export let onClearFocus: () => void = () => {};
+  interface Props {
+    categoryId: string;
+    /** True while filtering ANY tag in the category (ALL chip). */
+    categoryAllMode?: boolean;
+    activeTags?: string[];
+    countsByTag?: Record<string, number>;
+    onToggleTag?: (tag: string) => void;
+    onClearFocus?: () => void;
+  }
 
-  $: category = findCommonsTagCategory(categoryId);
-  $: localizedCategory = category ? localizeCommonsTagCategory($t, category) : null;
-  $: art = localizedCategory ? commonsTagArtSrc(localizedCategory) : null;
-  $: activeSet = new Set(activeTags);
+  let {
+    categoryId,
+    categoryAllMode = false,
+    activeTags = [],
+    countsByTag = {},
+    onToggleTag = () => {},
+    onClearFocus = () => {},
+  }: Props = $props();
+
+  const category = $derived(findCommonsTagCategory(categoryId));
+  const localizedCategory = $derived(category ? localizeCommonsTagCategory($t, category) : null);
+  const art = $derived(localizedCategory ? commonsTagArtSrc(localizedCategory) : null);
+  const activeSet = $derived(new Set(activeTags));
 </script>
 
 {#if localizedCategory}

--- a/src/components/commons/CommonsPersonalPanel.svelte
+++ b/src/components/commons/CommonsPersonalPanel.svelte
@@ -19,22 +19,26 @@
   } from '../../lib/commons/message-preview';
   import { commonsUserHasActiveBroadcast } from '../../stores/commons-ui';
 
-  /** Bump to force a reload after publishing. */
-  export let refreshKey = 0;
-  export let onBroadcast: () => void = () => {};
-  /** Notify parent (feed) after the active broadcast changes. */
-  export let onChanged: () => void = () => {};
+  interface Props {
+    /** Bump to force a reload after publishing. */
+    refreshKey?: number;
+    onBroadcast?: () => void;
+    /** Notify parent (feed) after the active broadcast changes. */
+    onChanged?: () => void;
+  }
 
-  let lastBroadcast: CommonsBroadcastLocalState | null = null;
-  let loading = true;
-  let loadedKey = -1;
-  let cancelling = false;
-  let messageExpanded = false;
+  let { refreshKey = 0, onBroadcast = () => {}, onChanged = () => {} }: Props = $props();
 
-  $: npub = $currentUser?.npub ?? '';
-  $: profile = npub ? $profiles[npub] : null;
-  $: avatarSrc = getProfileAvatarSrc(profile);
-  $: displayName = npub ? getProfileDisplayName(profile) : '';
+  let lastBroadcast: CommonsBroadcastLocalState | null = $state(null);
+  let loading = $state(true);
+  let loadedKey = $state(-1);
+  let cancelling = $state(false);
+  let messageExpanded = $state(false);
+
+  const npub = $derived($currentUser?.npub ?? '');
+  const profile = $derived(npub ? $profiles[npub] : null);
+  const avatarSrc = $derived(getProfileAvatarSrc(profile));
+  const displayName = $derived(npub ? getProfileDisplayName(profile) : '');
 
   const tFn = get(t);
 
@@ -52,10 +56,12 @@
     loading = false;
   }
 
-  $: if (refreshKey !== loadedKey && npub) {
-    loadedKey = refreshKey;
-    void load();
-  }
+  $effect(() => {
+    if (refreshKey !== loadedKey && npub) {
+      loadedKey = refreshKey;
+      void load();
+    }
+  });
 
   function relativeExpiry(expiresAt: number): string {
     const ms = expiresAt * 1000 - Date.now();
@@ -88,12 +94,15 @@
     onChanged();
   }
 
-  $: hasActive = !!lastBroadcast;
-  $: fullMessage = lastBroadcast?.message ?? '';
-  $: messageTruncated = isCommonsMessageTruncated(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX);
-  $: previewMessage = messageTruncated
-    ? truncateCommonsMessage(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX)
-    : fullMessage;
+  const hasActive = $derived(!!lastBroadcast);
+  const fullMessage = $derived.by(() => {
+    const broadcast = lastBroadcast;
+    return broadcast?.message ?? '';
+  });
+  const messageTruncated = $derived(isCommonsMessageTruncated(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX));
+  const previewMessage = $derived(
+    messageTruncated ? truncateCommonsMessage(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX) : fullMessage
+  );
 </script>
 
 <section class="commons-personal" aria-label={$t('commons.personal.ariaLabel')}>

--- a/src/components/commons/CommonsTagBrowser.svelte
+++ b/src/components/commons/CommonsTagBrowser.svelte
@@ -9,13 +9,22 @@
     type CommonsTagCategory,
   } from '../../lib/commons/tag-catalog';
 
-  export let categories: CommonsTagCategory[] = COMMONS_TAG_TREE;
-  export let activeCategoryId: string | null = null;
-  /** Active broadcast count per leaf tag. */
-  export let countsByTag: Record<string, number> = {};
-  export let onSelectCategory: (categoryId: string) => void = () => {};
+  interface Props {
+    categories?: CommonsTagCategory[];
+    activeCategoryId?: string | null;
+    /** Active broadcast count per leaf tag. */
+    countsByTag?: Record<string, number>;
+    onSelectCategory?: (categoryId: string) => void;
+  }
 
-  $: localizedCategories = categories.map((c) => localizeCommonsTagCategory($t, c));
+  let {
+    categories = COMMONS_TAG_TREE,
+    activeCategoryId = null,
+    countsByTag = {},
+    onSelectCategory = () => {},
+  }: Props = $props();
+
+  const localizedCategories = $derived(categories.map((c) => localizeCommonsTagCategory($t, c)));
 </script>
 
 <div class="commons-browser">

--- a/src/components/commons/CommonsTagMenu.svelte
+++ b/src/components/commons/CommonsTagMenu.svelte
@@ -2,21 +2,32 @@
   import { t } from 'svelte-i18n';
   import { COMMONS_TAG_TREE, localizeCommonsTagCategory, type CommonsTagCategory } from '../../lib/commons/tag-catalog';
 
-  export let categories: CommonsTagCategory[] = COMMONS_TAG_TREE;
-  export let activeTags: string[] = [];
-  /** Active broadcast count per leaf tag. */
-  export let countsByTag: Record<string, number> = {};
-  export let onToggleTag: (tag: string) => void = () => {};
-  /** Force every category open (e.g. while a text query is filtering). */
-  export let expandAll = false;
-  /** Denser typography for modal / inline pickers. */
-  export let compact = false;
+  interface Props {
+    categories?: CommonsTagCategory[];
+    activeTags?: string[];
+    /** Active broadcast count per leaf tag. */
+    countsByTag?: Record<string, number>;
+    onToggleTag?: (tag: string) => void;
+    /** Force every category open (e.g. while a text query is filtering). */
+    expandAll?: boolean;
+    /** Denser typography for modal / inline pickers. */
+    compact?: boolean;
+  }
 
-  $: localizedCategories = categories.map((c) => localizeCommonsTagCategory($t, c));
+  let {
+    categories = COMMONS_TAG_TREE,
+    activeTags = [],
+    countsByTag = {},
+    onToggleTag = () => {},
+    expandAll = false,
+    compact = false,
+  }: Props = $props();
 
-  let openIds = new Set<string>();
+  const localizedCategories = $derived(categories.map((c) => localizeCommonsTagCategory($t, c)));
 
-  $: activeSet = new Set(activeTags);
+  let openIds = $state(new Set<string>());
+
+  const activeSet = $derived(new Set(activeTags));
 
   function toggle(id: string) {
     const next = new Set(openIds);

--- a/src/components/commons/CommonsTagPicker.svelte
+++ b/src/components/commons/CommonsTagPicker.svelte
@@ -8,29 +8,40 @@
   } from '../../lib/commons/tag-catalog';
   import { appConfig } from '../../stores/app-config';
 
-  /** Selected leaf tags (bindable). */
-  export let selected: string[] = [];
-  export let maxTags: number | undefined = undefined;
-  export let disabled = false;
-  export let placeholder = $t('commons.tagPicker.searchPlaceholder');
+  interface Props {
+    /** Selected leaf tags (bindable). */
+    selected?: string[];
+    maxTags?: number;
+    disabled?: boolean;
+    placeholder?: string;
+  }
 
-  let query = '';
+  let {
+    selected = $bindable([]),
+    maxTags = undefined,
+    disabled = false,
+    placeholder = $t('commons.tagPicker.searchPlaceholder'),
+  }: Props = $props();
+
+  let query = $state('');
   /** Flat predictive list visible (search mode only). */
-  let listOpen = false;
+  let listOpen = $state(false);
   /** Category tree replaces the search bar. */
-  let categoryBrowse = false;
+  let categoryBrowse = $state(false);
   let container: HTMLDivElement;
   let blurCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
-  $: resolvedMaxTags = maxTags ?? $appConfig.commonsMaxTags;
-  $: atMax = selected.length >= resolvedMaxTags;
-  $: q = query.trim().toLowerCase();
-  $: activeSet = new Set(selected);
+  const resolvedMaxTags = $derived(maxTags ?? $appConfig.commonsMaxTags);
+  const atMax = $derived(selected.length >= resolvedMaxTags);
+  const q = $derived(query.trim().toLowerCase());
+  const activeSet = $derived(new Set(selected));
 
-  $: flatMatches = getLocalizedCommonsTagGroups($t).filter((g) => {
-    if (!q) return true;
-    return g.title.toLowerCase().includes(q) || g.tag.includes(q);
-  });
+  const flatMatches = $derived(
+    getLocalizedCommonsTagGroups($t).filter((g) => {
+      if (!q) return true;
+      return g.title.toLowerCase().includes(q) || g.tag.includes(q);
+    })
+  );
 
   function selectTag(tag: string) {
     const group = findCommonsTagGroup(tag);
@@ -108,7 +119,7 @@
     };
   });
 
-  $: showFlatList = !categoryBrowse && listOpen;
+  const showFlatList = $derived(!categoryBrowse && listOpen);
 </script>
 
 <div class="tag-picker" bind:this={container}>

--- a/src/components/commons/CommonsTopFilters.svelte
+++ b/src/components/commons/CommonsTopFilters.svelte
@@ -7,20 +7,34 @@
   } from '../../lib/commons/commons-feed';
   import { getLocalizedCommonsTagCategory } from '../../lib/commons/tag-catalog';
 
-  export let tags: string[] = [];
-  export let categoryId: string | null = null;
-  export let focusedCategoryId: string | null = null;
-  export let browseMode: CommonsBrowseMode = 'categories';
-  export let subjectFilter: CommonsSubjectFilter = 'both';
-  export let audienceFilter: CommonsAudienceFilter = 'any';
-  /** Whether the focused tag (genre) menu is open; hides the passive tiles. */
-  export let tagMenuOpen = false;
-  export let onRemoveTag: ((tag: string) => void) | undefined = undefined;
-  export let onClearCategory: (() => void) | undefined = undefined;
+  interface Props {
+    tags?: string[];
+    categoryId?: string | null;
+    focusedCategoryId?: string | null;
+    browseMode?: CommonsBrowseMode;
+    subjectFilter?: CommonsSubjectFilter;
+    audienceFilter?: CommonsAudienceFilter;
+    /** Whether the focused tag (genre) menu is open; hides the passive tiles. */
+    tagMenuOpen?: boolean;
+    onRemoveTag?: (tag: string) => void;
+    onClearCategory?: () => void;
+  }
 
-  $: categoryLabel = categoryId
-    ? (getLocalizedCommonsTagCategory($t, categoryId)?.title ?? categoryId)
-    : null;
+  let {
+    tags = $bindable([]),
+    categoryId = $bindable(null),
+    focusedCategoryId = $bindable(null),
+    browseMode = $bindable('categories'),
+    subjectFilter = $bindable('both'),
+    audienceFilter = $bindable('any'),
+    tagMenuOpen = $bindable(false),
+    onRemoveTag = undefined,
+    onClearCategory = undefined,
+  }: Props = $props();
+
+  const categoryLabel = $derived(
+    categoryId ? (getLocalizedCommonsTagCategory($t, categoryId)?.title ?? categoryId) : null
+  );
 
   function removeTag(tag: string) {
     if (onRemoveTag) onRemoveTag(tag);
@@ -70,14 +84,13 @@
   }
 
   /** Tag-library search (not category drill-down). */
-  $: isTagLibrarySearch = tags.length > 0 && categoryId == null && focusedCategoryId == null;
+  const isTagLibrarySearch = $derived(tags.length > 0 && categoryId == null && focusedCategoryId == null);
 
-  $: isLatestActive = browseMode === 'latest' && !tagMenuOpen;
-  $: isCategoriesActive =
-    browseMode === 'categories' && !tagMenuOpen && !isTagLibrarySearch;
-  $: isTagsActive = tagMenuOpen && tags.length === 0;
-  $: isSearchActive = (tagMenuOpen && tags.length > 0) || isTagLibrarySearch;
-  $: showSearchButton = tagMenuOpen || isTagLibrarySearch;
+  const isLatestActive = $derived(browseMode === 'latest' && !tagMenuOpen);
+  const isCategoriesActive = $derived(browseMode === 'categories' && !tagMenuOpen && !isTagLibrarySearch);
+  const isTagsActive = $derived(tagMenuOpen && tags.length === 0);
+  const isSearchActive = $derived((tagMenuOpen && tags.length > 0) || isTagLibrarySearch);
+  const showSearchButton = $derived(tagMenuOpen || isTagLibrarySearch);
 </script>
 
 <div class="commons-filters" role="search">

--- a/src/components/commons/CommonsView.svelte
+++ b/src/components/commons/CommonsView.svelte
@@ -34,52 +34,51 @@
   import { profiles, loadProfile } from '../../stores/profiles';
   import { get } from 'svelte/store';
 
-  let filterTags: string[] = [...DEFAULT_COMMONS_FEED_FILTERS.tags];
-  let filterCategoryId: string | null = DEFAULT_COMMONS_FEED_FILTERS.categoryId;
-  let focusedCategoryId: string | null = null;
-  let browseMode: CommonsBrowseMode = 'categories';
-  let subjectFilter: CommonsSubjectFilter = DEFAULT_COMMONS_FEED_FILTERS.subjectFilter;
-  let audienceFilter: CommonsAudienceFilter = DEFAULT_COMMONS_FEED_FILTERS.audienceFilter;
+  let filterTags: string[] = $state([...DEFAULT_COMMONS_FEED_FILTERS.tags]);
+  let filterCategoryId: string | null = $state(DEFAULT_COMMONS_FEED_FILTERS.categoryId);
+  let focusedCategoryId: string | null = $state(null);
+  let browseMode: CommonsBrowseMode = $state('categories');
+  let subjectFilter: CommonsSubjectFilter = $state(DEFAULT_COMMONS_FEED_FILTERS.subjectFilter);
+  let audienceFilter: CommonsAudienceFilter = $state(DEFAULT_COMMONS_FEED_FILTERS.audienceFilter);
 
-  let personalNonce = 0;
+  let personalNonce = $state(0);
   let lastModalClosedNonce = 0;
-  let tagMenuOpen = false;
+  let tagMenuOpen = $state(false);
 
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let wasCommonsActive = false;
 
-  $: feedFilters = { tags: filterTags, categoryId: filterCategoryId, subjectFilter, audienceFilter };
-  $: filteredBroadcasts = prepareCommonsFeed($commonsBroadcasts, feedFilters);
-  $: latestBroadcasts = prepareCommonsFeed($commonsBroadcasts, {
-    tags: [],
-    categoryId: null,
-    subjectFilter,
-    audienceFilter,
-  });
-  $: hasTagFilters =
+  const feedFilters = $derived({ tags: filterTags, categoryId: filterCategoryId, subjectFilter, audienceFilter });
+  const filteredBroadcasts = $derived(prepareCommonsFeed($commonsBroadcasts, feedFilters));
+  const latestBroadcasts = $derived(
+    prepareCommonsFeed($commonsBroadcasts, {
+      tags: [],
+      categoryId: null,
+      subjectFilter,
+      audienceFilter,
+    })
+  );
+  const hasTagFilters = $derived(
     filterTags.length > 0 ||
     filterCategoryId != null ||
-    focusedCategoryId != null;
-  $: hasFilters =
+    focusedCategoryId != null
+  );
+  const hasFilters = $derived(
     hasTagFilters ||
     subjectFilter !== 'both' ||
-    audienceFilter !== 'any';
-  $: showTileGrid =
-    browseMode === 'categories' && !tagMenuOpen && focusedCategoryId == null && !hasTagFilters;
-  $: categoryAllMode = focusedCategoryId != null && filterCategoryId != null && filterTags.length === 0;
-  $: focusedCategoryTitle = focusedCategoryId
-    ? (getLocalizedCommonsTagCategory($t, focusedCategoryId)?.title ??
-      focusedCategoryId.toUpperCase())
-    : null;
-
-  $: if ($commonsBroadcastModalClosedNonce !== lastModalClosedNonce) {
-    lastModalClosedNonce = $commonsBroadcastModalClosedNonce;
-    personalNonce += 1;
-    void loadFeed({ silent: true });
-  }
+    audienceFilter !== 'any'
+  );
+  const showTileGrid = $derived(
+    browseMode === 'categories' && !tagMenuOpen && focusedCategoryId == null && !hasTagFilters
+  );
+  const categoryAllMode = $derived(focusedCategoryId != null && filterCategoryId != null && filterTags.length === 0);
+  const focusedCategoryTitle = $derived.by(() => {
+    const catId = focusedCategoryId;
+    return catId ? (getLocalizedCommonsTagCategory($t, catId)?.title ?? catId.toUpperCase()) : null;
+  });
 
   // Active broadcast counts per catalog tag for the grid "live" badges.
-  $: countsByTag = (() => {
+  const countsByTag = $derived.by(() => {
     const counts: Record<string, number> = {};
     const active = dedupeCommonsBroadcasts($commonsBroadcasts).filter((b) => isCommonsBroadcastActive(b));
     const known = new Set(COMMONS_TAG_GROUPS.map((g) => g.tag));
@@ -89,7 +88,7 @@
       }
     }
     return counts;
-  })();
+  });
 
   async function loadFeed(options: { silent?: boolean } = {}) {
     const rows = await refreshCommonsBroadcasts(options);
@@ -181,7 +180,15 @@
     }, COMMONS_FEED_REFRESH_MS);
   }
 
-  $: {
+  $effect(() => {
+    if ($commonsBroadcastModalClosedNonce !== lastModalClosedNonce) {
+      lastModalClosedNonce = $commonsBroadcastModalClosedNonce;
+      personalNonce += 1;
+      void loadFeed({ silent: true });
+    }
+  });
+
+  $effect(() => {
     const commonsActive = $activeTopNavTab === 'commons';
     if (commonsActive && !wasCommonsActive) {
       void loadFeed({ silent: get(commonsBroadcasts).length > 0 });
@@ -190,7 +197,7 @@
       stopPolling();
     }
     wasCommonsActive = commonsActive;
-  }
+  });
 
   onDestroy(() => {
     stopPolling();

--- a/src/components/commons/PersonalBroadcastModal.svelte
+++ b/src/components/commons/PersonalBroadcastModal.svelte
@@ -6,11 +6,15 @@
 
   import { closeCommonsBroadcastModal } from '../../stores/commons-ui';
 
-  export let onClose: () => void = closeCommonsBroadcastModal;
+  interface Props {
+    onClose?: () => void;
+  }
 
-  let publishing = false;
+  let { onClose = closeCommonsBroadcastModal }: Props = $props();
 
-  $: userNpub = $currentUser?.npub ?? '';
+  let publishing = $state(false);
+
+  const userNpub = $derived($currentUser?.npub ?? '');
 </script>
 
 <Modal

--- a/src/components/commons/UserCommonsBroadcastPanel.svelte
+++ b/src/components/commons/UserCommonsBroadcastPanel.svelte
@@ -17,28 +17,33 @@
   import type { CommonsBroadcastLocalState } from '../../lib/commons/types';
   import { commonsUserHasActiveBroadcast } from '../../stores/commons-ui';
 
-  export let userNpub: string;
-  /** Called after a successful publish (e.g. close modal). */
-  export let onPublished: () => void = () => {};
+  interface Props {
+    userNpub: string;
+    /** Called after a successful publish (e.g. close modal). */
+    onPublished?: () => void;
+    publishing?: boolean;
+  }
 
-  let tags: string[] = [];
-  let message = '';
-  let durationHours: CommonsBroadcastDurationHours = 24;
-  let submitError = '';
-  export let publishing = false;
-  let loadingActive = true;
-  let activeBroadcast: CommonsBroadcastLocalState | null = null;
-  let cooldownLabel = '';
+  let { userNpub, onPublished = () => {}, publishing = $bindable(false) }: Props = $props();
+
+  let tags: string[] = $state([]);
+  let message = $state('');
+  let durationHours: CommonsBroadcastDurationHours = $state(24);
+  let submitError = $state('');
+  let loadingActive = $state(true);
+  let activeBroadcast: CommonsBroadcastLocalState | null = $state(null);
+  let cooldownLabel = $state('');
   let cooldownTimer: ReturnType<typeof setInterval> | null = null;
 
   const tFn = get(t);
 
-  $: onCooldown = !!activeBroadcast;
-  $: canSubmit =
+  const onCooldown = $derived(!!activeBroadcast);
+  const canSubmit = $derived(
     !onCooldown &&
     message.trim().length > 0 &&
     tags.length >= 1 &&
-    !publishing;
+    !publishing
+  );
 
   function updateCooldownLabel() {
     if (!activeBroadcast) {


### PR DESCRIPTION
## Summary

Converts all 12 components under `src/components/commons/` (the Commons feed, filters, tag pickers, and squad/personal broadcast modals) from Svelte 4 legacy syntax (`export let`, `$:`, `on:`) to Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`). Part of the repo-wide runes migration (epic `pacto-app-a7r`).

No behavior change is intended — this is a syntax-level conversion that preserves every existing reactive relationship, including the two places where getting the reactivity *shape* right actually matters for correctness:

- **Filtering never triggers a network reload.** All feed-filter state in `CommonsView` (`filterTags`, `filterCategoryId`, `subjectFilter`, `audienceFilter`, `browseMode`, `tagMenuOpen`, `focusedCategoryId`) is `$state`, and every value derived from it (`feedFilters`, `filteredBroadcasts`, `latestBroadcasts`, `hasFilters`, `showTileGrid`, `countsByTag`, `focusedCategoryTitle`) is a pure `$derived`/`$derived.by` — so toggling a tag, category, or filter recomputes the visible list locally with zero calls to `refreshCommonsBroadcasts`. Only the two genuine side effects (closing the broadcast-publish modal, and the active-tab poll timer) call `loadFeed`, and both are guarded `$effect`s keyed on a sentinel value (mirroring their original `$: if (...)` shape) so they run once per real transition, not once per render.
- **Card and modal show identical broadcast presentation.** `CommonsBroadcastCard` and `CommonsBroadcastDetailModal` both consume the shared `computeBroadcastPresentation` helper (extracted in the prior `U1b` PR) via an identical `$derived.by`, so title/subtitle/cover stay byte-for-byte the same between the feed tile and its detail modal.

## Changes

- `CommonsBroadcastCard.svelte`, `CommonsBroadcastDetailModal.svelte` — props to `$props()`, presentation fields to `$derived` off the shared `computeBroadcastPresentation` call.
- `CommonsView.svelte` — 6 filter fields + `tagMenuOpen` + `personalNonce` to `$state` (bind targets for `CommonsTopFilters`/`CommonsPersonalPanel`); 9 pure computations to `$derived`/`$derived.by`; the modal-closed-nonce reload and active-tab poll-start/stop to sentinel-guarded `$effect`s.
- `CommonsTopFilters.svelte` — 7 bindable props (`$bindable`) so `CommonsView`'s existing `bind:tags`, `bind:categoryId`, etc. keep working; remaining derived UI-state flags to `$derived`.
- `CommonsTagPicker.svelte`, `UserCommonsBroadcastPanel.svelte` — `selected`/`publishing` promoted to `$bindable` for their existing two-way bindings.
- `CommonsTagBrowser.svelte`, `CommonsTagMenu.svelte`, `CommonsCategoryFocus.svelte`, `BroadcastSquadModal.svelte`, `CommonsPersonalPanel.svelte`, `PersonalBroadcastModal.svelte` — straightforward props/state/derived conversions, no bindable or effect changes beyond `CommonsPersonalPanel`'s single sentinel-guarded reload effect.

No file in this batch imports `svelte/legacy`; no `export let`, `$:`, or `<slot>` remains.

## Test plan

- `pnpm check` — 0 errors (2933 files).
- `pnpm lint` — 0 problems.
- `pnpm test` — 240 test files / 2185 tests passing, including `src/lib/commons/broadcast-presentation.test.ts` from U1b.
- Manually traced (not runtime-exercised): filtering by tag/category/subject/audience only touches `$derived` chains (no `loadFeed`/`refreshCommonsBroadcasts` call in the trace); `selectFocusedTag`/`toggleFocusedCategoryTag`/`sendCommonsJoinRequest` call sites confirmed to not call `loadFeed`.

## Manual QA follow-up (could not exercise live)

This batch was verified via `pnpm check`/`lint`/`test` and static trace of the reactive graph, not a live app session. A human reviewer should click through the Commons tab once to confirm: filtering the feed by tag/category/subject/audience feels instant with no flash-of-loading; opening a broadcast card's detail modal shows the same title/subtitle/cover as the card; picking tags in the category-focus and tag-menu views doesn't refetch; and joining a squad / requesting a DM from a card shows its toast without the feed list flickering/reloading.

Closes pacto-app-a7r.14

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
