### PR TITLE
feat: convert governance actions and proposals to svelte 5 runes

### DIFF
--- a/src/components/parent/governance/GovCaptainActions.svelte
+++ b/src/components/parent/governance/GovCaptainActions.svelte
@@ -41,31 +41,55 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let network: string;
-  export let parentId: string;
-  export let treasuryAuthority: string;
-  export let quartermaster: string;
-  export let mutinyModule: string;
-  export let privilege: GovernancePrivilege;
-  export let proposals: TreasuryProposalDto[] = [];
-  export let mutinyStatus: MutinyStatusDto | null = null;
-  export let qmStatus: QuartermasterStatusDto | null = null;
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let captainWearers: string[] = [];
-  export let onRefreshProposals: () => void = () => {};
-  export let onRefreshMutiny: () => void = () => {};
-  export let onRefreshQm: () => void = () => {};
-  export let fundingHint = '';
+  interface Props {
+    network: string;
+    parentId: string;
+    treasuryAuthority: string;
+    quartermaster: string;
+    mutinyModule: string;
+    privilege: GovernancePrivilege;
+    proposals?: TreasuryProposalDto[];
+    mutinyStatus?: MutinyStatusDto | null;
+    qmStatus?: QuartermasterStatusDto | null;
+    memberEvmOptions?: { address: string; label: string }[];
+    captainWearers?: string[];
+    onRefreshProposals?: () => void;
+    onRefreshMutiny?: () => void;
+    onRefreshQm?: () => void;
+    fundingHint?: string;
+    /** True while capability preflight is still loading; forces every gate closed. */
+    capabilitiesPending?: boolean;
+  }
+
+  let {
+    network,
+    parentId,
+    treasuryAuthority,
+    quartermaster,
+    mutinyModule,
+    privilege,
+    proposals = [],
+    mutinyStatus = null,
+    qmStatus = null,
+    memberEvmOptions = [],
+    captainWearers = [],
+    onRefreshProposals = () => {},
+    onRefreshMutiny = () => {},
+    onRefreshQm = () => {},
+    fundingHint = '',
+    capabilitiesPending = false,
+  }: Props = $props();
 
   const tFn = get(t);
+  const PENDING_GATE: CtaGate = { enabled: false, reason: 'governance.status.loading' };
 
-  let acting = false;
-  let voteProposalId = '';
-  let execProposalId = '';
-  let resignTo = '';
-  let qmAddress = '';
-  let qmPending: QuartermasterPendingDto | null = null;
-  let showBootstrapModal = false;
+  let acting = $state(false);
+  let voteProposalId = $state('');
+  let execProposalId = $state('');
+  let resignTo = $state('');
+  let qmAddress = $state('');
+  let qmPending: QuartermasterPendingDto | null = $state(null);
+  let showBootstrapModal = $state(false);
 
   function shortEvm(addr: string): string {
     const a = addr.trim();
@@ -73,23 +97,28 @@
     return `${a.slice(0, 6)}…${a.slice(-4)}`;
   }
 
-  $: if (memberEvmOptions.length > 0) {
-    const hit = memberEvmOptions.some(
-      (o) => o.address.trim().toLowerCase() === qmAddress.trim().toLowerCase(),
-    );
-    if (!qmAddress.trim() || !hit) {
-      qmAddress = memberEvmOptions[0].address;
+  $effect(() => {
+    if (memberEvmOptions.length > 0) {
+      const hit = memberEvmOptions.some(
+        (o) => o.address.trim().toLowerCase() === qmAddress.trim().toLowerCase(),
+      );
+      if (!qmAddress.trim() || !hit) {
+        qmAddress = memberEvmOptions[0].address;
+      }
     }
-  }
+  });
 
-  $: captainGate = gateRequiresCaptain(privilege);
-  $: qmGate = gateBlockedByMutinyMode(privilege, !!qmStatus?.mutinyActive);
-  $: execGate = gatePermissionlessSigner(privilege);
-  $: votable = captainVotableProposals(proposals);
-  $: executable = executableTreasuryProposals(proposals);
-  $: mutinyActive = isMutinyActive(mutinyStatus);
-  $: bootstrapAvailable = qmStatus?.bootstrapAvailable === true;
-  $: bootstrapGate = ((): CtaGate => {
+  let captainGate = $derived(capabilitiesPending ? PENDING_GATE : gateRequiresCaptain(privilege));
+  let qmGate = $derived(
+    capabilitiesPending ? PENDING_GATE : gateBlockedByMutinyMode(privilege, !!qmStatus?.mutinyActive),
+  );
+  let execGate = $derived(capabilitiesPending ? PENDING_GATE : gatePermissionlessSigner(privilege));
+  let votable = $derived(captainVotableProposals(proposals));
+  let executable = $derived(executableTreasuryProposals(proposals));
+  let mutinyActive = $derived(isMutinyActive(mutinyStatus));
+  let bootstrapAvailable = $derived(qmStatus?.bootstrapAvailable === true);
+  let bootstrapGate = $derived.by((): CtaGate => {
+    if (capabilitiesPending) return PENDING_GATE;
     if (!bootstrapAvailable) {
       return {
         enabled: false,
@@ -99,13 +128,19 @@
       };
     }
     return captainGate;
-  })();
-  $: if (votable.length && !votable.some((p) => p.proposalId === voteProposalId)) {
-    voteProposalId = votable[0]?.proposalId ?? '';
-  }
-  $: if (executable.length && !executable.some((p) => p.proposalId === execProposalId)) {
-    execProposalId = executable[0]?.proposalId ?? '';
-  }
+  });
+
+  $effect(() => {
+    if (votable.length && !votable.some((p) => p.proposalId === voteProposalId)) {
+      voteProposalId = votable[0]?.proposalId ?? '';
+    }
+  });
+
+  $effect(() => {
+    if (executable.length && !executable.some((p) => p.proposalId === execProposalId)) {
+      execProposalId = executable[0]?.proposalId ?? '';
+    }
+  });
 
   async function run(label: string, fn: () => Promise<unknown>, refresh: () => void) {
     if (acting) return;
@@ -149,6 +184,7 @@
         {treasuryAuthority}
         {privilege}
         {fundingHint}
+        {capabilitiesPending}
         onSubmitted={onRefreshProposals}
       />
 

--- a/src/components/parent/governance/GovCrewActions.svelte
+++ b/src/components/parent/governance/GovCrewActions.svelte
@@ -23,6 +23,7 @@
   import {
     gatePermissionlessSigner,
     gateRequiresCrew,
+    type CtaGate,
     type GovernancePrivilege,
   } from '../../../lib/governance/governance-privilege';
   import {
@@ -35,37 +36,63 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let network: string;
-  export let parentId: string;
-  export let treasuryAuthority: string;
-  export let mutinyModule: string;
-  export let privilege: GovernancePrivilege;
-  export let proposals: TreasuryProposalDto[] = [];
-  export let mutinyStatus: MutinyStatusDto | null = null;
-  export let mutinyHasVotedFlag = false;
-  export let onRefreshProposals: () => void = () => {};
-  export let onRefreshMutiny: () => void = () => {};
-  export let fundingHint = '';
+  interface Props {
+    network: string;
+    parentId: string;
+    treasuryAuthority: string;
+    mutinyModule: string;
+    privilege: GovernancePrivilege;
+    proposals?: TreasuryProposalDto[];
+    mutinyStatus?: MutinyStatusDto | null;
+    mutinyHasVotedFlag?: boolean;
+    onRefreshProposals?: () => void;
+    onRefreshMutiny?: () => void;
+    fundingHint?: string;
+    /** True while capability preflight is still loading; forces every gate closed. */
+    capabilitiesPending?: boolean;
+  }
+
+  let {
+    network,
+    parentId,
+    treasuryAuthority,
+    mutinyModule,
+    privilege,
+    proposals = [],
+    mutinyStatus = null,
+    mutinyHasVotedFlag = false,
+    onRefreshProposals = () => {},
+    onRefreshMutiny = () => {},
+    fundingHint = '',
+    capabilitiesPending = false,
+  }: Props = $props();
 
   const tFn = get(t);
+  const PENDING_GATE: CtaGate = { enabled: false, reason: 'governance.status.loading' };
 
-  let acting = false;
-  let voteProposalId = '';
-  let execProposalId = '';
-  let startKind: 'crew' | 'committee' | 'eoa' | 'contract' | 'pause' = 'crew';
-  let proposed = '';
+  let acting = $state(false);
+  let voteProposalId = $state('');
+  let execProposalId = $state('');
+  let startKind: 'crew' | 'committee' | 'eoa' | 'contract' | 'pause' = $state('crew');
+  let proposed = $state('');
 
-  $: crewGate = gateRequiresCrew(privilege);
-  $: execGate = gatePermissionlessSigner(privilege);
-  $: votable = crewVotableProposals(proposals);
-  $: executable = executableTreasuryProposals(proposals);
-  $: mutinyActive = isMutinyActive(mutinyStatus);
-  $: if (votable.length && !votable.some((p) => p.proposalId === voteProposalId)) {
-    voteProposalId = votable[0]?.proposalId ?? '';
-  }
-  $: if (executable.length && !executable.some((p) => p.proposalId === execProposalId)) {
-    execProposalId = executable[0]?.proposalId ?? '';
-  }
+  let crewGate = $derived(capabilitiesPending ? PENDING_GATE : gateRequiresCrew(privilege));
+  let execGate = $derived(capabilitiesPending ? PENDING_GATE : gatePermissionlessSigner(privilege));
+  let votable = $derived(crewVotableProposals(proposals));
+  let executable = $derived(executableTreasuryProposals(proposals));
+  let mutinyActive = $derived(isMutinyActive(mutinyStatus));
+
+  $effect(() => {
+    if (votable.length && !votable.some((p) => p.proposalId === voteProposalId)) {
+      voteProposalId = votable[0]?.proposalId ?? '';
+    }
+  });
+
+  $effect(() => {
+    if (executable.length && !executable.some((p) => p.proposalId === execProposalId)) {
+      execProposalId = executable[0]?.proposalId ?? '';
+    }
+  });
 
   async function run(label: string, fn: () => Promise<unknown>, refresh: () => void) {
     if (acting) return;
@@ -112,6 +139,7 @@
         {treasuryAuthority}
         {privilege}
         {fundingHint}
+        {capabilitiesPending}
         onSubmitted={onRefreshProposals}
       />
 

--- a/src/components/parent/governance/GovCtaButton.svelte
+++ b/src/components/parent/governance/GovCtaButton.svelte
@@ -2,14 +2,18 @@
   import { t } from 'svelte-i18n';
   import type { CtaGate } from '../../../lib/governance/governance-privilege';
 
-  export let label: string;
-  export let gate: CtaGate;
-  export let acting = false;
-  export let variant: 'primary' | 'secondary' | 'danger' | 'execute' = 'secondary';
-  export let onClick: () => void = () => {};
+  interface Props {
+    label: string;
+    gate: CtaGate;
+    acting?: boolean;
+    variant?: 'primary' | 'secondary' | 'danger' | 'execute';
+    onClick?: () => void;
+  }
 
-  $: disabled = acting || !gate.enabled;
-  $: title = gate.enabled ? label : $t(gate.reason);
+  let { label, gate, acting = false, variant = 'secondary', onClick = () => {} }: Props = $props();
+
+  let disabled = $derived(acting || !gate.enabled);
+  let title = $derived(gate.enabled ? label : $t(gate.reason));
 </script>
 
 <div class="gov-cta-wrap">

--- a/src/components/parent/governance/GovProcessCard.svelte
+++ b/src/components/parent/governance/GovProcessCard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
   import type { GovProcessCard } from '../../../lib/governance/gov-process';
   import { govProcessToolLabel } from '../../../lib/governance/gov-process';
@@ -13,65 +12,54 @@
   import { executableTreasuryProposals, isMutinyExecutable } from '../../../lib/governance/gov-proposal-lists';
   import ProposalActionSummary from './ProposalActionSummary.svelte';
 
-  export let card: GovProcessCard;
-  export let showExecute = false;
-  export let executePending = false;
-  /** Privilege gate i18n key (empty when allowed). Delay lock is derived from the card. */
-  export let privilegeReasonKey = '';
-  export let onExecute: (() => void) | undefined = undefined;
-
-  let delayElapsed = false;
-  let unlockTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function clearUnlockTimer() {
-    if (unlockTimer != null) {
-      clearTimeout(unlockTimer);
-      unlockTimer = null;
-    }
+  interface Props {
+    card: GovProcessCard;
+    showExecute?: boolean;
+    executePending?: boolean;
+    /** Privilege gate i18n key (empty when allowed). Delay lock is derived from the card. */
+    privilegeReasonKey?: string;
+    onExecute?: () => void;
   }
 
-  onDestroy(clearUnlockTimer);
+  let { card, showExecute = false, executePending = false, privilegeReasonKey = '', onExecute = undefined }: Props =
+    $props();
 
-  $: tool = $t(govProcessToolLabel(card));
-  $: isActive =
-    card.kind === 'treasury' ? isTreasuryProposalActive(card.proposal.status) : true;
-  $: isPast = card.kind === 'treasury' ? isTreasuryProposalPast(card.proposal.status) : false;
-  $: cardUnlockAtSec =
+  let delayElapsed = $state(false);
+
+  let tool = $derived($t(govProcessToolLabel(card)));
+  let isActive = $derived(card.kind === 'treasury' ? isTreasuryProposalActive(card.proposal.status) : true);
+  let isPast = $derived(card.kind === 'treasury' ? isTreasuryProposalPast(card.proposal.status) : false);
+  let cardUnlockAtSec = $derived(
     card.kind === 'crew_add' || card.kind === 'crew_remove'
       ? card.executableAt > 0
         ? card.executableAt
         : null
-      : null;
-  $: {
-    clearUnlockTimer();
-    const alreadyOpen = cardUnlockAtSec == null || cardUnlockAtSec <= Math.floor(Date.now() / 1000);
-    delayElapsed = alreadyOpen;
-    if (!alreadyOpen && cardUnlockAtSec != null) {
-      unlockTimer = setTimeout(() => {
-        delayElapsed = true;
-      }, Math.max(0, cardUnlockAtSec * 1000 - Date.now()));
-    }
-  }
-  $: execUi = govExecuteUiState({
-    card,
-    privilegeReasonKey,
-    nowSec: delayElapsed ? Math.floor(Date.now() / 1000) : 0,
-  });
-  $: isExecutable =
+      : null,
+  );
+  let execUi = $derived(
+    govExecuteUiState({
+      card,
+      privilegeReasonKey,
+      nowSec: delayElapsed ? Math.floor(Date.now() / 1000) : 0,
+    }),
+  );
+  let isExecutable = $derived(
     card.kind === 'treasury'
       ? executableTreasuryProposals([card.proposal]).length > 0
       : card.kind === 'mutiny'
         ? isMutinyExecutable(card.status)
-        : card.status === 'executable';
-  $: title =
+        : card.status === 'executable',
+  );
+  let title = $derived(
     card.kind === 'treasury'
       ? $t('governance.proposal.title', { values: { id: card.proposal.proposalId } })
       : card.kind === 'mutiny'
         ? $t('governance.proposal.mutinyTitle', { values: { id: card.status.activeMutinyId } })
         : card.kind === 'crew_add'
           ? $t('governance.proposal.addCrewTitle')
-          : $t('governance.proposal.removeCrewTitle');
-  $: statusLabel =
+          : $t('governance.proposal.removeCrewTitle'),
+  );
+  let statusLabel = $derived(
     card.kind === 'treasury'
       ? treasuryProposalStatusLabel(card.proposal.status)
       : card.kind === 'mutiny'
@@ -80,10 +68,10 @@
           : $t('governance.proposal.active')
         : card.status === 'executable'
           ? $t('governance.proposal.readyToExecute')
-          : $t('governance.proposal.timelock');
-  $: outcome =
-    card.kind === 'treasury' ? treasuryProposalOutcomeLabel(card.proposal.status) : '';
-  $: executeTitle = (() => {
+          : $t('governance.proposal.timelock'),
+  );
+  let outcome = $derived(card.kind === 'treasury' ? treasuryProposalOutcomeLabel(card.proposal.status) : '');
+  let executeTitle = $derived.by(() => {
     if (execUi.executeEnabled || !execUi.disabledReasonKey) {
       return $t('governance.common.execute');
     }
@@ -98,7 +86,21 @@
     return execUi.disabledReasonKey.startsWith('governance.')
       ? $t(execUi.disabledReasonKey)
       : execUi.disabledReasonKey;
-  })();
+  });
+
+  /** Flip the delay lock open once the crew-change timelock elapses. */
+  $effect(() => {
+    const unlockAt = cardUnlockAtSec;
+    const alreadyOpen = unlockAt == null || unlockAt <= Math.floor(Date.now() / 1000);
+    delayElapsed = alreadyOpen;
+    if (!alreadyOpen && unlockAt != null) {
+      const timer = setTimeout(() => {
+        delayElapsed = true;
+      }, Math.max(0, unlockAt * 1000 - Date.now()));
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  });
 </script>
 
 <li

--- a/src/components/parent/governance/GovProposalsBoard.svelte
+++ b/src/components/parent/governance/GovProposalsBoard.svelte
@@ -14,6 +14,7 @@
   import {
     gatePermissionlessSigner,
     gateQuartermasterExecute,
+    type CtaGate,
     type GovernancePrivilege,
   } from '../../../lib/governance/governance-privilege';
   import {
@@ -32,43 +33,74 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let network: string;
-  export let parentId: string;
-  export let treasuryAuthority: string;
-  export let quartermaster = '';
-  export let privilege: GovernancePrivilege;
-  export let proposals: TreasuryProposalDto[] = [];
-  export let proposalsLoading = false;
-  export let proposalsError = '';
-  export let mutinyStatus: MutinyStatusDto | null = null;
-  export let mutinyLoading = false;
-  export let qmPending: QuartermasterPendingActionDto[] = [];
-  export let qmPendingLoading = false;
-  export let qmPendingError = '';
-  export let mutinyMode = false;
-  export let onRefreshProposals: () => void = () => {};
-  export let onExecuteMutiny: () => void | Promise<void> = () => {};
-  export let fundingHint = '';
+  interface Props {
+    network: string;
+    parentId: string;
+    treasuryAuthority: string;
+    quartermaster?: string;
+    privilege: GovernancePrivilege;
+    proposals?: TreasuryProposalDto[];
+    proposalsLoading?: boolean;
+    proposalsError?: string;
+    mutinyStatus?: MutinyStatusDto | null;
+    mutinyLoading?: boolean;
+    qmPending?: QuartermasterPendingActionDto[];
+    qmPendingLoading?: boolean;
+    qmPendingError?: string;
+    mutinyMode?: boolean;
+    onRefreshProposals?: () => void;
+    onExecuteMutiny?: () => void | Promise<void>;
+    fundingHint?: string;
+    /** True while capability preflight is still loading; forces every gate closed. */
+    capabilitiesPending?: boolean;
+  }
+
+  let {
+    network,
+    parentId,
+    treasuryAuthority,
+    quartermaster = '',
+    privilege,
+    proposals = [],
+    proposalsLoading = false,
+    proposalsError = '',
+    mutinyStatus = null,
+    mutinyLoading = false,
+    qmPending = [],
+    qmPendingLoading = false,
+    qmPendingError = '',
+    mutinyMode = false,
+    onRefreshProposals = () => {},
+    onExecuteMutiny = () => {},
+    fundingHint = '',
+    capabilitiesPending = false,
+  }: Props = $props();
 
   const tFn = get(t);
+  const PENDING_GATE: CtaGate = { enabled: false, reason: 'governance.status.loading' };
 
-  let acting = false;
+  let acting = $state(false);
 
-  $: execGate = gatePermissionlessSigner(privilege);
-  $: qmExecGate = gateQuartermasterExecute(privilege, mutinyMode);
-  $: processCards = buildGovProcessCards({
-    treasuryProposals: proposals,
-    mutinyStatus,
-    qmPending,
-  });
-  $: openCount = countOpenGovProcesses(processCards);
-  $: boardLoading =
+  let execGate = $derived(capabilitiesPending ? PENDING_GATE : gatePermissionlessSigner(privilege));
+  let qmExecGate = $derived(
+    capabilitiesPending ? PENDING_GATE : gateQuartermasterExecute(privilege, mutinyMode),
+  );
+  let processCards = $derived(
+    buildGovProcessCards({
+      treasuryProposals: proposals,
+      mutinyStatus,
+      qmPending,
+    }),
+  );
+  let openCount = $derived(countOpenGovProcesses(processCards));
+  let boardLoading = $derived(
     (proposalsLoading && proposals.length === 0) ||
-    (mutinyLoading && !mutinyStatus) ||
-    (qmPendingLoading && qmPending.length === 0);
-  $: refreshSpinning = proposalsLoading || mutinyLoading || qmPendingLoading;
-  $: proposalsRpcKind = rpcReadErrorKind(proposalsError);
-  $: qmPendingRpcKind = rpcReadErrorKind(qmPendingError);
+      (mutinyLoading && !mutinyStatus) ||
+      (qmPendingLoading && qmPending.length === 0),
+  );
+  let refreshSpinning = $derived(proposalsLoading || mutinyLoading || qmPendingLoading);
+  let proposalsRpcKind = $derived(rpcReadErrorKind(proposalsError));
+  let qmPendingRpcKind = $derived(rpcReadErrorKind(qmPendingError));
 
   async function runTreasuryExecute(proposalId: string) {
     if (acting || !execGate.enabled) return;

--- a/src/components/parent/governance/GovProposeForm.svelte
+++ b/src/components/parent/governance/GovProposeForm.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import GovCtaButton from './GovCtaButton.svelte';
   import { treasuryAuthorityPropose } from '../../../lib/governance/api';
-  import { gateRequiresCaptainOrCrew, type GovernancePrivilege } from '../../../lib/governance/governance-privilege';
+  import {
+    gateRequiresCaptainOrCrew,
+    type CtaGate,
+    type GovernancePrivilege,
+  } from '../../../lib/governance/governance-privilege';
   import {
     fundedByFromWriteResult,
     govWriteSubmittedToast,
@@ -11,22 +15,37 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let network: string;
-  export let parentId: string;
-  export let treasuryAuthority: string;
-  export let privilege: GovernancePrivilege;
-  export let fundingHint = '';
-  export let onSubmitted: () => void = () => {};
+  interface Props {
+    network: string;
+    parentId: string;
+    treasuryAuthority: string;
+    privilege: GovernancePrivilege;
+    fundingHint?: string;
+    /** True while capability preflight is still loading; forces the gate closed. */
+    capabilitiesPending?: boolean;
+    onSubmitted?: () => void;
+  }
+
+  let {
+    network,
+    parentId,
+    treasuryAuthority,
+    privilege,
+    fundingHint = '',
+    capabilitiesPending = false,
+    onSubmitted = () => {},
+  }: Props = $props();
 
   const tFn = get(t);
+  const PENDING_GATE: CtaGate = { enabled: false, reason: 'governance.status.loading' };
 
-  let acting = false;
-  let proposeTo = '';
-  let proposeValue = '0';
-  let proposeData = '0x';
-  let proposeOp = 'call';
+  let acting = $state(false);
+  let proposeTo = $state('');
+  let proposeValue = $state('0');
+  let proposeData = $state('0x');
+  let proposeOp = $state('call');
 
-  $: proposeGate = gateRequiresCaptainOrCrew(privilege);
+  let proposeGate = $derived(capabilitiesPending ? PENDING_GATE : gateRequiresCaptainOrCrew(privilege));
 
   async function submit() {
     if (acting || !proposeGate.enabled) return;

--- a/src/components/parent/governance/PactoGovGovernanceShell.svelte
+++ b/src/components/parent/governance/PactoGovGovernanceShell.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import GovProposalsBoard from './GovProposalsBoard.svelte';
   import GovCrewActions from './GovCrewActions.svelte';
   import GovCaptainActions from './GovCaptainActions.svelte';
@@ -41,68 +40,96 @@
   import { get } from 'svelte/store';
   import { t } from 'svelte-i18n';
 
-  export let payload: PactoGovProviderPayloadV1;
-  export let network: string;
-  export let parentId: string;
-  export let myAddress = '';
-  export let captainWearers: string[] = [];
-  export let crewWearers: string[] = [];
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let treasuryProposals: TreasuryProposalDto[] = [];
-  export let treasuryProposalsLoading = false;
-  export let treasuryProposalsError = '';
-  export let onRefreshProposals: () => void = () => {};
-  export let hasSponsor = false;
+  interface Props {
+    payload: PactoGovProviderPayloadV1;
+    network: string;
+    parentId: string;
+    myAddress?: string;
+    captainWearers?: string[];
+    crewWearers?: string[];
+    memberEvmOptions?: { address: string; label: string }[];
+    treasuryProposals?: TreasuryProposalDto[];
+    treasuryProposalsLoading?: boolean;
+    treasuryProposalsError?: string;
+    onRefreshProposals?: () => void;
+    hasSponsor?: boolean;
+  }
+
+  let {
+    payload,
+    network,
+    parentId,
+    myAddress = '',
+    captainWearers = [],
+    crewWearers = [],
+    memberEvmOptions = [],
+    treasuryProposals = [],
+    treasuryProposalsLoading = false,
+    treasuryProposalsError = '',
+    onRefreshProposals = () => {},
+    hasSponsor = false,
+  }: Props = $props();
 
   type GovSubMode = 'proposals' | 'crew' | 'captain';
   type MutinySnapshot = { status: MutinyStatusDto; hasVoted: boolean };
+  /** Capability-preflight state: `unresolved` must never render a gated action as available. */
+  type CapabilitiesStatus = 'unresolved' | 'ready' | 'error';
 
   const tFn = get(t);
 
-  let govSubMode: GovSubMode = 'proposals';
-  let mutinyCaptain = '';
-  let capabilities: SquadCapabilitiesDto | null = null;
-  let capabilitiesLoadKey = '';
+  let govSubMode: GovSubMode = $state('proposals');
+  let mutinyCaptain = $state('');
+  let capabilities: SquadCapabilitiesDto | null = $state(null);
+  let capabilitiesStatus: CapabilitiesStatus = $state('unresolved');
+  let capabilitiesLoadKey = $state('');
 
-  let mutinyStatus: MutinyStatusDto | null = null;
-  let mutinyHasVotedFlag = false;
-  let mutinyLoading = false;
-  let mutinyHydrateKey = '';
+  let mutinyStatus: MutinyStatusDto | null = $state(null);
+  let mutinyHasVotedFlag = $state(false);
+  let mutinyLoading = $state(false);
+  let mutinyHydrateKey = $state('');
 
-  let qmStatus: QuartermasterStatusDto | null = null;
-  let qmHydrateKey = '';
+  let qmStatus: QuartermasterStatusDto | null = $state(null);
+  let qmHydrateKey = $state('');
 
-  let qmPending: QuartermasterPendingActionDto[] = [];
-  let qmPendingLoading = false;
-  let qmPendingError = '';
-  let qmPendingHydrateKey = '';
-  let lastSeenProcessNonce = 0;
+  let qmPending: QuartermasterPendingActionDto[] = $state([]);
+  let qmPendingLoading = $state(false);
+  let qmPendingError = $state('');
+  let qmPendingHydrateKey = $state('');
+  let lastSeenProcessNonce = $state(0);
 
-  $: processNonce = $governanceProcessNonceByParentId[parentId.trim()] ?? 0;
-  $: if (processNonce > 0 && processNonce !== lastSeenProcessNonce) {
-    lastSeenProcessNonce = processNonce;
-    refreshAllProposals();
-  }
+  let rosterBalanceRaw = $state('0');
+  let rosterBalanceKnown = $state(false);
+  let fundingBalanceKey = $state('');
 
-  let rosterBalanceRaw = '0';
-  let rosterBalanceKnown = false;
-  let fundingBalanceKey = '';
+  let processNonce = $derived($governanceProcessNonceByParentId[parentId.trim()] ?? 0);
 
-  $: captainList = (() => {
+  $effect(() => {
+    if (processNonce > 0 && processNonce !== lastSeenProcessNonce) {
+      lastSeenProcessNonce = processNonce;
+      refreshAllProposals();
+    }
+  });
+
+  let captainList = $derived.by(() => {
     const set = new Set(captainWearers.map((a) => a.trim().toLowerCase()).filter(Boolean));
     if (mutinyCaptain.trim()) set.add(mutinyCaptain.trim().toLowerCase());
     return [...set];
-  })();
+  });
 
-  $: privilege = resolveGovernancePrivilege({
-    myAddress,
-    safeAddress: payload.safe,
-    captainWearers: captainList,
-    crewWearers,
-    capabilities,
-  }) as GovernancePrivilege;
+  /** Destructive captain/crew CTAs must stay closed until the ACL preflight resolves. */
+  let capabilitiesPending = $derived(capabilitiesStatus === 'unresolved');
 
-  $: {
+  let privilege = $derived(
+    resolveGovernancePrivilege({
+      myAddress,
+      safeAddress: payload.safe,
+      captainWearers: captainList,
+      crewWearers,
+      capabilities,
+    }) as GovernancePrivilege,
+  );
+
+  $effect(() => {
     const addr = (privilege.myAddress || myAddress).trim();
     const key = `${network}|${addr}|${hasSponsor}`;
     if (key !== fundingBalanceKey) {
@@ -113,46 +140,49 @@
         rosterBalanceKnown = false;
       }
     }
-  }
-
-  $: fundingHint = displayGovWriteFundingHint({
-    balanceRaw: rosterBalanceRaw,
-    balanceKnown: rosterBalanceKnown,
-    hasSponsorInfra: hasSponsor,
   });
 
-  $: {
+  let fundingHint = $derived(
+    displayGovWriteFundingHint({
+      balanceRaw: rosterBalanceRaw,
+      balanceKnown: rosterBalanceKnown,
+      hasSponsorInfra: hasSponsor,
+    }),
+  );
+
+  $effect(() => {
     const pid = parentId.trim();
     const key = `${pid}|${network}`;
     if (pid && key !== capabilitiesLoadKey) {
       capabilitiesLoadKey = key;
+      capabilitiesStatus = 'unresolved';
       void loadCapabilities(pid);
     }
-  }
+  });
 
-  $: {
+  $effect(() => {
     const key = `${parentId}|${network}|${payload.mutinyModule ?? ''}|${privilege.myAddress}`;
     if (key !== mutinyHydrateKey && parentId.trim() && payload.mutinyModule?.trim()) {
       mutinyHydrateKey = key;
       void reloadMutiny(false);
     }
-  }
+  });
 
-  $: {
+  $effect(() => {
     const key = `${parentId}|${network}|${payload.quartermaster ?? ''}`;
     if (key !== qmHydrateKey && parentId.trim() && payload.quartermaster?.trim()) {
       qmHydrateKey = key;
       void reloadQm(false);
     }
-  }
+  });
 
-  $: {
+  $effect(() => {
     const key = `${parentId}|${network}|${payload.quartermaster ?? ''}|pending`;
     if (key !== qmPendingHydrateKey && parentId.trim() && payload.quartermaster?.trim()) {
       qmPendingHydrateKey = key;
       void reloadQmPending();
     }
-  }
+  });
 
   async function loadCapabilities(pid: string) {
     const key = `${pid}|${network}`;
@@ -160,9 +190,11 @@
       const snap = await getSquadCapabilities(pid, network);
       if (key !== capabilitiesLoadKey) return;
       capabilities = snap;
+      capabilitiesStatus = 'ready';
     } catch {
       if (key !== capabilitiesLoadKey) return;
       capabilities = null;
+      capabilitiesStatus = 'error';
     }
   }
 
@@ -306,14 +338,6 @@
     }
   }
 
-  onMount(() => {
-    const pid = parentId.trim();
-    if (pid) {
-      capabilitiesLoadKey = `${pid}|${network}`;
-      void loadCapabilities(pid);
-    }
-  });
-
   function shortAddr(addr: string): string {
     const a = addr.trim();
     if (a.length < 14) return a || '—';
@@ -370,6 +394,7 @@
         onRefreshProposals={refreshAllProposals}
         onExecuteMutiny={executeMutinyFromBoard}
         {fundingHint}
+        {capabilitiesPending}
       />
     {:else if govSubMode === 'crew'}
       <GovCrewActions
@@ -384,6 +409,7 @@
         onRefreshProposals={refreshAllProposals}
         onRefreshMutiny={() => reloadMutiny(true)}
         {fundingHint}
+        {capabilitiesPending}
       />
     {:else}
       <GovCaptainActions
@@ -405,6 +431,7 @@
           void reloadQmPending();
         }}
         {fundingHint}
+        {capabilitiesPending}
       />
     {/if}
   </div>

--- a/src/components/parent/governance/PactoGovGovernanceShell.test.ts
+++ b/src/components/parent/governance/PactoGovGovernanceShell.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import PactoGovGovernanceShell from './PactoGovGovernanceShell.svelte';
+import { getSquadCapabilities } from '../../../lib/governance/api';
+import { fetchEvmBalance } from '../../../lib/wallet/signer-balance';
+import type { SquadCapabilitiesDto } from '../../../lib/governance/api';
+import type { PactoGovProviderPayloadV1 } from '../../../lib/governance/pacto-gov-payload';
+
+vi.mock('../../../lib/governance/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/governance/api')>();
+  return { ...actual, getSquadCapabilities: vi.fn() };
+});
+
+vi.mock('../../../lib/wallet/signer-balance', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/wallet/signer-balance')>();
+  return { ...actual, fetchEvmBalance: vi.fn() };
+});
+
+const mockedGetSquadCapabilities = vi.mocked(getSquadCapabilities);
+const mockedFetchEvmBalance = vi.mocked(fetchEvmBalance);
+
+const CAPTAIN_ADDRESS = '0xcaptain0000000000000000000000000000001';
+
+function basePayload(): PactoGovProviderPayloadV1 {
+  return {
+    safe: '0xsafe000000000000000000000000000000000',
+    treasuryAuthority: '0xta00000000000000000000000000000000001',
+    quartermaster: '',
+    mutinyModule: '',
+  };
+}
+
+function capabilitiesSnapshot(overrides: Partial<SquadCapabilitiesDto> = {}): SquadCapabilitiesDto {
+  return {
+    parentId: 'parent1',
+    rosterAddress: CAPTAIN_ADDRESS,
+    wearsCaptain: true,
+    wearsCrew: false,
+    captainIsSafe: false,
+    squadAdminFull: false,
+    squadAdminPaused: false,
+    roleLabel: 'Captain',
+    capabilities: {},
+    ...overrides,
+  };
+}
+
+describe('PactoGovGovernanceShell capability preflight gating', () => {
+  beforeEach(() => {
+    mockedGetSquadCapabilities.mockReset();
+    mockedFetchEvmBalance.mockReset();
+    mockedFetchEvmBalance.mockResolvedValue({
+      balanceRaw: '0',
+      balanceDecimal: '0',
+      symbol: 'ETH',
+      loading: false,
+      error: '',
+    });
+  });
+
+  it('keeps the propose action unavailable while capabilities are unresolved, then enables it once resolved', async () => {
+    const { promise: capabilitiesPromise, resolve: resolveCapabilities } =
+      Promise.withResolvers<SquadCapabilitiesDto>();
+    mockedGetSquadCapabilities.mockReturnValue(capabilitiesPromise);
+
+    render(PactoGovGovernanceShell, {
+      props: {
+        payload: basePayload(),
+        network: 'sepolia',
+        parentId: 'parent1',
+        myAddress: CAPTAIN_ADDRESS,
+        captainWearers: [CAPTAIN_ADDRESS],
+        crewWearers: [],
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole('tab', { name: 'Captain' }));
+
+    const submitButton = (await screen.findByRole('button', {
+      name: 'Submit proposal',
+    })) as HTMLButtonElement;
+
+    // The hat check alone would already allow this captain — but the ACL preflight
+    // hasn't settled, so the action must render unavailable, not permitted.
+    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.title).toBe('Loading…');
+
+    resolveCapabilities(capabilitiesSnapshot());
+
+    await waitFor(() => expect(submitButton.disabled).toBe(false));
+  });
+
+  it('never flips a captain action from available to revoked when the backend denies it', async () => {
+    const { promise: capabilitiesPromise, resolve: resolveCapabilities } =
+      Promise.withResolvers<SquadCapabilitiesDto>();
+    mockedGetSquadCapabilities.mockReturnValue(capabilitiesPromise);
+
+    render(PactoGovGovernanceShell, {
+      props: {
+        payload: basePayload(),
+        network: 'sepolia',
+        parentId: 'parent1',
+        myAddress: CAPTAIN_ADDRESS,
+        captainWearers: [CAPTAIN_ADDRESS],
+        crewWearers: [],
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole('tab', { name: 'Captain' }));
+
+    const submitButton = (await screen.findByRole('button', {
+      name: 'Submit proposal',
+    })) as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+
+    resolveCapabilities(
+      capabilitiesSnapshot({
+        capabilities: { proposeTreasury: { allowed: false, reason: 'Access denied' } },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(submitButton.title).toBe(
+        'Not allowed for your role. Check your hats or bind a squad EVM in My Dashboard → Alerts.',
+      ),
+    );
+    // Went straight from "loading" to "denied" — it was never briefly enabled.
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('shows a disabled propose action with a reason for a member without a captain or crew hat', async () => {
+    mockedGetSquadCapabilities.mockRejectedValue(new Error('network unreachable'));
+
+    render(PactoGovGovernanceShell, {
+      props: {
+        payload: basePayload(),
+        network: 'sepolia',
+        parentId: 'parent1',
+        myAddress: '0xmember000000000000000000000000000000009',
+        captainWearers: [CAPTAIN_ADDRESS],
+        crewWearers: [],
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole('tab', { name: 'Crew' }));
+
+    const submitButton = (await screen.findByRole('button', {
+      name: 'Submit proposal',
+    })) as HTMLButtonElement;
+
+    await waitFor(() =>
+      expect(submitButton.title).toBe(
+        'You need a Captain or Crew hat. Ask a captain or crew member for a hat.',
+      ),
+    );
+    expect(submitButton.disabled).toBe(true);
+  });
+});

--- a/src/components/parent/governance/PactoGovInfraList.svelte
+++ b/src/components/parent/governance/PactoGovInfraList.svelte
@@ -12,10 +12,14 @@
   import { hatsTreeDomain, prettyHatId } from '../../../lib/governance/pretty-hat-id';
   import { t } from 'svelte-i18n';
 
-  export let providerPayload: string | null | undefined = undefined;
-  export let topHatId = '';
-  export let chain: string | undefined = undefined;
-  export let showDeployTx = true;
+  interface Props {
+    providerPayload?: string | null;
+    topHatId?: string;
+    chain?: string;
+    showDeployTx?: boolean;
+  }
+
+  let { providerPayload = undefined, topHatId = '', chain = undefined, showDeployTx = true }: Props = $props();
 
   function shortAddr(addr: string): string {
     const a = addr.trim();
@@ -27,12 +31,12 @@
     return hatsTreeDomain(id) ?? prettyHatId(id) ?? id.trim();
   }
 
-  $: chainId = parseSupportedChainId(chain);
-  $: chainIdNumeric = SUPPORTED_CHAINS[chainId].id;
-  $: explorerLabel = explorerTxLinkLabel(chainId);
-  $: rows = pactoGovDeployAnnounceRows({ providerPayload, topHatId });
-  $: txHash = showDeployTx ? txHashFromPactoGovProviderPayload(providerPayload) : '';
-  $: explorerTxUrl = txHash ? getExplorerTxUrl(chainId, txHash) : null;
+  let chainId = $derived(parseSupportedChainId(chain));
+  let chainIdNumeric = $derived(SUPPORTED_CHAINS[chainId].id);
+  let explorerLabel = $derived(explorerTxLinkLabel(chainId));
+  let rows = $derived(pactoGovDeployAnnounceRows({ providerPayload, topHatId }));
+  let txHash = $derived(showDeployTx ? txHashFromPactoGovProviderPayload(providerPayload) : '');
+  let explorerTxUrl = $derived(txHash ? getExplorerTxUrl(chainId, txHash) : null);
 </script>
 
 {#if rows.length > 0}


### PR DESCRIPTION
## Summary

Converts the governance actions/proposals surface (`GovCaptainActions`, `GovCrewActions`, `PactoGovGovernanceShell`, `GovProcessCard`, `GovProposalsBoard`, `PactoGovInfraList`, `GovProposeForm`, `GovCtaButton`) from Svelte 4 legacy reactivity (`export let` / `$:`) to Svelte 5 runes, as part of the [Svelte 5 runes migration epic](../issues).

Along the way this closes a real correctness gap: capability-preflight loading raced against rendering. `PactoGovGovernanceShell` starts with `capabilities: null` and only populates it after an async `get_squad_capabilities` round-trip. Before this change, the privilege resolver's null-capabilities fallback derives permission purely from the hat-wearer lists already passed as props — so a captain/crew hat-holder whose *ACL* would actually deny the action (paused squad, threshold not met, explicit deny) could see the button render **enabled** for one paint, then flip to **disabled** once the real capability snapshot landed. For destructive actions (approve/veto proposals, execute, quartermaster roster mutations, mutiny, treasury propose) that's an availability flash a user could click through.

Fixed by adding an explicit `capabilitiesStatus: 'unresolved' | 'ready' | 'error'` state distinct from "denied." Every gate that used to read privilege directly now short-circuits to a shared "loading" gate while `capabilitiesStatus === 'unresolved'`, so the button renders unavailable with a "Loading…" reason until the preflight actually resolves — it can only go loading -> enabled or loading -> denied, never enabled -> denied.

## Changes

- Standard runes conversion (props -> `$derived` -> `$effect`) across all 8 files, following the KTD3 triage rubric: pure lookups became `$derived`; sentinel-guarded default-selection blocks (`voteProposalId`/`execProposalId`/`qmAddress` fallbacks, cache-key hydration blocks) became guarded `$effect`s with the sentinel write kept inside the guard; the crew-timelock unlock timer became an `$effect` with a returned cleanup function, replacing the old manual `clearUnlockTimer`/`onDestroy` pair.
- New `capabilitiesPending` boolean threaded from `PactoGovGovernanceShell` through `GovCaptainActions`/`GovCrewActions`/`GovProposalsBoard` into `GovProposeForm`; each destructive gate (`captainGate`, `qmGate`, `execGate`, `bootstrapGate`, `crewGate`, `qmExecGate`, `proposeGate`) forces a shared `{ enabled: false, reason: 'governance.status.loading' }` while pending, reusing the existing `governance.status.loading` i18n string (no new copy).
- Removed `PactoGovGovernanceShell`'s `onMount` capability-load call, which duplicated the reactive load effect and caused a redundant fetch on every mount (`$effect` runs after mount too, so the reactive effect alone now covers the initial load).
- No changes to `src/stores/` (still `svelte/store`), the three god shells, or any file outside this batch.

## Test plan

- `pnpm check` — 0 errors.
- `pnpm lint` — 0 problems.
- `pnpm test` — full suite green (241 files / 2188 tests). One pre-existing, unrelated `dialog-content.test.ts` teardown-timing flake (`document is not defined` in a bits-ui `setTimeout` firing after jsdom teardown) reproduced only under the full-suite run and disappeared on a second full run and in isolation — confirmed not caused by this change (no files in this PR are touched by or touch that test).
- Added `PactoGovGovernanceShell.test.ts` (jsdom, `@testing-library/svelte`) covering the capability-preflight gate directly, per R20:
  1. Propose action renders disabled with "Loading…" while `get_squad_capabilities` is in flight, then enables once it resolves for a captain.
  2. Propose action never flips available -> denied: stays disabled the whole time, going straight from "Loading…" to the ACL-denied reason once the backend returns an explicit deny.
  3. A member with neither captain nor crew hats sees the propose action disabled with the "requires Captain or Crew hat" reason once the preflight settles (network error -> hat-based fallback).
- Manual/code-read verification (no testnet access from this environment): `govWriteErrorMessage`/`getInvokeErrorMessage` (unmodified, existing helpers) only ever surface a `message`/`error` string extracted from the invoke rejection — none of the code paths touched in this PR construct or forward an RPC URL into a toast, confirming write-failure toasts stay leak-free.

## Follow-up for reviewer

- Testnet/live-wallet manual QA (captain vs crew role switching against a real deployed squad) was not exercised in this sandboxed environment — recommend a manual pass before merge if that's part of your release process.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Closes pacto-app-a7r.18