### PR TITLE
refactor: convert dm/ composer and thread to svelte 5 runes

### DIFF
--- a/src/components/dm/DmMessageRouter.svelte
+++ b/src/components/dm/DmMessageRouter.svelte
@@ -38,42 +38,66 @@
   import { reactToMessage } from '../../lib/api/nostr';
   import { clearPendingReactions } from '../../lib/messaging/reactions';
 
-  export let msg: DmMessage;
-  export let npub: string;
-  export let contactDisplayName: string;
-  export let fulfilledWalletRequestIds: ReadonlySet<string>;
-  export let acceptingSquadInviteId: string | null = null;
-  export let acceptingChannelInSquadId: string | null = null;
-  export let acceptingWalletPeerInfoRequestId: string | null = null;
-  export let onAcceptSquadInvite: (msg: DmMessage, groupId: string) => void = () => {};
-  export let onAcceptChannelInSquad: (
-    msg: DmMessage,
-    payload: { channelGroupId: string; announcementsGroupId: string; channelName: string }
-  ) => void = () => {};
-  export let onDeclineSquad: (msg: DmMessage) => void = () => {};
-  export let onDeclineChannelInSquad: (msg: DmMessage) => void = () => {};
-  export let onAcceptWalletPeerInfoRequest: (
-    msg: DmMessage,
-    payload: WalletPeerInfoRequestPayload
-  ) => void | Promise<void> = () => {};
-  export let onDeclineWalletPeerInfoRequest: (
-    msg: DmMessage,
-    payload: WalletPeerInfoRequestPayload
-  ) => void | Promise<void> = () => {};
-  export let onOpenInviterChat: ((inviterNpub: string) => void) | undefined = undefined;
-  export let onReply: (messageId: string) => void = () => {};
-  /** Nest under previous same-author plain message (hide avatar/header). */
-  export let compact: boolean = false;
+  interface Props {
+    msg: DmMessage;
+    npub: string;
+    contactDisplayName: string;
+    fulfilledWalletRequestIds: ReadonlySet<string>;
+    acceptingSquadInviteId?: string | null;
+    acceptingChannelInSquadId?: string | null;
+    acceptingWalletPeerInfoRequestId?: string | null;
+    onAcceptSquadInvite?: (msg: DmMessage, groupId: string) => void;
+    onAcceptChannelInSquad?: (
+      msg: DmMessage,
+      payload: { channelGroupId: string; announcementsGroupId: string; channelName: string }
+    ) => void;
+    onDeclineSquad?: (msg: DmMessage) => void;
+    onDeclineChannelInSquad?: (msg: DmMessage) => void;
+    onAcceptWalletPeerInfoRequest?: (
+      msg: DmMessage,
+      payload: WalletPeerInfoRequestPayload
+    ) => void | Promise<void>;
+    onDeclineWalletPeerInfoRequest?: (
+      msg: DmMessage,
+      payload: WalletPeerInfoRequestPayload
+    ) => void | Promise<void>;
+    onOpenInviterChat?: (inviterNpub: string) => void;
+    onReply?: (messageId: string) => void;
+    /** Nest under previous same-author plain message (hide avatar/header). */
+    compact?: boolean;
+  }
 
-  $: presentation = resolveDmMessagePresentation(msg);
-  $: inviterNpubForCard = isInvitePresentation(presentation) ? inviteInviterNpub(msg, npub) : null;
-  $: inviterDisplay = isInvitePresentation(presentation)
-    ? getInviterDisplayFromNpub(inviterNpubForCard, $profiles)
-    : { inviterName: '', inviterAvatarSrc: null };
-  $: openInviter =
+  let {
+    msg,
+    npub,
+    contactDisplayName,
+    fulfilledWalletRequestIds,
+    acceptingSquadInviteId = null,
+    acceptingChannelInSquadId = null,
+    acceptingWalletPeerInfoRequestId = null,
+    onAcceptSquadInvite = () => {},
+    onAcceptChannelInSquad = () => {},
+    onDeclineSquad = () => {},
+    onDeclineChannelInSquad = () => {},
+    onAcceptWalletPeerInfoRequest = () => {},
+    onDeclineWalletPeerInfoRequest = () => {},
+    onOpenInviterChat,
+    onReply = () => {},
+    compact = false,
+  }: Props = $props();
+
+  let presentation = $derived(resolveDmMessagePresentation(msg));
+  let inviterNpubForCard = $derived(isInvitePresentation(presentation) ? inviteInviterNpub(msg, npub) : null);
+  let inviterDisplay = $derived(
+    isInvitePresentation(presentation)
+      ? getInviterDisplayFromNpub(inviterNpubForCard, $profiles)
+      : { inviterName: '', inviterAvatarSrc: null }
+  );
+  let openInviter = $derived(
     !msg.mine && inviterNpubForCard && inviterNpubForCard !== npub && onOpenInviterChat
       ? () => onOpenInviterChat!(inviterNpubForCard!)
-      : undefined;
+      : undefined
+  );
 
   async function onReact(messageId: string, emoji: string) {
     try {

--- a/src/components/dm/DmThread.svelte
+++ b/src/components/dm/DmThread.svelte
@@ -48,47 +48,80 @@
 
   const tFn = get(t);
 
-  export let npub: string;
-  export let messages: DmMessage[] = [];
-  export let canLoadOlder = false;
-  export let loadingOlder = false;
-  export let onLoadOlder: () => void = () => {};
-  export let onSend: (content: string, repliedTo?: string) => void | boolean | Promise<boolean> = () => {};
-  export let onSendFile:
-    | ((bytes: ArrayBuffer, fileName: string, repliedTo: string, useCompression: boolean) => Promise<void>)
-    | undefined = undefined;
-  export let onSendGif:
-    | ((url: string, slug: string, repliedTo: string) => Promise<void>)
-    | undefined = undefined;
-  export let onTyping: () => void = () => {};
-  export let onAcceptSquadInvite: (msg: DmMessage, groupId: string) => void = () => {};
-  export let onAcceptChannelInSquad: (
-    msg: DmMessage,
-    payload: { channelGroupId: string; announcementsGroupId: string; channelName: string }
-  ) => void = () => {};
-  export let onDeclineSquad: (msg: DmMessage) => void = () => {};
-  export let onDeclineChannelInSquad: (msg: DmMessage) => void = () => {};
-  export let acceptingSquadInviteId: string | null = null;
-  export let acceptingChannelInSquadId: string | null = null;
-  export let showOptionsMenu = true;
-  export let showPinOption = true;
-  export let onSaveNickname: (value: string) => Promise<void> = async () => {};
-  export let onDeleteChat: (() => void) | undefined = undefined;
-  export let showWalletButton: boolean = false;
-  export let onAcceptWalletPeerInfoRequest: ((msg: DmMessage, payload: WalletPeerInfoRequestPayload) => void | Promise<void>) =
-    () => {};
-  export let onDeclineWalletPeerInfoRequest: ((
-    msg: DmMessage,
-    payload: WalletPeerInfoRequestPayload
-  ) => void | Promise<void>) = () => {};
-  export let acceptingWalletPeerInfoRequestId: string | null = null;
-  export let onOpenInviterChat: ((inviterNpub: string) => void) | undefined = undefined;
-  /** Called when the user scrolls to the bottom — marks messages read up to `messageId`. */
-  export let onMarkReadUpTo: (messageId: string) => void = () => {};
+  interface Props {
+    npub: string;
+    messages?: DmMessage[];
+    canLoadOlder?: boolean;
+    loadingOlder?: boolean;
+    onLoadOlder?: () => void;
+    onSend?: (content: string, repliedTo?: string) => void | boolean | Promise<boolean>;
+    onSendFile?: (
+      bytes: ArrayBuffer,
+      fileName: string,
+      repliedTo: string,
+      useCompression: boolean
+    ) => Promise<void>;
+    onSendGif?: (url: string, slug: string, repliedTo: string) => Promise<void>;
+    onTyping?: () => void;
+    onAcceptSquadInvite?: (msg: DmMessage, groupId: string) => void;
+    onAcceptChannelInSquad?: (
+      msg: DmMessage,
+      payload: { channelGroupId: string; announcementsGroupId: string; channelName: string }
+    ) => void;
+    onDeclineSquad?: (msg: DmMessage) => void;
+    onDeclineChannelInSquad?: (msg: DmMessage) => void;
+    acceptingSquadInviteId?: string | null;
+    acceptingChannelInSquadId?: string | null;
+    showOptionsMenu?: boolean;
+    showPinOption?: boolean;
+    onSaveNickname?: (value: string) => Promise<void>;
+    onDeleteChat?: () => void;
+    showWalletButton?: boolean;
+    onAcceptWalletPeerInfoRequest?: (
+      msg: DmMessage,
+      payload: WalletPeerInfoRequestPayload
+    ) => void | Promise<void>;
+    onDeclineWalletPeerInfoRequest?: (
+      msg: DmMessage,
+      payload: WalletPeerInfoRequestPayload
+    ) => void | Promise<void>;
+    acceptingWalletPeerInfoRequestId?: string | null;
+    onOpenInviterChat?: (inviterNpub: string) => void;
+    /** Called when the user scrolls to the bottom — marks messages read up to `messageId`. */
+    onMarkReadUpTo?: (messageId: string) => void;
+  }
 
-  let replyToMessageId: string | null = null;
-  let replyPreview: string | undefined = undefined;
-  $: chatDeleting = $deletingDmNpubs.has(npub);
+  let {
+    npub,
+    messages = [],
+    canLoadOlder = false,
+    loadingOlder = false,
+    onLoadOlder = () => {},
+    onSend = () => {},
+    onSendFile,
+    onSendGif,
+    onTyping = () => {},
+    onAcceptSquadInvite = () => {},
+    onAcceptChannelInSquad = () => {},
+    onDeclineSquad = () => {},
+    onDeclineChannelInSquad = () => {},
+    acceptingSquadInviteId = null,
+    acceptingChannelInSquadId = null,
+    showOptionsMenu = true,
+    showPinOption = true,
+    onSaveNickname = async () => {},
+    onDeleteChat,
+    showWalletButton = false,
+    onAcceptWalletPeerInfoRequest = () => {},
+    onDeclineWalletPeerInfoRequest = () => {},
+    acceptingWalletPeerInfoRequestId = null,
+    onOpenInviterChat,
+    onMarkReadUpTo = () => {},
+  }: Props = $props();
+
+  let replyToMessageId: string | null = $state(null);
+  let replyPreview: string | undefined = $state(undefined);
+  let chatDeleting = $derived($deletingDmNpubs.has(npub));
 
   function onReply(messageId: string) {
     const msg = messages.find((m) => m.id === messageId);
@@ -132,11 +165,14 @@
     cancelReply();
   }
 
+  // Reply state resets whenever the open conversation changes.
   let prevNpubForReply: string | null = null;
-  $: if (npub !== prevNpubForReply) {
-    prevNpubForReply = npub;
-    cancelReply();
-  }
+  $effect(() => {
+    if (npub !== prevNpubForReply) {
+      prevNpubForReply = npub;
+      cancelReply();
+    }
+  });
 
   function lastReadableMessageId(): string | null {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -147,14 +183,16 @@
     return null;
   }
 
-  let dmMessagesContainer: HTMLDivElement | null = null;
+  let dmMessagesContainer: HTMLDivElement | null = $state(null);
   let scrollPrevNpub: string | null = null;
   let lastScrolledToBottomNpub: string | null = null;
   let lastReportedReadId = '';
 
-  $: if (npub !== scrollPrevNpub) {
-    lastReportedReadId = '';
-  }
+  $effect(() => {
+    if (npub !== scrollPrevNpub) {
+      lastReportedReadId = '';
+    }
+  });
 
   function notifyIfAtBottom() {
     if (!dmMessagesContainer) {
@@ -178,13 +216,15 @@
   let appliedWalletGrantsForNpub: string | null = null;
   let reciprocalGrantInFlight = new Set<string>();
 
-  $: if (npub !== appliedWalletGrantsForNpub) {
-    appliedWalletGrantsForNpub = npub;
-    appliedWalletGrantIds = new Set();
-    reciprocalGrantInFlight = new Set();
-  }
+  $effect(() => {
+    if (npub !== appliedWalletGrantsForNpub) {
+      appliedWalletGrantsForNpub = npub;
+      appliedWalletGrantIds = new Set();
+      reciprocalGrantInFlight = new Set();
+    }
+  });
 
-  $: (() => {
+  $effect(() => {
     const uid = $currentUser?.npub;
     const peerNpub = npub;
     if (!uid || !peerNpub) return;
@@ -278,55 +318,61 @@
         }
       })();
     }
-  })();
+  });
 
   function truncateNpub(n: string): string {
     if (n.length <= 16) return n;
     return n.slice(0, 8) + '…' + n.slice(-4);
   }
 
-  $: if (dmMessagesContainer && messages.length) {
+  // $effect runs after the DOM has already been updated with the new message list, so
+  // (unlike its Svelte 4 `setTimeout(0)` predecessor, which deferred until after a `$:`
+  // block that ran before the DOM update) the scroll measurement below sees the real
+  // scrollHeight synchronously and does not need to wait a tick.
+  $effect(() => {
     const container = dmMessagesContainer;
+    if (!container || !messages.length) return;
     const conversationJustChanged = npub !== scrollPrevNpub;
     const firstTimeWithMessages = npub !== lastScrolledToBottomNpub;
     if (conversationJustChanged) {
       scrollPrevNpub = npub;
       dmThreadScrolledToBottom.set(false);
     }
-    setTimeout(() => {
-      if (!container || !document.contains(container)) return;
-      const isNearBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight < 100;
-      if (conversationJustChanged || firstTimeWithMessages || isNearBottom) {
-        container.scrollTop = container.scrollHeight;
-        lastScrolledToBottomNpub = npub;
-        notifyIfAtBottom();
-      }
-    }, 0);
-  }
-  $: if (npub !== scrollPrevNpub && messages.length === 0) {
-    scrollPrevNpub = npub;
-    dmThreadScrolledToBottom.set(false);
-  }
+    const isNearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 100;
+    if (conversationJustChanged || firstTimeWithMessages || isNearBottom) {
+      container.scrollTop = container.scrollHeight;
+      lastScrolledToBottomNpub = npub;
+      notifyIfAtBottom();
+    }
+  });
+  $effect(() => {
+    if (npub !== scrollPrevNpub && messages.length === 0) {
+      scrollPrevNpub = npub;
+      dmThreadScrolledToBottom.set(false);
+    }
+  });
 
-  $: contactProfile = npub ? $profiles[npub] : null;
-  $: peerBlockedByMe = contactProfile?.blocked === true;
-  $: contactAvatarSrc = getProfileAvatarSrc(contactProfile);
-  $: contactDisplayName = contactProfile
-    ? getProfileDisplayName(contactProfile)
-    : npub
-      ? truncateNpub(npub)
-      : $t('messaging.message.replyUnknown');
+  let contactProfile = $derived(npub ? $profiles[npub] : null);
+  let peerBlockedByMe = $derived(contactProfile?.blocked === true);
+  let contactAvatarSrc = $derived(getProfileAvatarSrc(contactProfile));
+  let contactDisplayName = $derived(
+    contactProfile
+      ? getProfileDisplayName(contactProfile)
+      : npub
+        ? truncateNpub(npub)
+        : $t('messaging.message.replyUnknown')
+  );
 
-  let menuOpen = false;
-  let deleteConfirmOpen = false;
-  let showNicknameEdit = false;
-  let nicknameEditValue = '';
-  let nicknameSaving = false;
-  let nicknameError: string | null = null;
+  let menuOpen = $state(false);
+  let deleteConfirmOpen = $state(false);
+  let showNicknameEdit = $state(false);
+  let nicknameEditValue = $state('');
+  let nicknameSaving = $state(false);
+  let nicknameError: string | null = $state(null);
 
   /** `request_id`s tied by a `wallet_tx_announcement` in this thread (on-chain completion). */
-  $: fulfilledWalletRequestIds = getFulfilledWalletRequestIdsFromMessages(messages);
+  let fulfilledWalletRequestIds = $derived(getFulfilledWalletRequestIdsFromMessages(messages));
 
   function openNicknameEdit() {
     menuOpen = false;

--- a/src/components/dm/DmThread.test.ts
+++ b/src/components/dm/DmThread.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import DmThread from './DmThread.svelte';
+import type { DmMessage } from '../../stores/dm';
+
+vi.mock('../../icons/smile-face.svg', () => ({ default: '/smile-face.svg' }));
+vi.mock('../../icons/attachment.svg', () => ({ default: '/attachment.svg' }));
+vi.mock('../../icons/image.svg', () => ({ default: '/image.svg' }));
+vi.mock('../../icons/file.svg', () => ({ default: '/file.svg' }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+const mockOnDragDropEvent = vi.fn(() => Promise.resolve(() => {}));
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({ onDragDropEvent: mockOnDragDropEvent }),
+}));
+
+function makeMessage(overrides: Partial<DmMessage> = {}): DmMessage {
+  return {
+    id: 'm1',
+    content: 'hello',
+    at: Date.now(),
+    mine: false,
+    ...overrides,
+  } as DmMessage;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('DmThread read receipts', () => {
+  it('marks the thread read once on open and does not refire on an unrelated re-render', async () => {
+    const onMarkReadUpTo = vi.fn();
+    render(DmThread, {
+      props: {
+        npub: 'npub1peer',
+        messages: [makeMessage({ id: 'm1' })],
+        onMarkReadUpTo,
+      },
+    });
+
+    await waitFor(() => {
+      expect(onMarkReadUpTo).toHaveBeenCalledTimes(1);
+    });
+    expect(onMarkReadUpTo).toHaveBeenCalledWith('m1');
+
+    // Opening the options dropdown only flips local `menuOpen` state — the
+    // read-receipt effect is keyed on `npub`/`messages`/the container ref and
+    // must not refire just because something else in the component re-rendered.
+    await fireEvent.click(screen.getByTitle('Options'));
+    expect(onMarkReadUpTo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DmThread scroll-to-bottom effect', () => {
+  it('does not touch scrollTop on an unrelated re-render, only when the message list actually changes', async () => {
+    const onMarkReadUpTo = vi.fn();
+    const { rerender } = render(DmThread, {
+      props: {
+        npub: 'npub1peer',
+        messages: [makeMessage({ id: 'm1' })],
+        onMarkReadUpTo,
+      },
+    });
+
+    await waitFor(() => {
+      expect(onMarkReadUpTo).toHaveBeenCalledTimes(1);
+    });
+
+    const container = document.querySelector('.dm-thread-messages') as HTMLDivElement;
+    expect(container).not.toBeNull();
+    const scrollTopSetter = vi.fn();
+    Object.defineProperty(container, 'scrollTop', {
+      configurable: true,
+      get: () => 0,
+      set: scrollTopSetter,
+    });
+
+    // Unrelated re-render: toggling the options menu must not re-run the
+    // scroll-to-bottom effect (it depends on `dmMessagesContainer`/`messages`/
+    // `npub` only).
+    await fireEvent.click(screen.getByTitle('Options'));
+    expect(scrollTopSetter).not.toHaveBeenCalled();
+
+    // A genuine message-list change (same conversation) must still scroll.
+    await rerender({
+      npub: 'npub1peer',
+      messages: [makeMessage({ id: 'm1' }), makeMessage({ id: 'm2', content: 'second' })],
+      onMarkReadUpTo,
+    });
+    await waitFor(() => {
+      expect(scrollTopSetter).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/dm/InviteCard.svelte
+++ b/src/components/dm/InviteCard.svelte
@@ -3,34 +3,53 @@
   import SquadAvatar from '../squad/SquadAvatar.svelte';
 
   /** Invite card for squad, squad-pair, or channel-in-squad DMs. */
-  export let variant: 'squad' | 'squad-pair' | 'channel-in-squad';
-  export let squadName = '';
-  export let channelName = '';
-  export let memberSquads: { id: string; name: string }[] = [];
-  export let isMine: boolean;
-  export let inviterName: string;
-  export let inviterAvatarSrc: string | null = null;
-  export let squadIconUrl: string | null | undefined = undefined;
-  export let squadId = '';
-  export let status: 'pending' | 'joining' | 'accepted' | 'declined';
-  export let accepting: boolean;
-  export let onAccept: () => void;
-  export let onDecline: () => void;
-  /** Opens a DM with the actual inviter, when they differ from the thread's peer. */
-  export let onMessageInviter: (() => void) | undefined = undefined;
+  interface Props {
+    variant: 'squad' | 'squad-pair' | 'channel-in-squad';
+    squadName?: string;
+    channelName?: string;
+    memberSquads?: { id: string; name: string }[];
+    isMine: boolean;
+    inviterName: string;
+    inviterAvatarSrc?: string | null;
+    squadIconUrl?: string | null;
+    squadId?: string;
+    status: 'pending' | 'joining' | 'accepted' | 'declined';
+    accepting: boolean;
+    onAccept: () => void;
+    onDecline: () => void;
+    /** Opens a DM with the actual inviter, when they differ from the thread's peer. */
+    onMessageInviter?: () => void;
+  }
 
-  $: title = (() => {
-    if (variant === 'squad' || variant === 'squad-pair') return squadName;
-    return `${squadName} · #${channelName}`;
-  })();
+  let {
+    variant,
+    squadName = '',
+    channelName = '',
+    memberSquads = [],
+    isMine,
+    inviterName,
+    inviterAvatarSrc = null,
+    squadIconUrl,
+    squadId = '',
+    status,
+    accepting,
+    onAccept,
+    onDecline,
+    onMessageInviter,
+  }: Props = $props();
 
-  $: memberSquadsLabel =
+  let title = $derived(
+    variant === 'squad' || variant === 'squad-pair' ? squadName : `${squadName} · #${channelName}`
+  );
+
+  let memberSquadsLabel = $derived(
     memberSquads?.length > 0
       ? $t('messaging.inviteCard.partnerSquadsLabel', { values: { squads: memberSquads.map((s) => s.name).join(', ') } })
-      : '';
-  $: subtitle = variant === 'squad-pair' && memberSquadsLabel ? memberSquadsLabel : '';
+      : ''
+  );
+  let subtitle = $derived(variant === 'squad-pair' && memberSquadsLabel ? memberSquadsLabel : '');
 
-  $: bodyText = (() => {
+  let bodyText = $derived.by(() => {
     if (variant === 'squad') {
       return isMine
         ? $t('messaging.inviteCard.squadInviteYou', { values: { inviterName } })
@@ -44,18 +63,19 @@
     return isMine
       ? $t('messaging.inviteCard.channelInviteYou', { values: { inviterName, channelName } })
       : $t('messaging.inviteCard.channelInviteThem', { values: { inviterName, channelName } });
-  })();
+  });
 
-  $: iconPlaceholder =
+  let iconPlaceholder = $derived(
     variant === 'squad' || variant === 'squad-pair'
       ? squadName
         ? squadName.charAt(0).toUpperCase()
         : $t('messaging.inviteCard.squadInitial')
-      : $t('messaging.inviteCard.channelInitial');
+      : $t('messaging.inviteCard.channelInitial')
+  );
 
-  $: showBadge = variant === 'squad-pair';
-  $: badgeLabel = $t('messaging.inviteCard.partnerSquad');
-  $: collapsed = status === 'accepted' || status === 'declined';
+  let showBadge = $derived(variant === 'squad-pair');
+  let badgeLabel = $derived($t('messaging.inviteCard.partnerSquad'));
+  let collapsed = $derived(status === 'accepted' || status === 'declined');
 </script>
 
 <div class="invite-card" class:collapsed role="article">

--- a/src/components/dm/MessageInput.svelte
+++ b/src/components/dm/MessageInput.svelte
@@ -49,69 +49,85 @@
     type KlipyGif,
   } from '../../lib/api/klipy';
 
-  export let channelName: string = "";
-  /** When set, replaces the default `Message #{channelName}` placeholder (e.g. blocked peer). */
-  export let placeholderOverride: string | undefined = undefined;
-  export let onSend: (content: string, repliedTo?: string) => void = () => {};
-  /** Optional: called for squad channels with a body + mention list so the caller can build the envelope. */
-  export let onSendMentions: ((body: string, mentions: Mention[], repliedTo?: string) => void) | undefined = undefined;
-  /** Optional: called with the bytes of a pending file attachment when the user sends it. */
-  export let onSendFile:
-    | ((bytes: ArrayBuffer, fileName: string, repliedTo: string, useCompression: boolean) => Promise<void>)
-    | undefined = undefined;
-  /** Optional: called with a picked GIF's URL + slug when the user sends it.
-   * Never uploads bytes — Klipy's terms forbid re-hosting its media. */
-  export let onSendGif:
-    | ((url: string, slug: string, repliedTo: string) => Promise<void>)
-    | undefined = undefined;
-  /** Optional squad context; when provided, typing `@` opens the member mention picker. */
-  export let squadMlsGroupId: string | undefined = undefined;
-  export let squadRosterNpubs: string[] | undefined = undefined;
-  export let squadProfiles: Record<string, NostrProfile | undefined> | undefined = undefined;
-  /** Optional: current user's npub; excluded from mention candidates so you cannot @ yourself. */
-  export let currentUserNpub: string | undefined = undefined;
-  /** Optional: called when user types (e.g. to send typing indicator). */
-  export let onTyping: (() => void) | undefined = undefined;
-  /** When true, input and send are disabled (e.g. channel still being created). */
-  export let disabled: boolean = false;
-  /** Optional id of the message this reply is attached to. */
-  export let repliedTo: string | undefined = undefined;
-  /** Optional preview text of the replied-to message (shown instead of the generic label). */
-  export let repliedToPreview: string | undefined = undefined;
-  /** Optional: called when the user cancels the reply state. */
-  export let onCancelReply: (() => void) | undefined = undefined;
+  interface Props {
+    channelName?: string;
+    /** When set, replaces the default `Message #{channelName}` placeholder (e.g. blocked peer). */
+    placeholderOverride?: string;
+    onSend?: (content: string, repliedTo?: string) => void;
+    /** Optional: called for squad channels with a body + mention list so the caller can build the envelope. */
+    onSendMentions?: (body: string, mentions: Mention[], repliedTo?: string) => void;
+    /** Optional: called with the bytes of a pending file attachment when the user sends it. */
+    onSendFile?: (bytes: ArrayBuffer, fileName: string, repliedTo: string, useCompression: boolean) => Promise<void>;
+    /** Optional: called with a picked GIF's URL + slug when the user sends it.
+     * Never uploads bytes — Klipy's terms forbid re-hosting its media. */
+    onSendGif?: (url: string, slug: string, repliedTo: string) => Promise<void>;
+    /** Optional squad context; when provided, typing `@` opens the member mention picker. */
+    squadMlsGroupId?: string;
+    squadRosterNpubs?: string[];
+    squadProfiles?: Record<string, NostrProfile | undefined>;
+    /** Optional: current user's npub; excluded from mention candidates so you cannot @ yourself. */
+    currentUserNpub?: string;
+    /** Optional: called when user types (e.g. to send typing indicator). */
+    onTyping?: () => void;
+    /** When true, input and send are disabled (e.g. channel still being created). */
+    disabled?: boolean;
+    /** Optional id of the message this reply is attached to. */
+    repliedTo?: string;
+    /** Optional preview text of the replied-to message (shown instead of the generic label). */
+    repliedToPreview?: string;
+    /** Optional: called when the user cancels the reply state. */
+    onCancelReply?: () => void;
+  }
 
-  $: inputPlaceholder = placeholderOverride ?? $t('messaging.messageInput.placeholder', { values: { channelName } });
+  let {
+    channelName = "",
+    placeholderOverride,
+    onSend = () => {},
+    onSendMentions,
+    onSendFile,
+    onSendGif,
+    squadMlsGroupId,
+    squadRosterNpubs,
+    squadProfiles,
+    currentUserNpub,
+    onTyping,
+    disabled = false,
+    repliedTo,
+    repliedToPreview,
+    onCancelReply,
+  }: Props = $props();
+
+  let inputPlaceholder = $derived(placeholderOverride ?? $t('messaging.messageInput.placeholder', { values: { channelName } }));
   const fullEmojiList = getEmojiList();
 
-  let messageText = "";
-  let textareaEl: HTMLTextAreaElement | undefined;
-  let inputWrapperEl: HTMLDivElement | undefined;
+  let messageText = $state("");
+  let textareaEl: HTMLTextAreaElement | undefined = $state();
+  let inputWrapperEl: HTMLDivElement | undefined = $state();
 
   // Media panel (emoji + GIFs)
-  let emojiPanelOpen = false;
-  let emojiPanelTab: 'emoji' | 'gifs' | 'stickers' = 'emoji';
-  let emojiPanelBodyEl: HTMLDivElement | undefined;
-  let emojiSearchQuery = "";
+  let emojiPanelOpen = $state(false);
+  let emojiPanelTab: 'emoji' | 'gifs' | 'stickers' = $state('emoji');
+  let emojiPanelBodyEl: HTMLDivElement | undefined = $state();
+  let emojiSearchQuery = $state("");
 
   // Attachment type menu
-  let attachmentMenuOpen = false;
+  let attachmentMenuOpen = $state(false);
 
   // Mention picker state
-  let mentionPickerOpen = false;
-  let mentionQuery = "";
-  let mentionSelectedIndex = 0;
-  let mentionStartIndex = 0;
+  let mentionPickerOpen = $state(false);
+  let mentionQuery = $state("");
+  let mentionSelectedIndex = $state(0);
+  let mentionStartIndex = $state(0);
   let mentionEndIndex = 0;
-  let mentions: Mention[] = [];
-  let mentionPickerEl: HTMLDivElement | undefined;
-  let mentionSnappedHeight: number | null = null;
+  let mentions: Mention[] = $state([]);
+  let mentionPickerEl: HTMLDivElement | undefined = $state();
+  let mentionSnappedHeight: number | null = $state(null);
 
   // Attachment + reply state
-  let fileInput: HTMLInputElement | undefined;
-  let pendingInputAccept = '';
-  let pendingInputCapture: 'environment' | undefined = undefined;
-  let isSendingAttachment = false;
+  let fileInput: HTMLInputElement | undefined = $state();
+  let pendingInputAccept = $state('');
+  let pendingInputCapture: 'environment' | undefined = $state(undefined);
+  let isSendingAttachment = $state(false);
   let dropUnregister: (() => void) | undefined;
   let composerDestroyed = false;
   const desktopPickerAvailable = isDesktopFilePickerAvailable();
@@ -155,23 +171,27 @@
     revokeGifThumbCache();
   });
 
-  $: excludedNpubs = (() => {
+  let excludedNpubs = $derived.by(() => {
     const set = new Set<string>();
     if (currentUserNpub) set.add(currentUserNpub);
     for (const m of mentions) set.add(m.npub);
     return set;
-  })();
-  $: mentionCandidates = squadMlsGroupId
-    ? buildMentionCandidates(squadRosterNpubs ?? [], squadProfiles ?? {}, excludedNpubs)
-    : [];
-  $: filteredMentions = filterMentionCandidates(mentionCandidates, mentionQuery);
+  });
+  let mentionCandidates = $derived(
+    squadMlsGroupId
+      ? buildMentionCandidates(squadRosterNpubs ?? [], squadProfiles ?? {}, excludedNpubs)
+      : []
+  );
+  let filteredMentions = $derived(filterMentionCandidates(mentionCandidates, mentionQuery));
 
-  $: if (disabled) {
-    emojiPanelOpen = false;
-    emojiSearchQuery = '';
-    attachmentMenuOpen = false;
-    closeMentionPicker();
-  }
+  $effect(() => {
+    if (disabled) {
+      emojiPanelOpen = false;
+      emojiSearchQuery = '';
+      attachmentMenuOpen = false;
+      closeMentionPicker();
+    }
+  });
 
   function closeMentionPicker() {
     mentionPickerOpen = false;
@@ -575,17 +595,25 @@
     });
   }
 
-  $: mentionPickerPlacement = mentionPickerOpen
-    ? computeMentionPickerPlacement(messageText, mentionStartIndex, textareaEl, inputWrapperEl)
-    : null;
+  let mentionPickerPlacement = $derived(
+    mentionPickerOpen
+      ? computeMentionPickerPlacement(messageText, mentionStartIndex, textareaEl, inputWrapperEl)
+      : null
+  );
 
-  $: void snapMentionPickerToWholeRows(filteredMentions, mentionPickerPlacement);
+  $effect(() => {
+    void snapMentionPickerToWholeRows(filteredMentions, mentionPickerPlacement);
+  });
 
-  $: mentionPickerStyle = mentionPickerPlacement
-    ? `left: ${mentionPickerPlacement.left}px; ${mentionPickerPlacement.edge}: ${mentionPickerPlacement.offset}px; max-height: ${Math.min(mentionPickerPlacement.maxHeight, mentionSnappedHeight ?? mentionPickerPlacement.maxHeight)}px;`
-    : '';
+  let mentionPickerStyle = $derived(
+    mentionPickerPlacement
+      ? `left: ${mentionPickerPlacement.left}px; ${mentionPickerPlacement.edge}: ${mentionPickerPlacement.offset}px; max-height: ${Math.min(mentionPickerPlacement.maxHeight, mentionSnappedHeight ?? mentionPickerPlacement.maxHeight)}px;`
+      : ''
+  );
 
-  $: if (mentionPickerOpen) void scrollMentionSelectionIntoView(mentionSelectedIndex);
+  $effect(() => {
+    if (mentionPickerOpen) void scrollMentionSelectionIntoView(mentionSelectedIndex);
+  });
 
   /** Cap browse/search so opening the panel does not mount ~1k+ buttons and freeze the UI. */
   const EMOJI_BROWSE_LIMIT = 100;
@@ -601,8 +629,8 @@
     }
     return out;
   })();
-  $: recentEmojis = $recentEmojisStore;
-  $: searchResults = (() => {
+  let recentEmojis = $derived($recentEmojisStore);
+  let searchResults = $derived.by(() => {
     const q = emojiSearchQuery.trim();
     if (!q) return [];
     const seen = new Set<string>();
@@ -614,7 +642,7 @@
       if (out.length >= EMOJI_SEARCH_LIMIT) break;
     }
     return out;
-  })();
+  });
 
   async function insertEmoji(emoji: string) {
     if (disabled) return;
@@ -670,7 +698,7 @@
 
   type StickerGroup = { pack: StickerPack; entries: StickerEntry[] };
 
-  $: stickerGroups = ((): StickerGroup[] => {
+  let stickerGroups = $derived.by((): StickerGroup[] => {
     const q = emojiSearchQuery.trim().toLowerCase();
     const groups: StickerGroup[] = [];
     for (const pack of $stickerPacks) {
@@ -681,7 +709,7 @@
       if (entries.length > 0) groups.push({ pack, entries });
     }
     return groups;
-  })();
+  });
 
   const STICKER_MIME_EXTENSIONS: Record<string, string> = {
     'image/png': 'png',
@@ -690,7 +718,7 @@
     'image/webp': 'webp',
   };
 
-  let stickerImageCache: Record<string, string> = {};
+  let stickerImageCache: Record<string, string> = $state({});
 
   async function ensureStickerImageCached(entry: StickerEntry) {
     if (stickerImageCache[entry.url]) return;
@@ -748,16 +776,16 @@
   }
 
   // GIFs tab (Klipy). Debounced search/trending, gated on the opt-in disclosure.
-  let gifsDisclosureAccepted = false;
-  let gifsResults: KlipyGif[] = [];
+  let gifsDisclosureAccepted = $state(false);
+  let gifsResults: KlipyGif[] = $state([]);
   let gifsPage = 1;
   let gifsHasMore = false;
-  let gifsLoading = false;
-  let gifsFetchFailed = false;
-  let gifsConfigured: boolean | null = null;
+  let gifsLoading = $state(false);
+  let gifsFetchFailed = $state(false);
+  let gifsConfigured: boolean | null = $state(null);
   let gifsRequestToken = 0;
 
-  let gifThumbCache: Record<string, string> = {};
+  let gifThumbCache: Record<string, string> = $state({});
 
   /** Revokes every cached GIF thumbnail blob URL and clears the cache. Called from every
    * teardown point (destroy, panel close, tab switch away from GIFs, and before a fresh
@@ -841,15 +869,19 @@
     }
   }
 
-  $: if (emojiPanelOpen && emojiPanelTab === 'gifs' && gifsDisclosureAccepted) {
-    gifsSearchScheduler.scheduleSearch(emojiSearchQuery);
-  }
-
-  $: if (emojiPanelTab === 'gifs') {
-    for (const gif of gifsResults) {
-      void ensureGifThumbCached(gif);
+  $effect(() => {
+    if (emojiPanelOpen && emojiPanelTab === 'gifs' && gifsDisclosureAccepted) {
+      gifsSearchScheduler.scheduleSearch(emojiSearchQuery);
     }
-  }
+  });
+
+  $effect(() => {
+    if (emojiPanelTab === 'gifs') {
+      for (const gif of gifsResults) {
+        void ensureGifThumbCached(gif);
+      }
+    }
+  });
 
   function handleGifsDisclosureAccept() {
     acceptGifsDisclosure();

--- a/src/components/dm/MessageInput.test.ts
+++ b/src/components/dm/MessageInput.test.ts
@@ -96,6 +96,19 @@ describe('MessageInput', () => {
     expect(input.value).toBe('');
   });
 
+  it('does not call onSend when Shift+Enter is pressed, so the default newline insertion proceeds', async () => {
+    const onSend = vi.fn();
+    render(MessageInput, { props: { channelName: 'general', onSend } });
+    const input = screen.getByPlaceholderText('Message #general') as HTMLTextAreaElement;
+    await fireEvent.input(input, { target: { value: 'hello world' } });
+    const event = await fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: true });
+    // Handler must not preventDefault a Shift+Enter — the browser's own default
+    // newline insertion is what actually adds the line break.
+    expect(event).toBe(true);
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input.value).toBe('hello world');
+  });
+
   it('forwards repliedTo to onSend when replying to a message', async () => {
     const onSend = vi.fn();
     render(MessageInput, { props: { channelName: 'general', onSend, repliedTo: 'msg-123' } });

--- a/src/components/dm/MessengerChatView.svelte
+++ b/src/components/dm/MessengerChatView.svelte
@@ -10,9 +10,9 @@
 
   const tFn = get(t);
 
-  let npub = '';
-  let messageText = '';
-  let sending = false;
+  let npub = $state('');
+  let messageText = $state('');
+  let sending = $state(false);
 
   // Consume any prefill (e.g. a "Request DM" from a Commons user card), then clear it.
   onMount(() => {
@@ -85,7 +85,7 @@
     $dmSendError = null;
   }
 
-  $: canSend = isValidNpub(npub.trim()) && messageText.trim().length > 0 && !sending;
+  let canSend = $derived(isValidNpub(npub.trim()) && messageText.trim().length > 0 && !sending);
 </script>
 
 <div class="messenger-chat-view">

--- a/src/components/dm/MessengerNavbar.svelte
+++ b/src/components/dm/MessengerNavbar.svelte
@@ -24,7 +24,7 @@
   import PendingWelcomeRequests from './PendingWelcomeRequests.svelte';
   import { offeredWelcomeList } from '../../lib/invites/pending-welcomes-store';
 
-  $: title = $t(`messaging.dm.navbar.${$activeDmTab}`);
+  let title = $derived($t(`messaging.dm.navbar.${$activeDmTab}`));
 
   function displayName(entry: DmEntry): string {
     const profile = $profiles[entry.npub];
@@ -33,7 +33,7 @@
   }
 
   /** Search tab: filter unified list by npub or display name (case-insensitive substring). */
-  let dmSearchQuery = '';
+  let dmSearchQuery = $state('');
 
   function matchesDmSearch(entry: DmEntry, rawQuery: string): boolean {
     const q = rawQuery.trim().toLowerCase();
@@ -50,14 +50,14 @@
     return $allDmEntriesUnified as DmEntry[];
   }
 
-  $: filteredEntries = (() => {
+  let filteredEntries = $derived.by(() => {
     const tab = $activeDmTab;
     const list = tabSourceList(tab);
     if (tab === 'search' && dmSearchQuery.trim() !== '') {
       return list.filter((e) => matchesDmSearch(e, dmSearchQuery));
     }
     return list;
-  })();
+  });
 
   function categoryLabel(cat: DmSidebarCategory): string {
     const tFn = get(t);
@@ -73,7 +73,7 @@
     $activeDmId = npub;
   }
 
-  let width = 240;
+  let width = $state(240);
   let isResizing = false;
   const minWidth = 180;
   const maxWidth = 400;


### PR DESCRIPTION
## Summary

Converts the DM composer, thread, and messenger shell — `MessageInput.svelte` (1537 lines, the largest non-god-shell component in the migration), `DmThread.svelte`, `MessengerNavbar.svelte`, `InviteCard.svelte`, `DmMessageRouter.svelte`, and `MessengerChatView.svelte` — from Svelte 4 legacy syntax (`export let`, `$:`) to Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`). Part of the repo-wide runes migration (epic `pacto-app-a7r`), unit U10.

The risk in this batch was `DmThread.svelte`'s six side-effect statements that drive scroll position and read receipts. `$:` ran *before* Svelte applied the DOM update; `$effect` runs *after*. A naive conversion risks either a duplicate read-receipt fire per re-render or a scroll-to-bottom effect that doesn't see the newly-rendered message. Each side effect was triaged individually rather than defaulted to `$effect`:

- Three are sentinel-guarded conversation resets (reply state, wallet-grant cache, empty-thread scroll position) — each keeps its guard write inside the effect so it can't loop.
- The wallet-peer-grant sync and the scroll-to-bottom effect are genuine external synchronization (network calls, DOM scroll) and become bare effects.
- The scroll-to-bottom effect drops its Svelte 4 `setTimeout(0)` deferral entirely: that hack existed only to wait for the DOM update `$:` couldn't see yet. Since `$effect` already runs post-update, the scroll measurement is now synchronous instead of landing a frame late — removing the one-frame jump risk rather than reproducing it in new syntax.

## Changes

- All six files converted in place (props → computed → side effects; `MessageInput.svelte`'s size and complexity is explicitly out of scope for decomposition per the migration plan's scope boundaries).
- `DmMessageRouter.svelte` and `InviteCard.svelte` picked up typed `Props` interfaces alongside the prop conversion.
- No `svelte/legacy` imports, no leftover `export let`/`$:`/`<slot>` in any of the six files (verified by grep and `pnpm check`).

## Test plan

- `pnpm check` — 0 errors, 0 warnings.
- `pnpm lint` — 0 problems.
- `pnpm test` — 241 test files / 2188 tests passing, including the existing `MessageInput.test.ts` (composer send/attachment/mention/emoji/GIF/sticker coverage) unchanged in behavior.
- Added `DmThread.test.ts`: asserts a thread is marked read exactly once on open and does not refire on an unrelated re-render (toggling the options menu), and that the scroll-to-bottom effect does not touch `scrollTop` on that same unrelated re-render but does when the message list actually changes — the two behaviors most at risk from the `$:` → `$effect` timing change.
- Added a Shift+Enter regression case to `MessageInput.test.ts` confirming it does not call `onSend` and lets the browser's default newline insertion proceed (Enter-sends case already existed).
- Code-read confirms `onSend`/`onCancelReply`/mention-picker keyboard handling are unchanged — they're plain event handlers, not reactive statements, so the rune conversion did not touch them.

## Manual QA follow-up for reviewer

Not exercised by this automated run (no interactive browser session): visually confirm in a running app that scrolling up during an incoming DM does not yank the thread back to the bottom, and that accepting an invite card transitions the thread without a full remount. Both are covered by unchanged logic (only the effect's DOM-timing wrapper changed) and by the automated scroll-effect test above, but a human eyeball pass on the actual animation/feel is still worth a few minutes.

Closes pacto-app-a7r.26

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)