### PR TITLE
refactor: migrate auth/backup/squad/profile/inbox/updater components to svelte 5 runes

### DIFF
--- a/src/components/auth/KeyImport.svelte
+++ b/src/components/auth/KeyImport.svelte
@@ -2,15 +2,22 @@
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store';
 
-  export let onImport: (privateKey: string) => void;
-  export let onBack: () => void;
-  export let isValidating: boolean = false;
-  export let error: string | null = null;
+  let {
+    onImport,
+    onBack,
+    isValidating = false,
+    error = null,
+  }: {
+    onImport: (privateKey: string) => void;
+    onBack: () => void;
+    isValidating?: boolean;
+    error?: string | null;
+  } = $props();
 
-  let privateKey = '';
-  let localError: string | null = null;
+  let privateKey = $state('');
+  let localError: string | null = $state(null);
 
-  $: displayError = localError || error;
+  let displayError = $derived(localError || error);
 
   function handleSubmit() {
     const trimmed = privateKey.trim();
@@ -43,7 +50,8 @@
   }
 
   // Clear errors when user starts typing
-  $: if (privateKey) {
+  function clearErrorsOnInput() {
+    if (!privateKey) return;
     localError = null;
     if (error) {
       error = null;
@@ -67,6 +75,7 @@
     <div class="import-form">
       <textarea
         bind:value={privateKey}
+        oninput={clearErrorsOnInput}
         onpaste={handlePaste}
         placeholder={$t('auth.recoveryPhrasePlaceholder')}
         disabled={isValidating}

--- a/src/components/auth/Login.svelte
+++ b/src/components/auth/Login.svelte
@@ -11,13 +11,13 @@
 
   type AuthStep = 'checking' | 'welcome' | 'import' | 'pin-create' | 'pin-confirm' | 'pin-unlock';
 
-  let currentStep: AuthStep = 'checking';
-  let privateKey: string = '';
-  let firstPin: string = '';
-  let error: string | null = null;
-  let unlockInFlight = false;
+  let currentStep: AuthStep = $state('checking');
+  let privateKey: string = $state('');
+  let firstPin: string = $state('');
+  let error: string | null = $state(null);
+  let unlockInFlight = $state(false);
 
-  $: pinDigitCount = $appConfig.pinDigitCount;
+  let pinDigitCount = $derived($appConfig.pinDigitCount);
 
   // Check if user has stored encrypted key on mount, and confirm backend session state.
   onMount(async () => {

--- a/src/components/auth/PinInput.svelte
+++ b/src/components/auth/PinInput.svelte
@@ -2,18 +2,28 @@
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
 
-  export let title: string;
-  export let onComplete: (pin: string) => void;
-  export let isProcessing: boolean = false;
-  export let error: string | null = null;
-  export let onErrorClear: (() => void) | undefined = undefined;
-  export let onBack: (() => void) | undefined = undefined;
-  export let pinDigitCount: number = 6;
+  let {
+    title,
+    onComplete,
+    isProcessing = false,
+    error = null,
+    onErrorClear = undefined,
+    onBack = undefined,
+    pinDigitCount = 6,
+  }: {
+    title: string;
+    onComplete: (pin: string) => void;
+    isProcessing?: boolean;
+    error?: string | null;
+    onErrorClear?: (() => void) | undefined;
+    onBack?: (() => void) | undefined;
+    pinDigitCount?: number;
+  } = $props();
 
-  let digits: string[] = Array(pinDigitCount).fill('');
-  let inputs: HTMLInputElement[] = [];
-  let isShaking = false;
-  let lastClearedForError: string | null = null;
+  let digits: string[] = $state(Array(pinDigitCount).fill(''));
+  let inputs: HTMLInputElement[] = $state([]);
+  let isShaking = $state(false);
+  let lastClearedForError: string | null = $state(null);
 
   function clearInputs() {
     digits = Array(pinDigitCount).fill('');
@@ -89,15 +99,15 @@
     inputs[0]?.focus();
   });
 
-  $: if (error && error !== lastClearedForError && digits.every((d) => d !== '')) {
-    lastClearedForError = error;
-    clearInputs();
-    triggerShake();
-  }
-
-  $: if (!error) {
-    lastClearedForError = null;
-  }
+  $effect(() => {
+    if (error && error !== lastClearedForError && digits.every((d) => d !== '')) {
+      lastClearedForError = error;
+      clearInputs();
+      triggerShake();
+    } else if (!error) {
+      lastClearedForError = null;
+    }
+  });
 </script>
 
 <div class="pin-input-container">

--- a/src/components/auth/PinInput.test.ts
+++ b/src/components/auth/PinInput.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import PinInput from './PinInput.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+function digitInput(n: number): HTMLInputElement {
+  return screen.getByLabelText(`PIN digit ${n}`) as HTMLInputElement;
+}
+
+describe('PinInput', () => {
+  it('advances focus per digit and fires completion exactly once on the final digit', async () => {
+    const onComplete = vi.fn();
+    render(PinInput, { title: 'Enter your PIN', onComplete, pinDigitCount: 4 });
+
+    await fireEvent.input(digitInput(1), { target: { value: '1' } });
+    expect(document.activeElement).toBe(digitInput(2));
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await fireEvent.input(digitInput(2), { target: { value: '2' } });
+    expect(document.activeElement).toBe(digitInput(3));
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await fireEvent.input(digitInput(3), { target: { value: '3' } });
+    expect(document.activeElement).toBe(digitInput(4));
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await fireEvent.input(digitInput(4), { target: { value: '4' } });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith('1234');
+  });
+
+  it('clears every digit exactly once when a new incorrect-PIN error arrives, without looping', async () => {
+    const onComplete = vi.fn();
+    const { rerender } = render(PinInput, {
+      title: 'Enter your PIN',
+      onComplete,
+      pinDigitCount: 4,
+      error: null,
+    });
+
+    for (let i = 1; i <= 4; i++) {
+      await fireEvent.input(digitInput(i), { target: { value: String(i) } });
+    }
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    for (let i = 1; i <= 4; i++) {
+      expect(digitInput(i).value).toBe(String(i));
+    }
+
+    // Parent surfaces an incorrect-PIN error after the failed unlock attempt.
+    await rerender({ title: 'Enter your PIN', onComplete, pinDigitCount: 4, error: 'Incorrect PIN' });
+
+    await waitFor(() => {
+      for (let i = 1; i <= 4; i++) {
+        expect(digitInput(i).value).toBe('');
+      }
+    });
+    expect(screen.getByRole('alert').textContent).toBe('Incorrect PIN');
+
+    // Re-rendering with the *same* error must not re-clear or re-shake (sentinel guard).
+    const container = screen.getByRole('alert').closest('.pin-input-container') as HTMLElement;
+    const pinInputsEl = container.querySelector('.pin-inputs') as HTMLElement;
+    await waitFor(() => expect(pinInputsEl.classList.contains('shake')).toBe(false));
+
+    await rerender({ title: 'Enter your PIN', onComplete, pinDigitCount: 4, error: 'Incorrect PIN' });
+    expect(pinInputsEl.classList.contains('shake')).toBe(false);
+    for (let i = 1; i <= 4; i++) {
+      expect(digitInput(i).value).toBe('');
+    }
+  });
+});

--- a/src/components/auth/WelcomeScreen.svelte
+++ b/src/components/auth/WelcomeScreen.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
 
-  export let onCreateAccount: () => void;
-  export let onImportKeys: () => void;
+  let { onCreateAccount, onImportKeys }: { onCreateAccount: () => void; onImportKeys: () => void } = $props();
 </script>
 
 <div class="welcome-container">

--- a/src/components/backup/BackupBanner.svelte
+++ b/src/components/backup/BackupBanner.svelte
@@ -6,7 +6,7 @@
     backupVerificationModalOpen,
   } from '../../stores/backup-verification';
 
-  let dismissed = false;
+  let dismissed = $state(false);
 </script>
 
 {#if $backupVerified === false && $isAuthenticated && !dismissed}

--- a/src/components/backup/BackupVerificationModal.svelte
+++ b/src/components/backup/BackupVerificationModal.svelte
@@ -11,8 +11,7 @@
   import type { SeedChallenge } from '../../lib/utils/seed-verification';
   import { markBackupVerified, backupVerificationModalOpen } from '../../stores/backup-verification';
 
-  export let open = false;
-  export let onClose: () => void = () => {};
+  let { open = false, onClose = () => {} }: { open?: boolean; onClose?: () => void } = $props();
 
   type Phase = 'show' | 'confirm' | 'quiz' | 'success';
 
@@ -21,19 +20,19 @@
   const MAX_ATTEMPTS = 3;
   const tFn = get(t);
 
-  let phase: Phase = 'show';
-  let seed = '';
-  let seedWords: string[] = [];
-  let revealed = false;
-  let copied = false;
-  let writtenDown = false;
-  let challenge: SeedChallenge = { positions: [], answers: [] };
-  let inputs: string[] = [];
-  let attempts = 0;
-  let quizError = '';
-  let busy = false;
-  let loadError = '';
-  let inputEls: HTMLInputElement[] = [];
+  let phase: Phase = $state('show');
+  let seed = $state('');
+  let seedWords: string[] = $state([]);
+  let revealed = $state(false);
+  let copied = $state(false);
+  let writtenDown = $state(false);
+  let challenge: SeedChallenge = $state({ positions: [], answers: [] });
+  let inputs: string[] = $state([]);
+  let attempts = $state(0);
+  let quizError = $state('');
+  let busy = $state(false);
+  let loadError = $state('');
+  let inputEls: HTMLInputElement[] = $state([]);
 
   function resetState(): void {
     phase = 'show';
@@ -74,13 +73,13 @@
     }
   }
 
-  $: {
+  $effect(() => {
     if (open) {
       void loadSeed();
-    } else if (!open) {
+    } else {
       resetState();
     }
-  }
+  });
 
   function toggleReveal(): void {
     revealed = !revealed;

--- a/src/components/backup/BackupVerificationModal.test.ts
+++ b/src/components/backup/BackupVerificationModal.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import BackupVerificationModal from './BackupVerificationModal.svelte';
+import { exportRecoveryPhrase } from '../../lib/api/auth';
+
+vi.mock('../../lib/api/auth', () => ({
+  exportRecoveryPhrase: vi.fn(),
+}));
+
+const mockedExportRecoveryPhrase = vi.mocked(exportRecoveryPhrase);
+
+const SEED_PHRASE =
+  'abandon ability able about above absent absorb abstract absurd abuse access accident';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BackupVerificationModal', () => {
+  beforeEach(() => {
+    mockedExportRecoveryPhrase.mockReset();
+    mockedExportRecoveryPhrase.mockResolvedValue(SEED_PHRASE);
+  });
+
+  it('reveals the recovery phrase only while open, and only after the user opts in', async () => {
+    const { container } = render(BackupVerificationModal, { open: true, onClose: vi.fn() });
+
+    await waitFor(() => expect(mockedExportRecoveryPhrase).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(container.querySelectorAll('.seed-mask').length).toBe(12));
+
+    // Masked until the user explicitly reveals it.
+    expect(screen.queryByText('abandon')).toBeNull();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Show seed phrase' }));
+
+    expect(container.querySelectorAll('.seed-mask').length).toBe(0);
+    expect(screen.getByText('abandon')).toBeTruthy();
+    expect(screen.getByText('accident')).toBeTruthy();
+  });
+
+  it('never fetches the seed while closed, and clears it from the DOM on close', async () => {
+    const { container, rerender } = render(BackupVerificationModal, {
+      open: false,
+      onClose: vi.fn(),
+    });
+
+    expect(mockedExportRecoveryPhrase).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    await rerender({ open: true, onClose: vi.fn() });
+    await waitFor(() => expect(mockedExportRecoveryPhrase).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(container.querySelectorAll('.seed-mask').length).toBe(12));
+
+    await rerender({ open: false, onClose: vi.fn() });
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    // Reopening re-fetches rather than reusing state left over from the prior reveal.
+    await rerender({ open: true, onClose: vi.fn() });
+    await waitFor(() => expect(mockedExportRecoveryPhrase).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('abandon')).toBeNull();
+  });
+});

--- a/src/components/inbox/SquadRosterKeyInboxCard.svelte
+++ b/src/components/inbox/SquadRosterKeyInboxCard.svelte
@@ -9,11 +9,17 @@
   import { setPersonalAlertNeeded } from '../../stores/squad-hub-alerts';
   import { showToast } from '../../stores/toast';
 
-  export let parentId: string;
-  export let announcementsGroupId: string;
-  export let onComplete: () => void = () => {};
+  let {
+    parentId,
+    announcementsGroupId,
+    onComplete = () => {},
+  }: {
+    parentId: string;
+    announcementsGroupId: string;
+    onComplete?: () => void;
+  } = $props();
 
-  let busy: 'default' | 'new' | null = null;
+  let busy: 'default' | 'new' | null = $state(null);
 
   async function useDefault(): Promise<void> {
     if (busy) return;

--- a/src/components/profile/Profile.svelte
+++ b/src/components/profile/Profile.svelte
@@ -15,7 +15,7 @@
     $activeView = 'hub';
   }
 
-  $: userNpub = $currentUser?.npub || '';
+  let userNpub = $derived($currentUser?.npub || '');
 </script>
 
 <div class="profile-view">

--- a/src/components/squad/PairWithSquadModal.svelte
+++ b/src/components/squad/PairWithSquadModal.svelte
@@ -8,41 +8,53 @@
   import type { SquadVisibility } from '../../stores/squads';
   import { appConfig } from '../../stores/app-config';
 
-  export let open = false;
-  export let anchorSquadName = '';
-  export let candidates: Squad[] = [];
-  export let error = '';
-  export let creating = false;
+  let {
+    open = false,
+    anchorSquadName = '',
+    candidates = [],
+    error = '',
+    creating = false,
+    onClose = () => {},
+    onCreate = () => {},
+  }: {
+    open?: boolean;
+    anchorSquadName?: string;
+    candidates?: Squad[];
+    error?: string;
+    creating?: boolean;
+    onClose?: () => void;
+    onCreate?: (params: {
+      name: string;
+      partnerSquadId: string;
+      iconUrl?: string;
+      visibility: SquadVisibility;
+      commonsTags?: string[];
+    }) => void;
+  } = $props();
 
-  export let onClose: () => void = () => {};
-  export let onCreate: (params: {
-    name: string;
-    partnerSquadId: string;
-    iconUrl?: string;
-    visibility: SquadVisibility;
-    commonsTags?: string[];
-  }) => void = () => {};
+  let pairName = $state('');
+  let iconUrl = $state('');
+  let selectedPartnerSquadId = $state('');
+  let visibility = $state<SquadVisibility>('private');
+  let tags: string[] = $state([]);
+  let tagError = $state('');
+  let commonsFields = $state<SquadCommonsVisibilityFields>();
 
-  let pairName = '';
-  let iconUrl = '';
-  let selectedPartnerSquadId = '';
-  let visibility: SquadVisibility = 'private';
-  let tags: string[] = [];
-  let tagError = '';
-  let commonsFields: SquadCommonsVisibilityFields;
+  let maxCommonsTags = $derived($appConfig.commonsMaxTags);
 
-  $: maxCommonsTags = $appConfig.commonsMaxTags;
-
-  $: canCreate =
+  let canCreate = $derived(
     pairName.trim().length > 0 &&
-    !!selectedPartnerSquadId &&
-    candidates.length > 0 &&
-    !creating &&
-    (visibility !== 'public' || tags.length === maxCommonsTags);
+      !!selectedPartnerSquadId &&
+      candidates.length > 0 &&
+      !creating &&
+      (visibility !== 'public' || tags.length === maxCommonsTags)
+  );
 
-  $: if (open) {
-    setTimeout(() => document.getElementById('squad-pair-name')?.focus(), 0);
-  }
+  $effect(() => {
+    if (open) {
+      setTimeout(() => document.getElementById('squad-pair-name')?.focus(), 0);
+    }
+  });
 
   function selectPartner(squadId: string) {
     selectedPartnerSquadId = squadId;

--- a/src/components/squad/SquadCommonsVisibilityFields.svelte
+++ b/src/components/squad/SquadCommonsVisibilityFields.svelte
@@ -3,11 +3,19 @@
   import CommonsTagPicker from '../commons/CommonsTagPicker.svelte';
   import type { SquadVisibility } from '../../stores/squads';
 
-  export let visibility: SquadVisibility = 'private';
-  export let tags: string[] = [];
-  export let tagError = '';
-  export let fieldsetName = 'squad-commons';
-  export let disabled = false;
+  let {
+    visibility = $bindable('private'),
+    tags = $bindable([]),
+    tagError = $bindable(''),
+    fieldsetName = 'squad-commons',
+    disabled = false,
+  }: {
+    visibility?: SquadVisibility;
+    tags?: string[];
+    tagError?: string;
+    fieldsetName?: string;
+    disabled?: boolean;
+  } = $props();
 
   export function resetCommonsFields() {
     visibility = 'private';

--- a/src/components/squad/SquadJoinRequestsPanel.svelte
+++ b/src/components/squad/SquadJoinRequestsPanel.svelte
@@ -8,7 +8,6 @@
   import {
     isJoinRequestRespondInFlight,
     joinRequestRespondInFlight,
-    joinRequestRespondInFlightRevision,
     respondToMlsJoinRequest,
   } from '../../lib/squad/squad-join-mls';
   import { muteJoinRequester } from '../../lib/squad/squad-join-spam';
@@ -32,32 +31,36 @@
   import type { Squad } from '../../stores/squads';
   import RefreshIconButton from '../ui/RefreshIconButton.svelte';
 
-  export let squad: Squad;
+  let { squad }: { squad: Squad } = $props();
 
-  let refreshError = '';
+  let refreshError = $state('');
   let profileLoadToken = 0;
-  let botState: SquadBotState | null = null;
-  let botStateLoading = true;
+  let botState = $state<SquadBotState | null>(null);
+  let botStateLoading = $state(true);
 
   const tFn = get(t);
 
-  $: void $joinRequestRespondInFlightRevision;
-  $: anyRespondInFlight = $joinRequestRespondInFlight.size > 0;
-  $: requests = $pendingJoinRequestsBySquadId[squad.id] ?? [];
-  $: hydrated = $joinRequestsHydratedBySquadId[squad.id] ?? false;
-  $: syncing = $joinRequestsSyncingBySquadId[squad.id] ?? false;
-  $: loadError = $joinRequestsErrorBySquadId[squad.id] ?? refreshError;
-  $: loading = (!hydrated && syncing) || botStateLoading;
-  $: canAct = !!(botState?.iAmHolder && botState?.hasLocalSecret);
-  $: admitting = listPendingAdmitForParent(squad.id).filter((e) => e.kind === 'join');
-  $: void $pendingAdmitQueue;
+  let anyRespondInFlight = $derived($joinRequestRespondInFlight.size > 0);
+  let requests = $derived($pendingJoinRequestsBySquadId[squad.id] ?? []);
+  let hydrated = $derived($joinRequestsHydratedBySquadId[squad.id] ?? false);
+  let syncing = $derived($joinRequestsSyncingBySquadId[squad.id] ?? false);
+  let loadError = $derived($joinRequestsErrorBySquadId[squad.id] ?? refreshError);
+  let loading = $derived((!hydrated && syncing) || botStateLoading);
+  let canAct = $derived(!!(botState?.iAmHolder && botState?.hasLocalSecret));
+  let admitting = $derived.by(() => {
+    void $pendingAdmitQueue;
+    return listPendingAdmitForParent(squad.id).filter((e) => e.kind === 'join');
+  });
 
-  $: if (squad?.id) {
-    void ensureJoinRequestsHydrated(squad.id);
-    void loadBotState(squad.id);
-  }
+  $effect(() => {
+    if (squad?.id) {
+      void ensureJoinRequestsHydrated(squad.id);
+      void loadBotState(squad.id);
+    }
+  });
 
-  $: if (requests.length > 0 || admitting.length > 0) {
+  $effect(() => {
+    if (requests.length === 0 && admitting.length === 0) return;
     const token = ++profileLoadToken;
     const npubs = [
       ...new Set([
@@ -68,7 +71,7 @@
     void Promise.all(npubs.map((npub) => loadProfile(npub))).then(() => {
       if (token !== profileLoadToken) return;
     });
-  }
+  });
 
   async function loadBotState(squadId: string) {
     botStateLoading = true;
@@ -228,7 +231,7 @@
                 disabled={anyRespondInFlight}
                 onclick={() => handleReject(request)}
               >
-                {isJoinRequestRespondInFlight(request.eventId)
+                {$joinRequestRespondInFlight.has(request.eventId)
                   ? $t('squad.joinRequests.working')
                   : $t('squad.joinRequests.reject')}
               </button>
@@ -238,7 +241,7 @@
                 disabled={anyRespondInFlight}
                 onclick={() => handleAccept(request)}
               >
-                {isJoinRequestRespondInFlight(request.eventId)
+                {$joinRequestRespondInFlight.has(request.eventId)
                   ? $t('squad.joinRequests.working')
                   : $t('squad.joinRequests.accept')}
               </button>

--- a/src/components/updater/UpdateAvailableModal.svelte
+++ b/src/components/updater/UpdateAvailableModal.svelte
@@ -3,19 +3,21 @@
   import UpdateAvailablePanel from './UpdateAvailablePanel.svelte';
   import { updateStatus } from '../../lib/updater/update-check';
 
-  $: open =
+  let open = $derived(
     $updateStatus.status === 'available' ||
-    $updateStatus.status === 'downloading' ||
-    $updateStatus.status === 'installing' ||
-    $updateStatus.status === 'installed' ||
-    $updateStatus.status === 'error';
+      $updateStatus.status === 'downloading' ||
+      $updateStatus.status === 'installing' ||
+      $updateStatus.status === 'installed' ||
+      $updateStatus.status === 'error'
+  );
 
-  $: title =
+  let title = $derived(
     $updateStatus.status === 'error'
       ? 'Update check failed'
       : $updateStatus.status === 'installed'
         ? 'Update installed'
-        : 'Update available';
+        : 'Update available'
+  );
 
   function closeModal(): void {
     const status = $updateStatus.status;

--- a/src/components/updater/UpdateAvailablePanel.svelte
+++ b/src/components/updater/UpdateAvailablePanel.svelte
@@ -11,7 +11,7 @@
 
   const tFn = get(t);
 
-  $: state = $updateStatus;
+  let state = $derived($updateStatus);
 
   function progressPercent(progress: number): string {
     return `${Math.round(progress * 100)}%`;


### PR DESCRIPTION
## Summary

Converts 13 small-to-mid Svelte components (auth, backup, squad, profile, inbox, updater) to Svelte 5 runes mode, part of the broader runes migration epic. No user-facing behavior changes are intended -- this is a like-for-like conversion of `export let`/reactive-statement/store-hack reactivity to `$props()`/`$derived`/`$effect`, done file-by-file with the props -> computed -> effects -> slots ordering.

Before this change, these files mixed Svelte 4 legacy syntax with the rest of the app's ongoing runes migration. After this change, they're fully runes-mode and none imports from `svelte/legacy`.

## Changes

- **auth/**: `Login`, `WelcomeScreen`, `KeyImport`, `PinInput` -- props to `$props()`, local state to `$state`, derived `$appConfig.pinDigitCount` reads to `$derived`. `KeyImport`'s error-clearing reactive block (which only ever reacted to the textarea's own input) moved into an `oninput` handler instead of a bare effect. `PinInput`'s two reactive blocks (a classic write-what-you-read sentinel guard clearing digits/shaking on a new error) became one sentinel-guarded `$effect`, with the sentinel write kept inside the guard to avoid a loop.
- **backup/**: `BackupBanner` (trivial `$state`), `BackupVerificationModal` -- the `open`-driven load/reset block became a plain `$effect` since it's genuine external sync (loading the recovery phrase from the backend when the modal opens, resetting when it closes).
- **squad/**: `SquadJoinRequestsPanel`, `PairWithSquadModal`, `SquadCommonsVisibilityFields`. `SquadCommonsVisibilityFields`'s `visibility`/`tags`/`tagError` props are now `$bindable()` to support the two-way `bind:` wiring `PairWithSquadModal` already relied on. `SquadJoinRequestsPanel` dropped a Svelte 4 store-revision-subscription hack that existed purely to force re-renders of a per-item "is this request in flight" check; the markup now reads the reactive store directly (`$joinRequestRespondInFlight.has(...)`), which is the correct fine-grained-reactivity idiom under runes and removes an otherwise-dead import.
- **profile/Profile**, **inbox/SquadRosterKeyInboxCard**, **updater/UpdateAvailablePanel**, **updater/UpdateAvailableModal** -- straightforward prop/derived conversions, no side effects to triage.
- Fixed two `bind:this={arr[i]}` patterns (`PinInput.inputs`, `BackupVerificationModal.inputEls`) to use `$state` arrays -- Svelte 5 warns (`binding_property_non_reactive`) without it, even though these are just DOM-ref arrays used imperatively.

## Test plan

- `pnpm check` -- 0 errors (one pre-existing-shape informational warning on `PinInput`'s one-time `pinDigitCount` capture, matching original Svelte 4 non-reactive init behavior; not a bug).
- `pnpm lint` -- 0 problems.
- `pnpm test` -- full suite green (242 files / 2189 tests, including 2 new files).
- Added jsdom component tests for the two `$effect` conversions that gate sensitive flows per the migration's test-coverage rule:
  - `BackupVerificationModal.test.ts` -- the recovery-phrase reveal effect: phrase is fetched and masked only while `open`, never fetched while closed, and cleared from the DOM (not left revealed) when the modal closes.
  - `PinInput.test.ts` -- focus advances per digit, `onComplete` fires exactly once on the final digit, and the sentinel-guarded effect clears/shakes exactly once per new error without looping on repeated renders with the same error.
- Manually reasoned through (not executable in this environment): log out/in flow via `Login.svelte`'s step machine, squad pairing modal's `$bindable()` wiring end-to-end, and the roster-key inbox card's render path -- all unchanged in logic, only prop/state syntax changed.

## Manual QA follow-up for reviewer

- Recommend an interactive click-through of the login -> PIN create/confirm -> unlock flow and the squad pairing modal (with commons visibility toggle) in a running dev build, since this environment can't drive the full Tauri app.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Closes pacto-app-a7r.10
