### PR TITLE
feat(pacto-app-a7r.11): convert settings/ to svelte 5 runes

### DIFF
--- a/src/components/settings/AppSettingsSection.svelte
+++ b/src/components/settings/AppSettingsSection.svelte
@@ -17,8 +17,8 @@
 
   const tFn = get(t);
 
-  $: isDev = $updateStatus.status === 'dev-disabled';
-  $: isChecking = $updateStatus.status === 'checking';
+  let isDev = $derived($updateStatus.status === 'dev-disabled');
+  let isChecking = $derived($updateStatus.status === 'checking');
 
   function versionLabel(): string {
     const version = $updateStatus.currentVersion || buildVersion;
@@ -63,9 +63,9 @@
     { minutes: 0, key: 'settings.timeoutNever' },
   ];
 
-  let selectedTimeout = 15;
-  let savingTimeout = false;
-  let savedTimeoutMessage: string | null = null;
+  let selectedTimeout = $state(15);
+  let savingTimeout = $state(false);
+  let savedTimeoutMessage: string | null = $state(null);
 
   onMount(async () => {
     try {

--- a/src/components/settings/DangerZoneSection.svelte
+++ b/src/components/settings/DangerZoneSection.svelte
@@ -6,8 +6,8 @@
   import { t } from 'svelte-i18n';
   import SettingsCollapsibleSection from './SettingsCollapsibleSection.svelte';
 
-  let isLoggingOut = false;
-  let showLogoutConfirm = false;
+  let isLoggingOut = $state(false);
+  let showLogoutConfirm = $state(false);
 
   function openLogoutConfirm() {
     showLogoutConfirm = true;

--- a/src/components/settings/DefaultWalletConfig.svelte
+++ b/src/components/settings/DefaultWalletConfig.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
@@ -23,34 +22,42 @@
   import { showToast } from '../../stores/toast';
   import EditIconButton from '../ui/EditIconButton.svelte';
 
-  export let accountNpub: string;
-  export let squadAccounts: EvmAccountRow[] = [];
-  export let accountsLoading = false;
-  export let onSaved: () => void | Promise<void> = () => {};
+  interface Props {
+    accountNpub: string;
+    squadAccounts?: EvmAccountRow[];
+    accountsLoading?: boolean;
+    onSaved?: () => void | Promise<void>;
+  }
 
-  let preferredNetwork: PreferredNetworkId = 'arbitrum';
-  let editOpen = false;
-  let saving = false;
+  let { accountNpub, squadAccounts = [], accountsLoading = false, onSaved = () => {} }: Props = $props();
 
-  let editNetwork: PreferredNetworkId = 'arbitrum';
-  let editSignerId = '';
-  let editReceiverId = '';
+  let preferredNetwork: PreferredNetworkId = $state('arbitrum');
+  let editOpen = $state(false);
+  let saving = $state(false);
+
+  let editNetwork: PreferredNetworkId = $state('arbitrum');
+  let editSignerId = $state('');
+  let editReceiverId = $state('');
 
   const networkOptions = listPreferredNetworkOptions();
 
-  $: activeSigner = squadAccounts.find((a) => a.isActive) ?? null;
-  $: activeReceiver = squadAccounts.find((a) => a.isDefaultShared) ?? null;
-  $: signerAddress = activeSigner?.address?.trim() || null;
-  $: receiverAddress = activeReceiver?.address?.trim() || signerAddress || null;
-  $: preferredNetworkLabel = getPreferredNetworkDisplayName(preferredNetwork);
+  let activeSigner = $derived(squadAccounts.find((a) => a.isActive) ?? null);
+  let activeReceiver = $derived(squadAccounts.find((a) => a.isDefaultShared) ?? null);
+  let signerAddress = $derived(activeSigner?.address?.trim() || null);
+  let receiverAddress = $derived(activeReceiver?.address?.trim() || signerAddress || null);
+  let preferredNetworkLabel = $derived(getPreferredNetworkDisplayName(preferredNetwork));
 
-  $: accountNpub, $walletPreferredNetworkTick, syncPreferredNetwork();
+  $effect(() => {
+    void accountNpub;
+    void $walletPreferredNetworkTick;
+    syncPreferredNetwork();
+  });
 
-  $: if (($settingsSectionCollapsed['settings-evm'] ?? true) && editOpen && !saving) {
-    editOpen = false;
-  }
-
-  onMount(syncPreferredNetwork);
+  $effect(() => {
+    if (($settingsSectionCollapsed['settings-evm'] ?? true) && editOpen && !saving) {
+      editOpen = false;
+    }
+  });
 
   function syncPreferredNetwork() {
     if (!accountNpub) return;

--- a/src/components/settings/EvmAccountKeyExportModal.svelte
+++ b/src/components/settings/EvmAccountKeyExportModal.svelte
@@ -10,33 +10,39 @@
   import { showToast } from '../../stores/toast';
   import { appConfig } from '../../stores/app-config';
 
-  export let open = false;
-  /** `evm` | `nostr` | `seed` (BIP-39 recovery phrase). */
-  export let variant: 'evm' | 'nostr' | 'seed' = 'evm';
-  export let account: EvmAccountRow | null = null;
-  /** Shown in PIN step when `variant` is `nostr`. */
-  export let npub = '';
-  export let onClose: () => void = () => {};
+  interface Props {
+    open?: boolean;
+    /** `evm` | `nostr` | `seed` (BIP-39 recovery phrase). */
+    variant?: 'evm' | 'nostr' | 'seed';
+    account?: EvmAccountRow | null;
+    /** Shown in PIN step when `variant` is `nostr`. */
+    npub?: string;
+    onClose?: () => void;
+  }
+
+  let { open = false, variant = 'evm', account = null, npub = '', onClose = () => {} }: Props = $props();
 
   const tFn = get(t);
 
   type Phase = 'pin' | 'key';
 
-  let phase: Phase = 'pin';
-  let pinDigits = Array(6).fill('');
-  let pinError = '';
-  let busy = false;
-  let privateKey = '';
-  let revealed = false;
-  let copied = false;
-  let pinInputs: HTMLInputElement[] = [];
+  let phase: Phase = $state('pin');
+  let pinDigits: string[] = $state(Array(6).fill(''));
+  let pinError = $state('');
+  let busy = $state(false);
+  let privateKey = $state('');
+  let revealed = $state(false);
+  let copied = $state(false);
+  let pinInputs: HTMLInputElement[] = $state([]);
 
   let wasOpen = false;
 
-  $: pinDigitCount = $appConfig.pinDigitCount;
-  $: if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
+  let pinDigitCount = $derived($appConfig.pinDigitCount);
+  $effect(() => {
+    if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
+  });
 
-  $: {
+  $effect(() => {
     if (open && !wasOpen && phase === 'pin') {
       setTimeout(() => pinInputs[0]?.focus(), 100);
     }
@@ -44,7 +50,7 @@
       resetState();
     }
     wasOpen = open;
-  }
+  });
 
   function resetState() {
     phase = 'pin';

--- a/src/components/settings/EvmAccountKeyExportModal.test.ts
+++ b/src/components/settings/EvmAccountKeyExportModal.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('../../lib/api/encryption', () => ({
+  loadAndDecryptKey: vi.fn(async () => 'decrypted-nsec-placeholder'),
+}));
+
+vi.mock('../../lib/api/auth', () => ({
+  exportEvmAccountKeyPlaintext: vi.fn(async () => '0xsecretprivatekey'),
+  exportRecoveryPhrase: vi.fn(async () => 'seed words go here'),
+}));
+
+import EvmAccountKeyExportModal from './EvmAccountKeyExportModal.svelte';
+import { loadAndDecryptKey } from '../../lib/api/encryption';
+import type { EvmAccountRow } from '../../lib/wallet/evm-accounts';
+
+const account: EvmAccountRow = {
+  id: 'acc-1',
+  scheme: 'secp256k1',
+  hdIndex: 0,
+  address: '0xabc0000000000000000000000000000000abc',
+  label: 'Squad wallet',
+  purpose: 'squad',
+  isActive: true,
+  isDefaultShared: false,
+  isActiveAdvanced: false,
+};
+
+async function submitPin() {
+  const boxes = screen.getAllByLabelText(/PIN digit/i);
+  for (let i = 0; i < boxes.length; i++) {
+    await fireEvent.input(boxes[i], { target: { value: String((i % 9) + 1) } });
+  }
+}
+
+describe('EvmAccountKeyExportModal reveal guard', () => {
+  beforeEach(() => {
+    vi.mocked(loadAndDecryptKey).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('never renders the private key before the PIN step is confirmed', () => {
+    render(EvmAccountKeyExportModal, { props: { open: true, variant: 'evm', account } });
+
+    expect(screen.getByRole('heading', { name: 'Enter your PIN' })).toBeTruthy();
+    expect(screen.queryByText('0xsecretprivatekey')).toBeNull();
+  });
+
+  it('reveals the secret only after PIN confirm, and it is masked until the reveal toggle is clicked', async () => {
+    render(EvmAccountKeyExportModal, { props: { open: true, variant: 'evm', account } });
+
+    await submitPin();
+
+    const revealButton = await screen.findByRole('button', { name: 'Reveal private key' });
+    expect(screen.queryByText('0xsecretprivatekey')).toBeNull();
+
+    await fireEvent.click(revealButton);
+
+    expect(await screen.findByText('0xsecretprivatekey')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Hide private key' })).toBeTruthy();
+  });
+
+  it('re-masks the secret when the modal is closed and reopened, without re-revealing it', async () => {
+    const { rerender } = render(EvmAccountKeyExportModal, {
+      props: { open: true, variant: 'evm', account },
+    });
+
+    await submitPin();
+    const revealButton = await screen.findByRole('button', { name: 'Reveal private key' });
+    await fireEvent.click(revealButton);
+    expect(await screen.findByText('0xsecretprivatekey')).toBeTruthy();
+
+    await rerender({ open: false, variant: 'evm', account });
+    await rerender({ open: true, variant: 'evm', account });
+
+    expect(await screen.findByRole('heading', { name: 'Enter your PIN' })).toBeTruthy();
+    expect(screen.queryByText('0xsecretprivatekey')).toBeNull();
+  });
+
+  it('never calls the key decryption API before the PIN is submitted', () => {
+    render(EvmAccountKeyExportModal, { props: { open: true, variant: 'evm', account } });
+    expect(loadAndDecryptKey).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/EvmAccountsSection.svelte
+++ b/src/components/settings/EvmAccountsSection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
@@ -24,36 +23,54 @@
   import { settingsSectionCollapsed } from '../../lib/settings/settings-section-collapse';
   import EditIconButton from '../ui/EditIconButton.svelte';
 
-  export let accountNpub: string | null = null;
-  export let evmAddress: string | null = null;
-  export let embeddedInSettings = false;
-  export let evmAccountList: EvmAccountRow[] = [];
-  export let accountsLoading = false;
-  export let onSetActiveAccount: (id: string) => void = () => {};
-  export let onSetActiveAdvancedAccount: (id: string) => void = () => {};
-  export let onEditAccount: (acc: EvmAccountRow) => void = () => {};
-  export let onAddSquad: () => void = () => {};
-  export let onAddAdvanced: () => void = () => {};
-  export let onImportKey: () => void = () => {};
-
-  let bindings: EvmAccountSquadBinding[] = [];
-  let bindingsLoading = false;
-  let exportAccount: EvmAccountRow | null = null;
-  let exportModalOpen = false;
-
-  $: squadList = squadEvmAccounts(evmAccountList);
-  $: advancedList = advancedEvmAccounts(evmAccountList);
-  $: bindingMap = bindingsByAccountId(bindings);
-  $: displayRows = embeddedInSettings ? squadList : [...squadList, ...advancedList];
-
-  $: accountNpub, evmAccountList, void loadBindings();
-
-  $: if (embeddedInSettings && ($settingsSectionCollapsed['settings-evm'] ?? true) && exportModalOpen) {
-    closeExportModal();
+  interface Props {
+    accountNpub?: string | null;
+    evmAddress?: string | null;
+    embeddedInSettings?: boolean;
+    evmAccountList?: EvmAccountRow[];
+    accountsLoading?: boolean;
+    onSetActiveAccount?: (id: string) => void;
+    onSetActiveAdvancedAccount?: (id: string) => void;
+    onEditAccount?: (acc: EvmAccountRow) => void;
+    onAddSquad?: () => void;
+    onAddAdvanced?: () => void;
+    onImportKey?: () => void;
   }
 
-  onMount(() => {
+  let {
+    accountNpub = null,
+    evmAddress = null,
+    embeddedInSettings = false,
+    evmAccountList = [],
+    accountsLoading = false,
+    onSetActiveAccount = () => {},
+    onSetActiveAdvancedAccount = () => {},
+    onEditAccount = () => {},
+    onAddSquad = () => {},
+    onAddAdvanced = () => {},
+    onImportKey = () => {},
+  }: Props = $props();
+
+  let bindings: EvmAccountSquadBinding[] = $state([]);
+  let bindingsLoading = $state(false);
+  let exportAccount: EvmAccountRow | null = $state(null);
+  let exportModalOpen = $state(false);
+
+  let squadList = $derived(squadEvmAccounts(evmAccountList));
+  let advancedList = $derived(advancedEvmAccounts(evmAccountList));
+  let bindingMap = $derived(bindingsByAccountId(bindings));
+  let displayRows = $derived(embeddedInSettings ? squadList : [...squadList, ...advancedList]);
+
+  $effect(() => {
+    void accountNpub;
+    void evmAccountList;
     void loadBindings();
+  });
+
+  $effect(() => {
+    if (embeddedInSettings && ($settingsSectionCollapsed['settings-evm'] ?? true) && exportModalOpen) {
+      closeExportModal();
+    }
   });
 
   async function loadBindings() {

--- a/src/components/settings/EvmWalletExtras.svelte
+++ b/src/components/settings/EvmWalletExtras.svelte
@@ -29,29 +29,41 @@
     return $t(source === 'custom' ? 'settings.tokenSourceCustom' : 'settings.tokenSourceCatalog');
   }
 
-  export let accountNpub: string | null = null;
-  export let enabledSet: Set<SupportedChainId>;
-  export let watchedRows: WatchedErc20Row[] = [];
-  /** `all` or one enabled chain; defaults to preferred network per account. */
-  export let tokenNetworkFilter: 'all' | SupportedChainId = DEFAULT_PREFERRED_NETWORK;
-  export let onToggleChain: (chain: SupportedChainId) => void = () => {};
-  export let onRemoveWatchedRow: (row: WatchedErc20Row) => void = () => {};
-  export let onImportTokens: () => void = () => {};
+  interface Props {
+    accountNpub: string | null;
+    enabledSet: Set<SupportedChainId>;
+    watchedRows: WatchedErc20Row[];
+    /** `all` or one enabled chain; defaults to preferred network per account. */
+    tokenNetworkFilter: 'all' | SupportedChainId;
+    onToggleChain?: (chain: SupportedChainId) => void;
+    onRemoveWatchedRow?: (row: WatchedErc20Row) => void;
+    onImportTokens?: () => void;
+  }
 
-  let tokenFilterInitializedFor: string | null = null;
-  let lastPreferred: PreferredNetworkId = DEFAULT_PREFERRED_NETWORK;
-  let preferredNetwork: PreferredNetworkId = DEFAULT_PREFERRED_NETWORK;
-  let rpcNetworkFilter: SupportedChainId = DEFAULT_PREFERRED_NETWORK;
-  let rpcFilterInitializedFor: string | null = null;
-  let personalRpcs: string[] = [];
-  let defaultRpcOptions: ReturnType<typeof listDefaultRpcOptions> = [];
-  let selectedDefaultRpc = '';
-  let newRpcUrl = '';
-  let addRpcError: string | null = null;
+  let {
+    accountNpub = null,
+    enabledSet,
+    watchedRows = [],
+    tokenNetworkFilter = $bindable(DEFAULT_PREFERRED_NETWORK),
+    onToggleChain = () => {},
+    onRemoveWatchedRow = () => {},
+    onImportTokens = () => {},
+  }: Props = $props();
 
-  $: enabledChainIdsOrdered = WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledSet.has(id));
+  let tokenFilterInitializedFor: string | null = $state(null);
+  let lastPreferred: PreferredNetworkId = $state(DEFAULT_PREFERRED_NETWORK);
+  let preferredNetwork: PreferredNetworkId = $state(DEFAULT_PREFERRED_NETWORK);
+  let rpcNetworkFilter: SupportedChainId = $state(DEFAULT_PREFERRED_NETWORK);
+  let rpcFilterInitializedFor: string | null = $state(null);
+  let personalRpcs: string[] = $state([]);
+  let defaultRpcOptions: ReturnType<typeof listDefaultRpcOptions> = $state([]);
+  let selectedDefaultRpc = $state('');
+  let newRpcUrl = $state('');
+  let addRpcError: string | null = $state(null);
 
-  $: {
+  let enabledChainIdsOrdered = $derived(WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledSet.has(id)));
+
+  $effect(() => {
     void $walletPreferredNetworkTick;
     void $walletRpcPrefsTick;
     preferredNetwork = accountNpub ? loadPreferredNetwork(accountNpub) : DEFAULT_PREFERRED_NETWORK;
@@ -73,38 +85,45 @@
     } else if (preferredNetwork !== lastPreferred && rpcNetworkFilter === lastPreferred) {
       rpcNetworkFilter = preferredNetwork;
     }
-  }
+  });
 
   // Prefer the user's preferred network, but never show a disabled chain in the
   // filter: fall back to the first enabled chain when the preferred one is off.
-  $: rpcFilterFallback = enabledSet.has(preferredNetwork)
-    ? preferredNetwork
-    : enabledChainIdsOrdered[0] ?? preferredNetwork;
-  $: if (!enabledSet.has(rpcNetworkFilter)) {
-    rpcNetworkFilter = rpcFilterFallback;
-  }
-  $: if (tokenNetworkFilter !== 'all' && !enabledSet.has(tokenNetworkFilter)) {
-    tokenNetworkFilter = 'all';
-  }
+  let rpcFilterFallback = $derived(
+    enabledSet.has(preferredNetwork) ? preferredNetwork : enabledChainIdsOrdered[0] ?? preferredNetwork
+  );
+  $effect(() => {
+    if (!enabledSet.has(rpcNetworkFilter)) {
+      rpcNetworkFilter = rpcFilterFallback;
+    }
+  });
+  $effect(() => {
+    if (tokenNetworkFilter !== 'all' && !enabledSet.has(tokenNetworkFilter)) {
+      tokenNetworkFilter = 'all';
+    }
+  });
 
-  $: filteredWatchedRows =
+  let filteredWatchedRows = $derived(
     tokenNetworkFilter === 'all'
       ? watchedRows
-      : watchedRows.filter((row) => row.network === tokenNetworkFilter);
+      : watchedRows.filter((row) => row.network === tokenNetworkFilter)
+  );
 
   const ALCHEMY_SIGNUP_URL = 'https://www.alchemy.com/';
   const POCKET_SIGNUP_URL = 'https://pocket.network/';
 
-  $: if (accountNpub) {
-    void $walletRpcPrefsTick;
-    personalRpcs = listPersonalRpcs(accountNpub, rpcNetworkFilter);
-    defaultRpcOptions = listDefaultRpcOptions(accountNpub, rpcNetworkFilter);
-    selectedDefaultRpc = loadDefaultRpc(accountNpub, rpcNetworkFilter) ?? '';
-  } else {
-    personalRpcs = [];
-    defaultRpcOptions = [];
-    selectedDefaultRpc = '';
-  }
+  $effect(() => {
+    if (accountNpub) {
+      void $walletRpcPrefsTick;
+      personalRpcs = listPersonalRpcs(accountNpub, rpcNetworkFilter);
+      defaultRpcOptions = listDefaultRpcOptions(accountNpub, rpcNetworkFilter);
+      selectedDefaultRpc = loadDefaultRpc(accountNpub, rpcNetworkFilter) ?? '';
+    } else {
+      personalRpcs = [];
+      defaultRpcOptions = [];
+      selectedDefaultRpc = '';
+    }
+  });
 
   function openAlchemySignup() {
     openExternalUrl(ALCHEMY_SIGNUP_URL);

--- a/src/components/settings/ExportAllSecretsModal.svelte
+++ b/src/components/settings/ExportAllSecretsModal.svelte
@@ -10,9 +10,13 @@
   import { showToast } from '../../stores/toast';
   import { appConfig } from '../../stores/app-config';
 
-  export let open = false;
-  export let npub = '';
-  export let onClose: () => void = () => {};
+  interface Props {
+    open?: boolean;
+    npub?: string;
+    onClose?: () => void;
+  }
+
+  let { open = false, npub = '', onClose = () => {} }: Props = $props();
 
   const tFn = get(t);
 
@@ -31,20 +35,22 @@
     evmKeys: EvmSecretRow[];
   }
 
-  let phase: Phase = 'pin';
-  let pinDigits = Array(6).fill('');
-  let pinError = '';
-  let busy = false;
-  let bundle: ExportBundle | null = null;
-  let revealed = new Set<string>();
-  let pinInputs: HTMLInputElement[] = [];
+  let phase: Phase = $state('pin');
+  let pinDigits: string[] = $state(Array(6).fill(''));
+  let pinError = $state('');
+  let busy = $state(false);
+  let bundle: ExportBundle | null = $state(null);
+  let revealed = $state(new Set<string>());
+  let pinInputs: HTMLInputElement[] = $state([]);
 
   let wasOpen = false;
 
-  $: pinDigitCount = $appConfig.pinDigitCount;
-  $: if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
+  let pinDigitCount = $derived($appConfig.pinDigitCount);
+  $effect(() => {
+    if (pinDigits.length !== pinDigitCount) pinDigits = Array(pinDigitCount).fill('');
+  });
 
-  $: {
+  $effect(() => {
     if (open && !wasOpen && phase === 'pin') {
       setTimeout(() => pinInputs[0]?.focus(), 100);
     }
@@ -52,7 +58,7 @@
       resetState();
     }
     wasOpen = open;
-  }
+  });
 
   function resetState() {
     phase = 'pin';

--- a/src/components/settings/ExportAllSecretsModal.test.ts
+++ b/src/components/settings/ExportAllSecretsModal.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('../../lib/api/encryption', () => ({
+  loadAndDecryptKey: vi.fn(async () => 'decrypted-nsec-placeholder'),
+}));
+
+vi.mock('../../lib/api/auth', () => ({
+  exportEvmAccountKeyPlaintext: vi.fn(async () => '0xevmsecretkey'),
+  exportRecoveryPhrase: vi.fn(async () => 'seed words go here'),
+}));
+
+vi.mock('../../lib/wallet/evm-accounts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/wallet/evm-accounts')>();
+  return {
+    ...actual,
+    listEvmAccounts: vi.fn(async () => [
+      {
+        id: 'acc-1',
+        scheme: 'secp256k1',
+        hdIndex: 0,
+        address: '0xabc0000000000000000000000000000000abc',
+        label: 'Squad wallet',
+        purpose: 'squad',
+        isActive: true,
+        isDefaultShared: false,
+        isActiveAdvanced: false,
+      },
+    ]),
+  };
+});
+
+import ExportAllSecretsModal from './ExportAllSecretsModal.svelte';
+import { loadAndDecryptKey } from '../../lib/api/encryption';
+
+async function submitPin() {
+  const boxes = screen.getAllByLabelText(/PIN digit/i);
+  for (let i = 0; i < boxes.length; i++) {
+    await fireEvent.input(boxes[i], { target: { value: String((i % 9) + 1) } });
+  }
+}
+
+describe('ExportAllSecretsModal reveal guards', () => {
+  beforeEach(() => {
+    vi.mocked(loadAndDecryptKey).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('never renders any secret before the PIN step is confirmed', () => {
+    render(ExportAllSecretsModal, { props: { open: true, npub: 'npub1owner' } });
+
+    expect(screen.getByRole('heading', { name: 'Enter your PIN' })).toBeTruthy();
+    expect(screen.queryByText('seed words go here')).toBeNull();
+    expect(screen.queryByText('decrypted-nsec-placeholder')).toBeNull();
+    expect(screen.queryByText('0xevmsecretkey')).toBeNull();
+  });
+
+  it('masks every secret independently after PIN confirm, revealing each only via its own toggle', async () => {
+    render(ExportAllSecretsModal, { props: { open: true, npub: 'npub1owner' } });
+
+    await submitPin();
+
+    const revealSeed = await screen.findByRole('button', { name: 'Reveal seed phrase' });
+    const revealNsec = screen.getByRole('button', { name: 'Reveal nsec' });
+    const revealEvm = screen.getByRole('button', { name: 'Reveal private key' });
+
+    // Nothing revealed yet, even though the bundle has already been decrypted.
+    expect(screen.queryByText('seed words go here')).toBeNull();
+    expect(screen.queryByText('decrypted-nsec-placeholder')).toBeNull();
+    expect(screen.queryByText('0xevmsecretkey')).toBeNull();
+
+    await fireEvent.click(revealSeed);
+    expect(await screen.findByText('seed words go here')).toBeTruthy();
+    // Revealing the seed must not also reveal the nsec or the EVM key.
+    expect(screen.queryByText('decrypted-nsec-placeholder')).toBeNull();
+    expect(screen.queryByText('0xevmsecretkey')).toBeNull();
+
+    await fireEvent.click(revealNsec);
+    expect(await screen.findByText('decrypted-nsec-placeholder')).toBeTruthy();
+    expect(screen.queryByText('0xevmsecretkey')).toBeNull();
+
+    await fireEvent.click(revealEvm);
+    expect(await screen.findByText('0xevmsecretkey')).toBeTruthy();
+  });
+
+  it('re-masks every secret when the modal is closed and reopened, without re-revealing anything', async () => {
+    const { rerender } = render(ExportAllSecretsModal, {
+      props: { open: true, npub: 'npub1owner' },
+    });
+
+    await submitPin();
+    const revealSeed = await screen.findByRole('button', { name: 'Reveal seed phrase' });
+    await fireEvent.click(revealSeed);
+    expect(await screen.findByText('seed words go here')).toBeTruthy();
+
+    await rerender({ open: false, npub: 'npub1owner' });
+    await rerender({ open: true, npub: 'npub1owner' });
+
+    expect(await screen.findByRole('heading', { name: 'Enter your PIN' })).toBeTruthy();
+    expect(screen.queryByText('seed words go here')).toBeNull();
+  });
+
+  it('never calls the key decryption API before the PIN is submitted', () => {
+    render(ExportAllSecretsModal, { props: { open: true, npub: 'npub1owner' } });
+    expect(loadAndDecryptKey).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/NostrSettingsSection.svelte
+++ b/src/components/settings/NostrSettingsSection.svelte
@@ -34,10 +34,10 @@
   import EvmAccountKeyExportModal from './EvmAccountKeyExportModal.svelte';
   import RefreshIconButton from '../ui/RefreshIconButton.svelte';
 
-  $: userNpub = $currentUser?.npub ?? '';
+  let userNpub = $derived($currentUser?.npub ?? '');
 
-  let copiedNpub = false;
-  let exportModalOpen = false;
+  let copiedNpub = $state(false);
+  let exportModalOpen = $state(false);
 
   async function copyNpub() {
     if (!userNpub) return;
@@ -50,22 +50,24 @@
     }
   }
 
-  let relays: RelayInfo[] = [];
-  let loading = true;
-  let loadError: string | null = null;
+  let relays: RelayInfo[] = $state([]);
+  let loading = $state(true);
+  let loadError: string | null = $state(null);
 
-  let newRelayUrl = '';
-  let newRelayMode: RelayMode = 'both';
-  let addError: string | null = null;
-  let adding = false;
+  let newRelayUrl = $state('');
+  let newRelayMode: RelayMode = $state('both');
+  let addError: string | null = $state(null);
+  let adding = $state(false);
 
-  let probing = false;
-  let probeResult: ProbeResult | null = null;
-  let probedUrl: string | null = null;
+  let probing = $state(false);
+  let probeResult: ProbeResult | null = $state(null);
+  let probedUrl: string | null = $state(null);
   // Stale results (from a probe of a URL the operator has since edited) never render.
-  $: if (newRelayUrl.trim() !== probedUrl) probeResult = null;
+  $effect(() => {
+    if (newRelayUrl.trim() !== probedUrl) probeResult = null;
+  });
 
-  let busyUrl: string | null = null;
+  let busyUrl: string | null = $state(null);
 
   type RelayDetailState = {
     loading: boolean;
@@ -83,8 +85,8 @@
     return url.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
 
-  let openUrls = new Set<string>();
-  let detailByUrl: Record<string, RelayDetailState> = {};
+  let openUrls = $state(new Set<string>());
+  let detailByUrl: Record<string, RelayDetailState> = $state({});
 
   function toggleDetail(url: string) {
     const next = new Set(openUrls);

--- a/src/components/settings/ProfileSection.svelte
+++ b/src/components/settings/ProfileSection.svelte
@@ -15,32 +15,34 @@
   import AvatarPicker from '../ui/AvatarPicker.svelte';
   import { requireBackupVerified } from '../../stores/backup-verification';
 
-  $: userNpub = $currentUser?.npub || '';
-  $: profile = userNpub ? $profiles[userNpub] : null;
-  $: loading = userNpub ? ($profileLoadingStates[userNpub] || false) : false;
+  let userNpub = $derived($currentUser?.npub || '');
+  let profile = $derived(userNpub ? $profiles[userNpub] : null);
+  let loading = $derived(userNpub ? ($profileLoadingStates[userNpub] || false) : false);
 
   // Compute avatar and banner sources with caching priority
-  $: avatarSrc = getProfileAvatarSrc(profile);
-  $: bannerSrc = getProfileBannerSrc(profile);
+  let avatarSrc = $derived(getProfileAvatarSrc(profile));
+  let bannerSrc = $derived(getProfileBannerSrc(profile));
 
-  let error: string | null = null;
+  let error: string | null = $state(null);
 
   // Edit profile state
-  let isEditing = false;
-  let editName = '';
-  let editAbout = '';
-  let editAvatarUrl = '';
-  let saveError: string | null = null;
-  let savingProfile = false;
+  let isEditing = $state(false);
+  let editName = $state('');
+  let editAbout = $state('');
+  let editAvatarUrl = $state('');
+  let saveError: string | null = $state(null);
+  let savingProfile = $state(false);
 
-  let copiedNpub = false;
-  let exportSeedModalOpen = false;
-  let exportAllModalOpen = false;
+  let copiedNpub = $state(false);
+  let exportSeedModalOpen = $state(false);
+  let exportAllModalOpen = $state(false);
 
-  // Watch for changes to userNpub and load profile
-  $: if (userNpub) {
-    loadUserProfile(userNpub);
-  }
+  // Load profile whenever the logged-in user's npub changes
+  $effect(() => {
+    if (userNpub) {
+      loadUserProfile(userNpub);
+    }
+  });
 
   async function loadUserProfile(npub: string) {
     if (!npub) return;

--- a/src/components/settings/SettingsCollapsibleSection.svelte
+++ b/src/components/settings/SettingsCollapsibleSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import chevronDownIcon from '../../icons/chevron-down.svg';
   import {
     setSettingsSectionCollapsed,
@@ -6,13 +7,21 @@
     type SettingsSectionId,
   } from '../../lib/settings/settings-section-collapse';
 
-  export let sectionId: SettingsSectionId;
-  export let title: string;
-  export let sectionClass = '';
+  let {
+    sectionId,
+    title,
+    sectionClass = '',
+    children,
+  }: {
+    sectionId: SettingsSectionId;
+    title: string;
+    sectionClass?: string;
+    children: Snippet;
+  } = $props();
 
-  $: collapsed = $settingsSectionCollapsed[sectionId] ?? true;
-  $: headingId = `${sectionId}-heading`;
-  $: panelId = `${sectionId}-panel`;
+  let collapsed = $derived($settingsSectionCollapsed[sectionId] ?? true);
+  let headingId = $derived(`${sectionId}-heading`);
+  let panelId = $derived(`${sectionId}-panel`);
 
   function toggleCollapsed() {
     setSettingsSectionCollapsed(sectionId, !collapsed);
@@ -44,7 +53,7 @@
   </h2>
 
   <div id={panelId} class="settings-section-panel" hidden={collapsed}>
-    <slot />
+    {@render children()}
   </div>
 </section>
 

--- a/src/components/settings/SettingsPage.svelte
+++ b/src/components/settings/SettingsPage.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, type Snippet } from 'svelte';
   import { t } from 'svelte-i18n';
   import backIcon from '../../icons/chevron-double-left.svg';
   import { setSettingsSectionCollapsed, settingsSectionCollapsed } from '../../lib/settings/settings-section-collapse';
 
-  export let onBack: () => void;
+  let { onBack, children }: { onBack: () => void; children: Snippet } = $props();
 
   const SECTION_LINKS = [
     { id: 'settings-profile', labelKey: 'nav.settings.sections.profile' },
@@ -18,7 +18,7 @@
   const SCROLL_MARKER_OFFSET_PX = 48;
   const SCROLL_BOTTOM_TOLERANCE_PX = 8;
 
-  let activeSectionId: (typeof SECTION_LINKS)[number]['id'] = SECTION_LINKS[0].id;
+  let activeSectionId: (typeof SECTION_LINKS)[number]['id'] = $state(SECTION_LINKS[0].id);
   let settingsMainEl: HTMLElement | undefined;
 
   function openSection(sectionId: (typeof SECTION_LINKS)[number]['id']) {
@@ -109,7 +109,7 @@
 
     <div class="settings-main" bind:this={settingsMainEl}>
       <div class="settings-sections">
-        <slot />
+        {@render children()}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Closes pacto-app-a7r.11

Migrates all 11 in-scope components under `src/components/settings/` from Svelte 4 legacy reactivity (`export let`, `$:`, `<slot />`) to Svelte 5 runes mode, part of the broader runes migration epic.

Before this change, settings components mixed reactive-statement idioms that don't compose well with runes (implicit dependency tracking, no explicit sentinel guards) and the two slot-based layout components (`SettingsPage`, `SettingsCollapsibleSection`) used `<slot />`, which is unsupported once a component authors any rune. After this change, every file in the batch is fully runes-mode: `$props()` for inputs (including a `$bindable` network filter on `EvmWalletExtras` that a legacy parent still `bind:`s to), `$derived`/`$derived.by` for pure computations, and `$effect` reserved for the handful of genuine synchronization/sentinel-guard cases — mostly the wallet-key modals' PIN-step open/close bookkeeping and the account-switch preferred-network resync.

The two secret-reveal modals (`EvmAccountKeyExportModal`, `ExportAllSecretsModal`) got the most scrutiny since a wrong `$effect` here could silently re-reveal a private key or seed phrase: their PIN-gate/reveal-toggle logic is unchanged in shape (same sentinel-guard `$effect`, same click-triggered `revealed` toggle with no reactive statement involved), and it's now backed by jsdom tests that assert no secret renders pre-PIN-confirm, each secret reveals only via its own toggle, and closing/reopening the modal re-masks everything without re-revealing.

`AvatarCropModal.svelte` (the plan's 12th in-scope file) turned out to already be fully runes-mode at HEAD — no changes were needed there.

## Changes

- Converted 11 files to runes: `SettingsPage`, `SettingsCollapsibleSection` (now `{@render children()}`), `AppSettingsSection`, `DangerZoneSection`, `ProfileSection`, `NostrSettingsSection`, `EvmWalletExtras`, `DefaultWalletConfig`, `EvmAccountsSection`, `EvmAccountKeyExportModal`, `ExportAllSecretsModal`.
- Wallet-key components (`EvmWalletExtras`, `DefaultWalletConfig`, `EvmAccountsSection`) had their account-switch / filter-clamp reactive blocks converted to `$effect` (genuine external sync with existing config storage), preserving the original grouping and guard semantics.
- Removed two `onMount` calls (`DefaultWalletConfig`, `EvmAccountsSection`) that became redundant once the equivalent `$effect` already runs on mount.
- Added `EvmAccountKeyExportModal.test.ts` and `ExportAllSecretsModal.test.ts` (jsdom, `@testing-library/svelte`) covering the reveal-guard behavior on both modals.

## Test plan

- `pnpm check` — 0 errors.
- `pnpm lint` — 0 problems.
- `pnpm test -- --run` — 242/242 test files, 2193/2193 tests passing, including the 2 new reveal-guard test files (8 new tests).
- Manual/mental walkthrough: every settings section renders through `SettingsCollapsibleSection`'s `{@render children()}`; toggling a section's header button flips `hidden` on the panel exactly as the old `<slot />` version did (no template logic changed, only the render mechanism).

## Manual QA follow-up for reviewer

- The reveal-guard tests mock `loadAndDecryptKey`/`exportEvmAccountKeyPlaintext`/`exportRecoveryPhrase`/`listEvmAccounts` (no Tauri backend in jsdom) — a real end-to-end PIN-unlock-and-reveal flow against a live backend/testnet account was not exercised and is worth a manual pass.
- Visual/manual walk of the EVM wallet extras (chain toggles, RPC add/remove, token filters) and the default-wallet-config edit modal wasn't done in a live browser session; `pnpm check`/`lint`/tests all pass but there's no automated coverage proving the `$effect`-based preferred-network sync in `EvmWalletExtras`/`DefaultWalletConfig`/`EvmAccountsSection` behaves identically to the old `$:` block across account switches — recommend a quick manual pass switching between two EVM accounts with different preferred networks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
