### PR TITLE
refactor(pacto-app-a7r.17): convert governance deploy-and-launch modals to svelte 5 runes

### DIFF
--- a/src/components/parent/governance/DeployPactoGovAndSponsorModal.svelte
+++ b/src/components/parent/governance/DeployPactoGovAndSponsorModal.svelte
@@ -32,41 +32,52 @@
   import { listSquadMemberEvmInvokeArgs } from '../../../lib/squad/squad-member-evm-share';
   import { formatEther, parseEther } from 'viem';
 
-  export let parentId: string;
-  /** Prefer #announcements MLS id for roster resolve when it differs from parentId. */
-  export let announcementsGroupId: string | null = null;
-  export let squadNetwork: SupportedChainId | null = null;
-  export let captainMemberOptions: PactoGovCaptainOption[] = [];
-  /** When set, skips Nave Pirata and deploys hats sponsor for this top hat. */
-  export let existingTopHatId = '';
-  /** Required for bootstrap when finishing sponsor after gov already exists. */
-  export let quartermaster = '';
-  export let onClose: () => void;
-  export let onComplete: (out: CombinedGovSponsorDeployComplete) => void | Promise<void>;
+  let {
+    parentId,
+    announcementsGroupId = null,
+    squadNetwork = null,
+    captainMemberOptions = [],
+    existingTopHatId = '',
+    quartermaster = '',
+    onClose,
+    onComplete,
+  }: {
+    parentId: string;
+    /** Prefer #announcements MLS id for roster resolve when it differs from parentId. */
+    announcementsGroupId?: string | null;
+    squadNetwork?: SupportedChainId | null;
+    captainMemberOptions?: PactoGovCaptainOption[];
+    /** When set, skips Nave Pirata and deploys hats sponsor for this top hat. */
+    existingTopHatId?: string;
+    /** Required for bootstrap when finishing sponsor after gov already exists. */
+    quartermaster?: string;
+    onClose: () => void;
+    onComplete: (out: CombinedGovSponsorDeployComplete) => void | Promise<void>;
+  } = $props();
 
   const titleId = 'deploy-gov-sponsor-title';
   const descId = 'deploy-gov-sponsor-desc';
 
   const tFn = get(t);
 
-  let captainAddress = '';
-  let resolvingAddresses = true;
-  let deployError = '';
-  let fundTransferEth = '';
-  let initialDepositEth = '';
-  let bootstrapCrew = false;
-  let progressStep: '' | 'fund' | 'gov' | 'sponsor' | 'bootstrap' = '';
-  let signerWallet: SquadSponsorDeploySignerWallet = 'squad';
-  let defaultSignerAddress: string | null = null;
-  let squadSignerAddress: string | null = null;
-  let defaultBalance: SignerBalance = emptyBalance();
-  let squadBalance: SignerBalance = emptyBalance();
+  let captainAddress = $state('');
+  let resolvingAddresses = $state(true);
+  let deployError = $state('');
+  let fundTransferEth = $state('');
+  let initialDepositEth = $state('');
+  let bootstrapCrew = $state(false);
+  let progressStep: '' | 'fund' | 'gov' | 'sponsor' | 'bootstrap' = $state('');
+  let signerWallet = $state<SquadSponsorDeploySignerWallet>('squad');
+  let defaultSignerAddress: string | null = $state(null);
+  let squadSignerAddress: string | null = $state(null);
+  let defaultBalance: SignerBalance = $state(emptyBalance());
+  let squadBalance: SignerBalance = $state(emptyBalance());
   let refreshSeq = 0;
   let preferredPayerOnce = false;
-  let deploying = false;
+  let deploying = $state(false);
   let closed = false;
 
-  $: sponsorOnly = !!existingTopHatId.trim();
+  const sponsorOnly = $derived(!!existingTopHatId.trim());
 
   const SIGNER_LOOKUP_TIMEOUT_MS = 15_000;
 
@@ -145,35 +156,39 @@
     refreshSeq += 1;
   });
 
-  $: defaultCanonical = canonicalAddress(defaultSignerAddress);
-  $: squadCanonical = canonicalAddress(squadSignerAddress);
-  $: signersAreSame =
-    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical;
+  const defaultCanonical = $derived(canonicalAddress(defaultSignerAddress));
+  const squadCanonical = $derived(canonicalAddress(squadSignerAddress));
+  const signersAreSame = $derived(
+    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical,
+  );
   /** Default only funds the squad key; on-chain deploy always signs as squad/captain. */
-  $: needsFundTransfer = !signersAreSame && signerWallet === 'default';
-  $: payFromEffective = (signersAreSame || needsFundTransfer
-    ? 'squad'
-    : signerWallet) as SquadSponsorDeploySignerWallet;
+  const needsFundTransfer = $derived(!signersAreSame && signerWallet === 'default');
+  const payFromEffective = $derived(
+    (signersAreSame || needsFundTransfer ? 'squad' : signerWallet) as SquadSponsorDeploySignerWallet,
+  );
 
-  $: selectedBalance = signersAreSame
-    ? squadBalance
-    : needsFundTransfer
-      ? defaultBalance
-      : signerWallet === 'default'
+  const selectedBalance = $derived(
+    signersAreSame
+      ? squadBalance
+      : needsFundTransfer
         ? defaultBalance
-        : squadBalance;
+        : signerWallet === 'default'
+          ? defaultBalance
+          : squadBalance,
+  );
 
-  $: transferTrimmed = fundTransferEth.trim();
-  $: depositTrimmed = initialDepositEth.trim();
+  const transferTrimmed = $derived(fundTransferEth.trim());
+  const depositTrimmed = $derived(initialDepositEth.trim());
 
-  $: transferExceedsDefault =
+  const transferExceedsDefault = $derived(
     needsFundTransfer &&
-    transferTrimmed.length > 0 &&
-    !defaultBalance.loading &&
-    !defaultBalance.error &&
-    amountExceedsBalance(transferTrimmed, defaultBalance.balanceRaw);
+      transferTrimmed.length > 0 &&
+      !defaultBalance.loading &&
+      !defaultBalance.error &&
+      amountExceedsBalance(transferTrimmed, defaultBalance.balanceRaw),
+  );
 
-  $: depositExceedsTransfer = (() => {
+  const depositExceedsTransfer = $derived.by(() => {
     if (!needsFundTransfer || !depositTrimmed || !transferTrimmed) return false;
     try {
       const dep = parseEther(depositTrimmed.replace(/,/g, ''));
@@ -182,39 +197,43 @@
     } catch {
       return false;
     }
-  })();
-
-  $: depositExceedsBalance = needsFundTransfer
-    ? depositExceedsTransfer
-    : depositTrimmed.length > 0 &&
-      !selectedBalance.loading &&
-      !selectedBalance.error &&
-      amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw);
-
-  $: bootstrapAllowed = canBootstrapCrewDuringDeploy({
-    captainAddress,
-    squadRosterAddress: squadSignerAddress,
-    payFrom: payFromEffective,
   });
-  $: if (!bootstrapAllowed && bootstrapCrew) {
-    bootstrapCrew = false;
-  }
+
+  const depositExceedsBalance = $derived(
+    needsFundTransfer
+      ? depositExceedsTransfer
+      : depositTrimmed.length > 0 &&
+          !selectedBalance.loading &&
+          !selectedBalance.error &&
+          amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw),
+  );
+
+  const bootstrapAllowed = $derived(
+    canBootstrapCrewDuringDeploy({
+      captainAddress,
+      squadRosterAddress: squadSignerAddress,
+      payFrom: payFromEffective,
+    }),
+  );
+
+  $effect(() => {
+    if (!bootstrapAllowed && bootstrapCrew) {
+      bootstrapCrew = false;
+    }
+  });
 
   /** Default is payer-only when it differs from the bound squad/captain key. */
-  $: bootstrapExcludeAddresses =
-    defaultCanonical && squadCanonical && defaultCanonical !== squadCanonical
-      ? [defaultCanonical]
-      : [];
+  const bootstrapExcludeAddresses = $derived(
+    defaultCanonical && squadCanonical && defaultCanonical !== squadCanonical ? [defaultCanonical] : [],
+  );
 
-  $: crewPreview = bootstrapCrewCandidates(
-    captainMemberOptions,
-    captainAddress,
-    bootstrapExcludeAddresses,
-  ).map((addr) => {
-    const key = addr.toLowerCase();
-    const opt = captainMemberOptions.find((o) => o.address.toLowerCase() === key);
-    return { address: addr, label: opt?.label?.trim() || '' };
-  });
+  const crewPreview = $derived(
+    bootstrapCrewCandidates(captainMemberOptions, captainAddress, bootstrapExcludeAddresses).map((addr) => {
+      const key = addr.toLowerCase();
+      const opt = captainMemberOptions.find((o) => o.address.toLowerCase() === key);
+      return { address: addr, label: opt?.label?.trim() || '' };
+    }),
+  );
 
   function onTransferInput(e: Event) {
     const el = e.currentTarget as HTMLInputElement;
@@ -377,16 +396,17 @@
     }
   }
 
-  $: deployDisabled =
+  const deployDisabled = $derived(
     deploying ||
-    !squadNetwork ||
-    resolvingAddresses ||
-    depositExceedsBalance ||
-    transferExceedsDefault ||
-    !squadCanonical ||
-    !captainAddress ||
-    (needsFundTransfer && (!transferTrimmed || !defaultCanonical)) ||
-    (signersAreSame ? !squadCanonical : signerWallet === 'default' ? !defaultCanonical : !squadCanonical);
+      !squadNetwork ||
+      resolvingAddresses ||
+      depositExceedsBalance ||
+      transferExceedsDefault ||
+      !squadCanonical ||
+      !captainAddress ||
+      (needsFundTransfer && (!transferTrimmed || !defaultCanonical)) ||
+      (signersAreSame ? !squadCanonical : signerWallet === 'default' ? !defaultCanonical : !squadCanonical),
+  );
 </script>
 
 <Modal {titleId} descriptionId={descId} {onClose} dismissible={!deploying} contentClass="deploy-gov-sponsor-panel">

--- a/src/components/parent/governance/DeployPactoGovModal.svelte
+++ b/src/components/parent/governance/DeployPactoGovModal.svelte
@@ -10,21 +10,29 @@
   import type { PactoGovCaptainOption } from '../../../lib/governance/start-pacto-gov-deploy';
   import { getAddress, isAddress } from 'viem';
 
-  export let parentId: string;
-  export let squadNetwork: SupportedChainId | null = null;
-  /** Kept for parent wiring; captain is always the deployer's roster EVM. */
-  export let captainMemberOptions: PactoGovCaptainOption[] = [];
-  export let onClose: () => void;
-  export let onComplete: (out: PactoGovDeployComplete) => void | Promise<void>;
+  let {
+    parentId,
+    squadNetwork = null,
+    captainMemberOptions = [],
+    onClose,
+    onComplete,
+  }: {
+    parentId: string;
+    squadNetwork?: SupportedChainId | null;
+    /** Kept for parent wiring; captain is always the deployer's roster EVM. */
+    captainMemberOptions?: PactoGovCaptainOption[];
+    onClose: () => void;
+    onComplete: (out: PactoGovDeployComplete) => void | Promise<void>;
+  } = $props();
 
   const titleId = 'deploy-pacto-gov-title';
   const descId = 'deploy-pacto-gov-desc';
 
   const tFn = get(t);
 
-  let captainAddress = '';
-  let resolvingDeployer = true;
-  let deployError = '';
+  let captainAddress = $state('');
+  let resolvingDeployer = $state(true);
+  let deployError = $state('');
 
   function shortAddress(addr: string): string {
     if (addr.length < 18) return addr;

--- a/src/components/parent/governance/DeploySquadAdminModal.svelte
+++ b/src/components/parent/governance/DeploySquadAdminModal.svelte
@@ -7,29 +7,39 @@
   import { runOnChainInBackground } from '../../../lib/evm/on-chain-background';
   import SquadDeployNetworkField from './SquadDeployNetworkField.svelte';
 
-  export let parentId: string;
-  /** When set, deploy uses captain_hat variant with this hat id. */
-  export let captainHatId: string | null = null;
-  /** Established squad network; when set the picker is pinned to it. */
-  export let squadNetwork: SupportedChainId | null = null;
-  export let onClose: () => void;
-  export let onComplete: (result: {
-    txHash: string;
-    chain: string;
-    squadAdminProxy: string;
-    providerPayload: string;
-    infraRowId: string;
-  }) => Promise<void>;
+  let {
+    parentId,
+    captainHatId = null,
+    squadNetwork = null,
+    onClose,
+    onComplete,
+  }: {
+    parentId: string;
+    /** When set, deploy uses captain_hat variant with this hat id. */
+    captainHatId?: string | null;
+    /** Established squad network; when set the picker is pinned to it. */
+    squadNetwork?: SupportedChainId | null;
+    onClose: () => void;
+    onComplete: (result: {
+      txHash: string;
+      chain: string;
+      squadAdminProxy: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+  } = $props();
 
   const titleId = 'deploy-squad-admin-title';
   const descId = 'deploy-squad-admin-desc';
 
   const tFn = get(t);
 
-  let deployNetwork: SupportedChainId | '' = squadNetwork ?? '';
-  let deployError = '';
+  /** Seeds the picker once; user can still change it before squadNetwork pins. */
+  // svelte-ignore state_referenced_locally
+  let deployNetwork: SupportedChainId | '' = $state(squadNetwork ?? '');
+  let deployError = $state('');
 
-  $: variant = captainHatId?.trim() ? ('captain_hat' as const) : ('ext_standalone' as const);
+  const variant = $derived(captainHatId?.trim() ? ('captain_hat' as const) : ('ext_standalone' as const));
 
   async function confirmDeploy() {
     deployError = '';

--- a/src/components/parent/governance/DeploySquadSponsorExtModal.svelte
+++ b/src/components/parent/governance/DeploySquadSponsorExtModal.svelte
@@ -24,37 +24,46 @@
   import { normalizeLeadingDotDecimalInput } from '../../../lib/wallet/amount-input';
   import SquadDeployNetworkField from './SquadDeployNetworkField.svelte';
 
-  export let parentId: string;
-  /** Established squad network; when set the picker is pinned to it. */
-  export let squadNetwork: SupportedChainId | null = null;
-  export let onClose: () => void;
-  export let onComplete: (result: {
-    txHash: string;
-    chain: string;
-    sponsorAddress: string;
-    providerPayload: string;
-    infraRowId: string;
-  }) => Promise<void>;
+  let {
+    parentId,
+    squadNetwork = null,
+    onClose,
+    onComplete,
+  }: {
+    parentId: string;
+    /** Established squad network; when set the picker is pinned to it. */
+    squadNetwork?: SupportedChainId | null;
+    onClose: () => void;
+    onComplete: (result: {
+      txHash: string;
+      chain: string;
+      sponsorAddress: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+  } = $props();
 
   const titleId = 'deploy-sponsor-ext-title';
   const descId = 'deploy-sponsor-ext-desc';
 
   const tFn = get(t);
 
-  let deployNetwork: SupportedChainId | '' = squadNetwork ?? '';
-  let initialDepositEth = '';
-  let deployError = '';
-  let deploying = false;
+  /** Seeds the picker once; user can still change it before squadNetwork pins. */
+  // svelte-ignore state_referenced_locally
+  let deployNetwork: SupportedChainId | '' = $state(squadNetwork ?? '');
+  let initialDepositEth = $state('');
+  let deployError = $state('');
+  let deploying = $state(false);
   let closed = false;
 
-  let signerWallet: SquadSponsorDeploySignerWallet = 'default';
-  let defaultSignerAddress: string | null = null;
-  let squadSignerAddress: string | null = null;
-  let addressesLoading = true;
+  let signerWallet = $state<SquadSponsorDeploySignerWallet>('default');
+  let defaultSignerAddress: string | null = $state(null);
+  let squadSignerAddress: string | null = $state(null);
+  let addressesLoading = $state(true);
   let refreshSeq = 0;
   let preferredPayerOnce = false;
-  let defaultBalance: SignerBalance = emptyBalance();
-  let squadBalance: SignerBalance = emptyBalance();
+  let defaultBalance: SignerBalance = $state(emptyBalance());
+  let squadBalance: SignerBalance = $state(emptyBalance());
 
   function parsePositiveDepositWei(amountTrimmed: string): bigint | null {
     try {
@@ -117,55 +126,59 @@
     refreshSeq += 1;
   });
 
-  $: parentId, deployNetwork, void refreshAll();
+  $effect(() => {
+    void parentId;
+    void deployNetwork;
+    void refreshAll();
+  });
 
-  $: defaultCanonical = canonicalAddress(defaultSignerAddress);
-  $: squadCanonical = canonicalAddress(squadSignerAddress);
-  $: signersAreSame =
-    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical;
-  $: payFromEffective = (signersAreSame ? 'squad' : signerWallet) as SquadSponsorDeploySignerWallet;
-  $: selectedBalance = signersAreSame
-    ? squadBalance
-    : payFromEffective === 'default'
-      ? defaultBalance
-      : squadBalance;
+  const defaultCanonical = $derived(canonicalAddress(defaultSignerAddress));
+  const squadCanonical = $derived(canonicalAddress(squadSignerAddress));
+  const signersAreSame = $derived(
+    defaultCanonical != null && squadCanonical != null && defaultCanonical === squadCanonical,
+  );
+  const payFromEffective = $derived(
+    (signersAreSame ? 'squad' : signerWallet) as SquadSponsorDeploySignerWallet,
+  );
+  const selectedBalance = $derived(
+    signersAreSame ? squadBalance : payFromEffective === 'default' ? defaultBalance : squadBalance,
+  );
 
-  $: depositTrimmed = initialDepositEth.trim();
-  $: depositWei = parsePositiveDepositWei(depositTrimmed);
-  $: depositInvalidFormat =
-    depositTrimmed.length > 0 &&
-    (() => {
-      try {
-        parseEther(depositTrimmed.replace(/,/g, ''));
-        return depositWei === null;
-      } catch {
-        return true;
-      }
-    })();
+  const depositTrimmed = $derived(initialDepositEth.trim());
+  const depositWei = $derived(parsePositiveDepositWei(depositTrimmed));
+  const depositInvalidFormat = $derived.by(() => {
+    if (depositTrimmed.length === 0) return false;
+    try {
+      parseEther(depositTrimmed.replace(/,/g, ''));
+      return depositWei === null;
+    } catch {
+      return true;
+    }
+  });
 
-  $: depositExceedsBalance =
+  const depositExceedsBalance = $derived(
     depositWei !== null &&
-    !selectedBalance.loading &&
-    !selectedBalance.error &&
-    amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw);
+      !selectedBalance.loading &&
+      !selectedBalance.error &&
+      amountExceedsBalance(depositTrimmed, selectedBalance.balanceRaw),
+  );
 
-  $: ownerUnavailable = !squadCanonical;
-  $: payerUnavailable = signersAreSame
-    ? !squadCanonical
-    : payFromEffective === 'default'
-      ? !defaultCanonical
-      : !squadCanonical;
+  const ownerUnavailable = $derived(!squadCanonical);
+  const payerUnavailable = $derived(
+    signersAreSame ? !squadCanonical : payFromEffective === 'default' ? !defaultCanonical : !squadCanonical,
+  );
 
-  $: canDeploy =
+  const canDeploy = $derived(
     deployNetwork !== '' &&
-    !addressesLoading &&
-    !ownerUnavailable &&
-    !payerUnavailable &&
-    !deploying &&
-    depositWei !== null &&
-    !depositInvalidFormat &&
-    !depositExceedsBalance &&
-    !selectedBalance.loading;
+      !addressesLoading &&
+      !ownerUnavailable &&
+      !payerUnavailable &&
+      !deploying &&
+      depositWei !== null &&
+      !depositInvalidFormat &&
+      !depositExceedsBalance &&
+      !selectedBalance.loading,
+  );
 
   function onDepositInput(e: Event) {
     const el = e.currentTarget as HTMLInputElement;

--- a/src/components/parent/governance/GovBootstrapCrewModal.svelte
+++ b/src/components/parent/governance/GovBootstrapCrewModal.svelte
@@ -11,49 +11,69 @@
   import { gateRequiresCaptain, type GovernancePrivilege } from '../../../lib/governance/governance-privilege';
   import { showToast } from '../../../stores/toast';
 
-  export let open = false;
-  export let onClose: () => void = () => {};
-  export let network = 'sepolia';
-  export let parentId = '';
-  export let quartermaster = '';
-  export let privilege: GovernancePrivilege;
-  export let memberOptions: { address: string; label: string }[] = [];
-  export let captainAddresses: string[] = [];
-  export let onSubmitted: () => void = () => {};
-  export let fundingHint = '';
+  let {
+    open = false,
+    onClose = () => {},
+    network = 'sepolia',
+    parentId = '',
+    quartermaster = '',
+    privilege,
+    memberOptions = [],
+    captainAddresses = [],
+    onSubmitted = () => {},
+    fundingHint = '',
+  }: {
+    open?: boolean;
+    onClose?: () => void;
+    network?: string;
+    parentId?: string;
+    quartermaster?: string;
+    privilege: GovernancePrivilege;
+    memberOptions?: { address: string; label: string }[];
+    captainAddresses?: string[];
+    onSubmitted?: () => void;
+    fundingHint?: string;
+  } = $props();
 
   const titleId = 'gov-bootstrap-crew-title';
   const descId = 'gov-bootstrap-crew-desc';
 
   const tFn = get(t);
 
-  let selected = new Set<string>();
-  let acting = false;
-  let error = '';
+  let selected = $state(new Set<string>());
+  let acting = $state(false);
+  let error = $state('');
   let wasOpen = false;
 
-  $: gasLine = fundingHint.trim() || govWriteFundingFallbackHint();
+  const gasLine = $derived(fundingHint.trim() || govWriteFundingFallbackHint());
 
-  $: captainSet = new Set(
-    [...captainAddresses, privilege?.myAddress ?? '']
-      .map((a) => a.trim().toLowerCase())
-      .filter(Boolean),
+  const captainSet = $derived(
+    new Set(
+      [...captainAddresses, privilege?.myAddress ?? '']
+        .map((a) => a.trim().toLowerCase())
+        .filter(Boolean),
+    ),
   );
-  $: eligible = memberOptions.filter((m) => {
-    const addr = m.address.trim().toLowerCase();
-    return addr && !captainSet.has(addr);
-  });
-  $: captainGate = gateRequiresCaptain(privilege);
-  $: allSelected = eligible.length > 0 && eligible.every((m) => selected.has(m.address.trim().toLowerCase()));
+  const eligible = $derived(
+    memberOptions.filter((m) => {
+      const addr = m.address.trim().toLowerCase();
+      return addr && !captainSet.has(addr);
+    }),
+  );
+  const captainGate = $derived(gateRequiresCaptain(privilege));
+  const allSelected = $derived(
+    eligible.length > 0 && eligible.every((m) => selected.has(m.address.trim().toLowerCase())),
+  );
 
-  $: if (open && !wasOpen) {
-    wasOpen = true;
-    selected = new Set(eligible.map((m) => m.address.trim().toLowerCase()));
-    error = '';
-  }
-  $: if (!open) {
-    wasOpen = false;
-  }
+  $effect(() => {
+    if (open && !wasOpen) {
+      wasOpen = true;
+      selected = new Set(eligible.map((m) => m.address.trim().toLowerCase()));
+      error = '';
+    } else if (!open && wasOpen) {
+      wasOpen = false;
+    }
+  });
 
   function toggle(addr: string) {
     const key = addr.trim().toLowerCase();

--- a/src/components/parent/governance/GovBootstrapCrewModal.test.ts
+++ b/src/components/parent/governance/GovBootstrapCrewModal.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import GovBootstrapCrewModal from './GovBootstrapCrewModal.svelte';
+import type { GovernancePrivilege } from '../../../lib/governance/governance-privilege';
+
+vi.mock('../../../lib/governance/api', () => ({
+  quartermasterBootstrapCrew: vi.fn(),
+}));
+
+afterEach(() => cleanup());
+
+const CAPTAIN: GovernancePrivilege = {
+  myAddress: '0xcaptain000000000000000000000000000001',
+  wearsCaptain: true,
+  wearsCrew: false,
+  captainIsSafe: false,
+  roleLabel: 'Captain',
+};
+
+const MEMBERS = [
+  { address: '0xaaaa000000000000000000000000000000aaa1', label: 'Alice' },
+  { address: '0xbbbb000000000000000000000000000000bbb2', label: 'Bob' },
+];
+
+function props(open: boolean) {
+  return {
+    open,
+    onClose: vi.fn(),
+    network: 'sepolia',
+    parentId: 'parent-1',
+    quartermaster: '0xquartermaster',
+    privilege: CAPTAIN,
+    memberOptions: MEMBERS,
+    captainAddresses: [CAPTAIN.myAddress],
+  };
+}
+
+describe('GovBootstrapCrewModal', () => {
+  it('defaults to every eligible crew member selected on open', () => {
+    render(GovBootstrapCrewModal, { props: props(true) });
+    const alice = screen.getByRole('checkbox', { name: /Alice/ }) as HTMLInputElement;
+    const bob = screen.getByRole('checkbox', { name: /Bob/ }) as HTMLInputElement;
+    expect(alice.checked).toBe(true);
+    expect(bob.checked).toBe(true);
+  });
+
+  it('discards a stale deselection when the modal is closed and reopened, instead of resubmitting it', async () => {
+    const { rerender } = render(GovBootstrapCrewModal, { props: props(true) });
+    const bobCheckbox = () => screen.getByRole('checkbox', { name: /Bob/ }) as HTMLInputElement;
+
+    await fireEvent.click(bobCheckbox());
+    expect(bobCheckbox().checked).toBe(false);
+
+    await rerender(props(false));
+    await rerender(props(true));
+
+    expect(bobCheckbox().checked).toBe(true);
+  });
+});

--- a/src/components/parent/governance/LaunchpadModal.svelte
+++ b/src/components/parent/governance/LaunchpadModal.svelte
@@ -6,27 +6,42 @@
     launchpadPrimaryCardState,
   } from '../../../lib/governance/launchpad-cta';
 
-  export let hasSponsor: boolean;
-  export let hasPactoGov: boolean;
-  export let hasSquadAdmin: boolean;
-  export let hasAnnouncementsChannel: boolean;
-  /** Sponsor clone address when already deployed. */
-  export let sponsorAddress = '';
-  /** Pacto Gov reference when deployed. */
-  export let pactoGovAddress = '';
-  /** Squad Admin proxy when deployed. */
-  export let squadAdminAddress = '';
-  export let onClose: () => void;
-  export let onDeployGovAndSponsor: () => void;
-  export let onDeployPactoGov: () => void = () => {};
-  export let onDeployExtSponsor: () => void;
-  export let onDeploySquadAdmin: () => void;
+  let {
+    hasSponsor,
+    hasPactoGov,
+    hasSquadAdmin,
+    hasAnnouncementsChannel,
+    sponsorAddress = '',
+    pactoGovAddress = '',
+    squadAdminAddress = '',
+    onClose,
+    onDeployGovAndSponsor,
+    onDeployPactoGov = () => {},
+    onDeployExtSponsor,
+    onDeploySquadAdmin,
+  }: {
+    hasSponsor: boolean;
+    hasPactoGov: boolean;
+    hasSquadAdmin: boolean;
+    hasAnnouncementsChannel: boolean;
+    /** Sponsor clone address when already deployed. */
+    sponsorAddress?: string;
+    /** Pacto Gov reference when deployed. */
+    pactoGovAddress?: string;
+    /** Squad Admin proxy when deployed. */
+    squadAdminAddress?: string;
+    onClose: () => void;
+    onDeployGovAndSponsor: () => void;
+    onDeployPactoGov?: () => void;
+    onDeployExtSponsor: () => void;
+    onDeploySquadAdmin: () => void;
+  } = $props();
 
   const titleId = 'deploy-governance-modal-title';
   const descId = 'deploy-governance-modal-desc';
 
-  $: channelBlocked = launchpadCtaDisabled({ hasAnnouncementsChannel });
-  $: primaryCard = launchpadPrimaryCardState({ hasSponsor, hasPactoGov });
+  const channelBlocked = $derived(launchpadCtaDisabled({ hasAnnouncementsChannel }));
+  const primaryCard = $derived(launchpadPrimaryCardState({ hasSponsor, hasPactoGov }));
 </script>
 
 <Modal {titleId} descriptionId={descId} {onClose} contentClass="launchpad-modal-panel">

--- a/src/components/parent/governance/SquadDeployNetworkField.svelte
+++ b/src/components/parent/governance/SquadDeployNetworkField.svelte
@@ -4,19 +4,31 @@
   import { listSquadDeployNetworkOptions } from '../../../lib/squad/squad-network';
   import { t } from 'svelte-i18n';
 
-  export let id: string;
-  /** When set, the squad network is established: pin the selection and show it read-only. */
-  export let squadNetwork: SupportedChainId | null = null;
-  /** Bound selection; forced to `squadNetwork` when pinned, otherwise the user's pick. */
-  export let value: SupportedChainId | '' = '';
-  export let labelText = '';
-  export let labelClass = '';
-  export let selectClass = '';
+  let {
+    id,
+    squadNetwork = null,
+    value = $bindable(''),
+    labelText = '',
+    labelClass = '',
+    selectClass = '',
+  }: {
+    id: string;
+    /** When set, the squad network is established: pin the selection and show it read-only. */
+    squadNetwork?: SupportedChainId | null;
+    /** Bound selection; forced to `squadNetwork` when pinned, otherwise the user's pick. */
+    value?: SupportedChainId | '';
+    labelText?: string;
+    labelClass?: string;
+    selectClass?: string;
+  } = $props();
 
   const options = listSquadDeployNetworkOptions();
 
-  $: resolvedLabel = labelText || $t('governance.field.network');
-  $: if (squadNetwork && value !== squadNetwork) value = squadNetwork;
+  const resolvedLabel = $derived(labelText || $t('governance.field.network'));
+
+  $effect(() => {
+    if (squadNetwork && value !== squadNetwork) value = squadNetwork;
+  });
 </script>
 
 <label class={labelClass} for={id}>{resolvedLabel}</label>


### PR DESCRIPTION
## Summary

Converts the seven governance deploy-and-launch components to Svelte 5 runes mode: DeployPactoGovAndSponsorModal, DeploySquadSponsorExtModal, LaunchpadModal, GovBootstrapCrewModal, DeployPactoGovModal, DeploySquadAdminModal, and SquadDeployNetworkField (2208 lines, 50 export let, 42 reactive statements). Pure syntax migration -- no behavior change.

These modals drive real on-chain deploys (Nave Pirata / Hats sponsor / squad admin / crew bootstrap), so the risk here was reactive-statement re-firing and resubmitting a transaction. Deployment-step advancement (progressStep) was already callback-driven inside the async executeDeploy/onProgress handlers before this change and stays that way -- it was never expressed as a reactive block, so there was nothing to convert there. The only actual side-effect conversions were:

- DeployPactoGovAndSponsorModal: a self-correcting bootstrap-checkbox reset (unchecks "bootstrap crew" when it becomes disallowed) -- idempotent guard, not a gate for the real deploy (executeDeploy independently re-validates canBootstrapCrewDuringDeploy before submitting).
- SquadDeployNetworkField: pins the network picker to squadNetwork once established -- same self-terminating guard as the original.
- DeploySquadSponsorExtModal: the signer/balance refresh trigger on parentId/deployNetwork change -- a network read, not a write, converted to the same pattern already used elsewhere in this codebase (e.g. SquadSponsoredFeeUsagePanel).
- GovBootstrapCrewModal: the open/close reset (clears crew selection and error state on reopen) -- kept as a wasOpen-sentinel-guarded effect with the sentinel write inside the guard, per the established U11 pattern, so it can't re-fire mid-session and can't skip resetting on reopen.

The three single-shot deploy modals (DeployPactoGovAndSponsorModal, DeploySquadSponsorExtModal, DeployPactoGovModal, DeploySquadAdminModal) are conditionally mounted by their caller (ParentDashboardModals.svelte, out of scope), so closing/reopening already destroys and remounts the component -- no explicit reset logic was needed or added there.

Error-message plumbing (getInvokeErrorMessage, runOnChainInBackground's onError) was not touched, so RPC-URL redaction on deploy failures is unchanged.

## Changes

- export let -> $props() destructuring with the same defaults/optionality.
- Reactive computed statements -> $derived / $derived.by.
- The four side-effect blocks above -> $effect, each triaged per the KTD3 rubric (self-correcting write, external-sync read, or sentinel-guarded reset -- no bare untriaged $effect).
- Non-reactive internal counters (refreshSeq, preferredPayerOnce, closed) stayed plain let, matching the convention in already-converted files (e.g. SquadSponsoredFeeUsagePanel).
- Added one narrow generic annotation ($state<SquadSponsorDeploySignerWallet>(...)) where TS otherwise over-narrowed a union-typed mutable local to its initial literal.
- Added GovBootstrapCrewModal.test.ts: a jsdom test locking in that a stale crew deselection is discarded (not silently resubmitted) when the modal closes and reopens -- the one conversion here that feeds a real on-chain write (quartermasterBootstrapCrew).

## Test plan

- pnpm check -- 0 errors, 0 warnings.
- pnpm lint -- 0 problems.
- pnpm test -- 241 files / 2187 tests passing (240/2185 baseline + 2 new).
- Manual read-through of every converted $effect confirming none can re-fire and resubmit a transaction, and that the reopen-reset and RPC-redaction behavior are preserved (see Summary).

**Not verified here (flagged for manual QA):** the actual testnet deploy flows (Nave Pirata + sponsor combined deploy, sponsor-only finish, ext sponsor deploy, squad admin deploy, quartermaster crew bootstrap) -- this environment can't drive a live wallet/RPC session. A human should exercise each Deploy button end-to-end on testnet before this ships to confirm no runtime regression slipped past svelte-check.

Closes pacto-app-a7r.17

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
