### PR TITLE
refactor(pacto-app-a7r.20): convert layout navbar/sidebar to svelte 5 runes

### DIFF
--- a/src/components/layout/Navbar.svelte
+++ b/src/components/layout/Navbar.svelte
@@ -72,19 +72,19 @@
   import { warnSkippedMembers, skippedMembersNotice } from '../../lib/squad/skipped-members';
 
   const translate = get(t);
-  $: orderedSquads = orderSquads($squads, $squadNavOrder);
+  let orderedSquads = $derived(orderSquads($squads, $squadNavOrder));
 
   const SQUAD_DRAG_THRESHOLD_PX = 6;
-  let squadRailEl: HTMLDivElement | null = null;
-  let squadDragFromId: string | null = null;
+  let squadRailEl = $state<HTMLDivElement | null>(null);
+  let squadDragFromId: string | null = $state(null);
   /** Visual gap index in `orderedSquads` (0 = before first, length = after last). */
-  let squadDropGapIndex: number | null = null;
+  let squadDropGapIndex: number | null = $state(null);
   let squadDragMoved = false;
   let squadDropApplied = false;
   let squadPointerId: number | null = null;
   let squadPointerStartY = 0;
   let squadPendingDragId: string | null = null;
-  let squadGhost: { x: number; y: number; name: string; image: string } | null = null;
+  let squadGhost: { x: number; y: number; name: string; image: string } | null = $state(null);
   let squadWindowListenersBound = false;
 
   function selectSquad(squadId: string) {
@@ -279,37 +279,40 @@
     squads: 'nav.navbar.addButton.squads',
     catchup: '',
   };
-  $: addButtonLabel = showAddButton ? $t(addButtonLabelKeys[$activeTopNavTab]) : '';
-  $: showAddButton =
-    $activeTopNavTab === 'commons' || $activeTopNavTab === 'dms' || $activeTopNavTab === 'squads';
-  $: maxSquadNameLength = $appConfig.squadNameMaxLength;
+  let showAddButton = $derived(
+    $activeTopNavTab === 'commons' || $activeTopNavTab === 'dms' || $activeTopNavTab === 'squads'
+  );
+  let addButtonLabel = $derived(showAddButton ? $t(addButtonLabelKeys[$activeTopNavTab]) : '');
+  let maxSquadNameLength = $derived($appConfig.squadNameMaxLength);
 
-  $: commonsStartBroadcastDisabled =
-    $activeTopNavTab === 'commons' && $commonsUserHasActiveBroadcast;
-  $: commonsAddButtonLabel = commonsStartBroadcastDisabled
-    ? $t('nav.navbar.addButton.broadcastActive')
-    : addButtonLabel;
+  let commonsStartBroadcastDisabled = $derived(
+    $activeTopNavTab === 'commons' && $commonsUserHasActiveBroadcast
+  );
+  let commonsAddButtonLabel = $derived(
+    commonsStartBroadcastDisabled ? $t('nav.navbar.addButton.broadcastActive') : addButtonLabel
+  );
 
-  let commonsActiveBroadcastSyncKey = '';
-  $: {
-    const npub = $activeTopNavTab === 'commons' ? ($currentUser?.npub ?? '') : '';
+  let commonsActiveBroadcastSyncKey = $state('');
+  let commonsBroadcastNpub = $derived($activeTopNavTab === 'commons' ? ($currentUser?.npub ?? '') : '');
+  $effect(() => {
+    const npub = commonsBroadcastNpub;
     if (npub && npub !== commonsActiveBroadcastSyncKey) {
       commonsActiveBroadcastSyncKey = npub;
       void syncCommonsUserActiveBroadcast(npub);
     }
     if (!npub) commonsActiveBroadcastSyncKey = '';
-  }
+  });
 
-  let showOrganizeSquadModal = false;
-  let organizeSquadName = '';
-  let organizeSquadIconUrl = '';
-  let organizeSquadMembers: string[] = [];
-  let organizeSquadError = '';
-  let organizeSquadVisibility: SquadVisibility = 'private';
-  let organizeSquadTags: string[] = [];
-  let organizeSquadTagError = '';
-  let organizeSquadNetwork: SupportedChainId | '' = DEFAULT_CHAIN_ID;
-  let commonsFields: SquadCommonsVisibilityFields;
+  let showOrganizeSquadModal = $state(false);
+  let organizeSquadName = $state('');
+  let organizeSquadIconUrl = $state('');
+  let organizeSquadMembers: string[] = $state([]);
+  let organizeSquadError = $state('');
+  let organizeSquadVisibility = $state<SquadVisibility>('private');
+  let organizeSquadTags: string[] = $state([]);
+  let organizeSquadTagError = $state('');
+  let organizeSquadNetwork = $state<SupportedChainId | ''>(DEFAULT_CHAIN_ID);
+  let commonsFields: SquadCommonsVisibilityFields | undefined = $state();
 
   const squadNetworkOptions = listSquadDeployNetworkOptions();
 
@@ -325,6 +328,7 @@
     organizeSquadTagError = '';
     organizeSquadNetwork = DEFAULT_CHAIN_ID;
     commonsFields?.resetCommonsFields();
+    setTimeout(() => document.getElementById('squad-name')?.focus(), 0);
   }
 
   function closeOrganizeSquadModal() {
@@ -528,43 +532,42 @@
     if ($activeTopNavTab === 'squads') openOrganizeSquadModal();
   }
 
-  $: canCreateSquad =
+  let canCreateSquad = $derived(
     organizeSquadName.trim().length > 0 &&
     organizeSquadMembers.length > 0 &&
-    (organizeSquadVisibility !== 'public' || organizeSquadTags.length === 3);
-  $: organizeMemberList = [...$pinnedList, ...$dmList];
+    (organizeSquadVisibility !== 'public' || organizeSquadTags.length === 3)
+  );
+  let organizeMemberList = $derived([...$pinnedList, ...$dmList]);
 
-  $: organizeSquadTitle = $t('nav.navbar.organizeSquad.title');
-  $: organizeSquadDescription = $t('nav.navbar.organizeSquad.description');
-  $: squadNameLabel = $t('nav.navbar.organizeSquad.nameLabel');
-  $: squadNamePlaceholder = $t('nav.navbar.organizeSquad.namePlaceholder');
-  $: iconUrlLabel = $t('nav.navbar.organizeSquad.iconLabel');
-  $: organizeMembersLabel = $t('nav.navbar.organizeSquad.membersLabel');
-  $: organizeMembersEmpty = $t('nav.navbar.organizeSquad.membersEmpty');
-  $: organizeNetworkLabel = $t('nav.navbar.organizeSquad.networkLabel');
-  $: organizeNetworkNone = $t('nav.navbar.organizeSquad.networkNone');
-  $: organizeCancel = $t('nav.navbar.organizeSquad.cancel');
-  $: organizeCreate = $t('nav.navbar.organizeSquad.create');
-  $: organizeCreateAria = $t('nav.navbar.organizeSquad.createAria');
+  let organizeSquadTitle = $derived($t('nav.navbar.organizeSquad.title'));
+  let organizeSquadDescription = $derived($t('nav.navbar.organizeSquad.description'));
+  let squadNameLabel = $derived($t('nav.navbar.organizeSquad.nameLabel'));
+  let squadNamePlaceholder = $derived($t('nav.navbar.organizeSquad.namePlaceholder'));
+  let iconUrlLabel = $derived($t('nav.navbar.organizeSquad.iconLabel'));
+  let organizeMembersLabel = $derived($t('nav.navbar.organizeSquad.membersLabel'));
+  let organizeMembersEmpty = $derived($t('nav.navbar.organizeSquad.membersEmpty'));
+  let organizeNetworkLabel = $derived($t('nav.navbar.organizeSquad.networkLabel'));
+  let organizeNetworkNone = $derived($t('nav.navbar.organizeSquad.networkNone'));
+  let organizeCancel = $derived($t('nav.navbar.organizeSquad.cancel'));
+  let organizeCreate = $derived($t('nav.navbar.organizeSquad.create'));
+  let organizeCreateAria = $derived($t('nav.navbar.organizeSquad.createAria'));
 
-  $: pinnedTabLabel = $t('nav.navbar.dmTabs.pinned');
-  $: friendsTabLabel = $t('nav.navbar.dmTabs.friends');
-  $: requestsTabLabel = $t('nav.navbar.dmTabs.requests');
-  $: pendingTabLabel = $t('nav.navbar.dmTabs.pending');
-  $: searchTabLabel = $t('nav.navbar.dmTabs.search');
-  $: settingsTabLabel = $t('nav.navbar.settings');
+  let pinnedTabLabel = $derived($t('nav.navbar.dmTabs.pinned'));
+  let friendsTabLabel = $derived($t('nav.navbar.dmTabs.friends'));
+  let requestsTabLabel = $derived($t('nav.navbar.dmTabs.requests'));
+  let pendingTabLabel = $derived($t('nav.navbar.dmTabs.pending'));
+  let searchTabLabel = $derived($t('nav.navbar.dmTabs.search'));
+  let settingsTabLabel = $derived($t('nav.navbar.settings'));
 
-  $: if (showOrganizeSquadModal) {
-    setTimeout(() => document.getElementById('squad-name')?.focus(), 0);
-  }
-
-  $: if ($squadRecreateRequest) {
-    const prefill = $squadRecreateRequest;
-    squadRecreateRequest.set(null);
-    openOrganizeSquadModal();
-    organizeSquadName = prefill.name;
-    organizeSquadMembers = prefill.memberNpubs;
-  }
+  $effect(() => {
+    if ($squadRecreateRequest) {
+      const prefill = $squadRecreateRequest;
+      squadRecreateRequest.set(null);
+      openOrganizeSquadModal();
+      organizeSquadName = prefill.name;
+      organizeSquadMembers = prefill.memberNpubs;
+    }
+  });
 </script>
 
 <div class="navbar">

--- a/src/components/layout/ParentNavbar.svelte
+++ b/src/components/layout/ParentNavbar.svelte
@@ -70,93 +70,111 @@
 
   const translate = get(t);
 
-  $: activeParent = $squads.find((s) => s.id === $activeSquadId) as Squad | undefined;
+  let activeParent = $derived($squads.find((s) => s.id === $activeSquadId) as Squad | undefined);
 
-  $: if ($activeTopNavTab === 'squads' && $squads.length > 0) {
-    void ensureJoinRequestsHydratedForSquads($squads);
-  }
+  /** First load of pending join requests for every visible squad; hydration is idempotent per squad. */
+  $effect(() => {
+    if ($activeTopNavTab === 'squads' && $squads.length > 0) {
+      void ensureJoinRequestsHydratedForSquads($squads);
+    }
+  });
 
-  $: activeSquadJoinRequestSyncKey =
-    $activeTopNavTab === 'squads' && activeParent ? activeParent.id : '';
-  $: if (activeSquadJoinRequestSyncKey && isJoinRequestsHydrated(activeSquadJoinRequestSyncKey)) {
-    void syncJoinRequestsForSquad(activeSquadJoinRequestSyncKey);
-  }
+  let activeSquadJoinRequestSyncKey = $derived(
+    $activeTopNavTab === 'squads' && activeParent ? activeParent.id : ''
+  );
+  $effect(() => {
+    if (activeSquadJoinRequestSyncKey && isJoinRequestsHydrated(activeSquadJoinRequestSyncKey)) {
+      void syncJoinRequestsForSquad(activeSquadJoinRequestSyncKey);
+    }
+  });
 
-  $: if ($activeTopNavTab === 'squads' && activeParent && $deferredSquadRosterKeyParentIds) {
-    void refreshPersonalAlertForSquad(activeParent);
-    void refreshGovActionPromptsForSquad(activeParent);
-  }
+  $effect(() => {
+    if ($activeTopNavTab === 'squads' && activeParent && $deferredSquadRosterKeyParentIds) {
+      void refreshPersonalAlertForSquad(activeParent);
+      void refreshGovActionPromptsForSquad(activeParent);
+    }
+  });
 
-  $: personalAlertRefreshKey =
+  let personalAlertRefreshKey = $derived(
     $activeTopNavTab === 'squads' && activeParent
       ? `${activeParent.id}:${$activeChannelId ?? ''}:${$activeHubChannelName ?? ''}`
-      : '';
-  $: if (personalAlertRefreshKey && activeParent) {
-    void refreshPersonalAlertForSquad(activeParent);
-    void refreshGovActionPromptsForSquad(activeParent);
-  }
+      : ''
+  );
+  $effect(() => {
+    if (personalAlertRefreshKey && activeParent) {
+      void refreshPersonalAlertForSquad(activeParent);
+      void refreshGovActionPromptsForSquad(activeParent);
+    }
+  });
 
-  $: rawChannels = activeParent
-    ? [...activeParent.channels].sort((a, b) => a.order - b.order)
-    : [];
-  $: channels = activeParent ? buildHubSidebarChannels(rawChannels) : [];
+  let rawChannels = $derived(
+    activeParent ? [...activeParent.channels].sort((a, b) => a.order - b.order) : []
+  );
+  let channels = $derived(activeParent ? buildHubSidebarChannels(rawChannels) : []);
 
-  $: creating =
+  let creating = $derived(
     activeParent &&
-    activeParent.channels.length === 0 &&
-    $parentsCreatingAnnouncements.has(activeParent.id);
+      activeParent.channels.length === 0 &&
+      $parentsCreatingAnnouncements.has(activeParent.id)
+  );
 
-  $: createError = activeParent ? $parentCreateErrorById[activeParent.id] ?? '' : '';
+  let createError = $derived(activeParent ? $parentCreateErrorById[activeParent.id] ?? '' : '');
 
-  $: retryingCreate = !!activeParent && $parentRetryingCreateIds.has(activeParent.id);
+  let retryingCreate = $derived(!!activeParent && $parentRetryingCreateIds.has(activeParent.id));
 
-  $: canRetryCreate =
+  let canRetryCreate = $derived(
     activeParent &&
-    createError &&
-    ($parentPendingCreateMembers[activeParent.id]?.length ?? 0) > 0;
+      createError &&
+      ($parentPendingCreateMembers[activeParent.id]?.length ?? 0) > 0
+  );
 
   /** Discard is destructive: never offer it while a create for this parent is still running. */
-  $: canDiscardCreate = !!activeParent && !!createError && !retryingCreate;
+  let canDiscardCreate = $derived(!!activeParent && !!createError && !retryingCreate);
 
-  $: subheading =
+  let subheading = $derived(
     activeParent &&
-    activeParent.kind === 'squad-pair' &&
-    activeParent.pairedSquads
+      activeParent.kind === 'squad-pair' &&
+      activeParent.pairedSquads
       ? activeParent.pairedSquads.map((s) => s.name).join(', ')
-      : undefined;
+      : undefined
+  );
 
-  $: showPartnerSquadsSection = !!activeParent && !!$activeSquadId;
+  let showPartnerSquadsSection = $derived(!!activeParent && !!$activeSquadId);
 
-  $: partnerSquads =
+  let partnerSquads = $derived(
     showPartnerSquadsSection && $activeSquadId
       ? partnerSquadsForHubParent($squads, $activeSquadId).map((s) => ({ id: s.id, name: s.name }))
-      : [];
+      : []
+  );
 
-  $: pairAnchorSquad =
-    activeParent && showPartnerSquadsSection ? resolvePairAnchorFromHub(activeParent, $squads) : undefined;
+  let pairAnchorSquad = $derived(
+    activeParent && showPartnerSquadsSection ? resolvePairAnchorFromHub(activeParent, $squads) : undefined
+  );
 
-  $: canPairFromHub = !!pairAnchorSquad;
+  let canPairFromHub = $derived(!!pairAnchorSquad);
 
-  $: activePartnerSquadId =
-    activeParent && activeParent.kind === 'squad-pair' ? activeParent.id : null;
+  let activePartnerSquadId = $derived(
+    activeParent && activeParent.kind === 'squad-pair' ? activeParent.id : null
+  );
 
   function selectPartnerSquad(squadPairId: string) {
     activateSquadHub(squadPairId);
   }
 
-  let showPairWithSquadModal = false;
-  let pairCreateError = '';
-  let pairCreating = false;
+  let showPairWithSquadModal = $state(false);
+  let pairCreateError = $state('');
+  let pairCreating = $state(false);
   let pairModal: PairWithSquadModal;
 
-  $: pairPartnerCandidates =
+  let pairPartnerCandidates = $derived(
     pairAnchorSquad && activeParent
       ? partnerSquadCandidates(
           $squads,
           pairAnchorSquad.id,
           pairPartnerExcludeSquadIds(activeParent, pairAnchorSquad)
         )
-      : [];
+      : []
+  );
 
   function openPairWithSquadModal() {
     if (!canPairFromHub || !showPartnerSquadsSection || !canShowParentMenuActions) return;
@@ -220,31 +238,36 @@
     }
   }
 
-  $: emptyMessage = $t('nav.parentNavbar.emptySquad');
+  let emptyMessage = $derived($t('nav.parentNavbar.emptySquad'));
 
-  $: canShowParentMenuActions =
-    !!activeParent && !creating && activeParent.channels.length > 0;
+  let canShowParentMenuActions = $derived(
+    !!activeParent && !creating && activeParent.channels.length > 0
+  );
 
-  $: maxChannelNameLength = $appConfig.channelNameMaxLength;
+  let maxChannelNameLength = $derived($appConfig.channelNameMaxLength);
 
-  $: createChannelSubtitle = $t('nav.parentNavbar.createChannel.subtitle', {
-    values: { squadName: activeParent?.name ?? $t('nav.parentNavbar.thisSquad') },
-  });
-  $: createChannelMembersLabel = $t('nav.parentNavbar.createChannel.membersLabel');
-  $: createChannelEmptyMessage = $t('nav.parentNavbar.createChannel.empty');
-  $: inviteModalTitle = $t('nav.parentNavbar.invite.title');
-  $: inviteModalSubtitle = $t('nav.parentNavbar.invite.subtitle', {
-    values: { squadName: activeParent?.name ?? $t('nav.parentNavbar.thisSquad') },
-  });
-  $: inviteModalEmptyMessage = $t('nav.parentNavbar.invite.empty');
+  let createChannelSubtitle = $derived(
+    $t('nav.parentNavbar.createChannel.subtitle', {
+      values: { squadName: activeParent?.name ?? $t('nav.parentNavbar.thisSquad') },
+    })
+  );
+  let createChannelMembersLabel = $derived($t('nav.parentNavbar.createChannel.membersLabel'));
+  let createChannelEmptyMessage = $derived($t('nav.parentNavbar.createChannel.empty'));
+  let inviteModalTitle = $derived($t('nav.parentNavbar.invite.title'));
+  let inviteModalSubtitle = $derived(
+    $t('nav.parentNavbar.invite.subtitle', {
+      values: { squadName: activeParent?.name ?? $t('nav.parentNavbar.thisSquad') },
+    })
+  );
+  let inviteModalEmptyMessage = $derived($t('nav.parentNavbar.invite.empty'));
 
-  let inviteErrorBanner = '';
-  let createChannelErrorBanner = '';
+  let inviteErrorBanner = $state('');
+  let createChannelErrorBanner = $state('');
 
-  $: errorBanners = [
+  let errorBanners = $derived([
     ...(inviteErrorBanner ? [{ id: 'invite', text: inviteErrorBanner }] : []),
     ...(createChannelErrorBanner ? [{ id: 'createChannel', text: createChannelErrorBanner }] : []),
-  ];
+  ]);
 
   function onDismissBanner(id: string) {
     if (id === 'invite') inviteErrorBanner = '';
@@ -312,14 +335,14 @@
     }
   }
 
-  let showCreateChannelModal = false;
-  let createChannelName = '';
-  let selectedNpubs: string[] = [];
-  let createChannelError = '';
-  let createChannelMemberList: string[] = [];
-  let loadingCreateChannelMembers = false;
-  let showClosedChannelPicker = false;
-  let creatingChannel = false;
+  let showCreateChannelModal = $state(false);
+  let createChannelName = $state('');
+  let selectedNpubs: string[] = $state([]);
+  let createChannelError = $state('');
+  let createChannelMemberList: string[] = $state([]);
+  let loadingCreateChannelMembers = $state(false);
+  let showClosedChannelPicker = $state(false);
+  let creatingChannel = $state(false);
 
   function openCreateChannelModal() {
     showCreateChannelModal = true;
@@ -355,8 +378,9 @@
       : [...selectedNpubs, npub];
   }
 
-  $: canCreateClosedChannel =
-    createChannelName.trim().length > 0 && selectedNpubs.length > 0;
+  let canCreateClosedChannel = $derived(
+    createChannelName.trim().length > 0 && selectedNpubs.length > 0
+  );
 
   function startCreateChannel(access: 'open' | 'closed', members: string[]) {
     const name = createChannelName.trim();
@@ -429,13 +453,13 @@
     return getProfileDisplayName($profiles[npub] ?? null) || npub.slice(0, 16) + '…';
   }
 
-  let showInviteModal = false;
-  let inviteCandidates: string[] = [];
-  let selectedInviteNpubs: string[] = [];
-  let inviteByNpub = '';
-  let loadingInvite = false;
-  let inviteError = '';
-  let inviting = false;
+  let showInviteModal = $state(false);
+  let inviteCandidates: string[] = $state([]);
+  let selectedInviteNpubs: string[] = $state([]);
+  let inviteByNpub = $state('');
+  let loadingInvite = $state(false);
+  let inviteError = $state('');
+  let inviting = $state(false);
 
   function openInviteModal() {
     showInviteModal = true;
@@ -506,8 +530,8 @@
     });
   }
 
-  let showExitModal = false;
-  let exitError = '';
+  let showExitModal = $state(false);
+  let exitError = $state('');
 
   function openExitModal() {
     showExitModal = true;

--- a/src/components/layout/ParentNavbar.test.ts
+++ b/src/components/layout/ParentNavbar.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import type * as SquadJoinMls from '../../lib/squad/squad-join-mls';
+
+// Real ensureJoinRequestsHydrated/isJoinRequestsHydrated/syncJoinRequestsForSquad run for real
+// (their own hydratingSquadIds/hydratedBySquadId guards are what we're proving) — only the
+// backend-facing network calls are mocked out.
+vi.mock('../../lib/squad/squad-join-mls', async (importOriginal) => {
+  const actual = await importOriginal<typeof SquadJoinMls>();
+  return {
+    ...actual,
+    fanOutBotJoinDmsToMls: vi.fn().mockResolvedValue(undefined),
+    loadPendingJoinRequestsFromMls: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock('../../stores/squad-hub-alerts', () => ({
+  refreshPersonalAlertForSquad: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../stores/gov-action-prompts', () => ({
+  refreshGovActionPromptsForSquad: vi.fn().mockResolvedValue(undefined),
+}));
+
+import ParentNavbar from './ParentNavbar.svelte';
+import { squads, type Squad } from '../../stores/squads';
+import { activeSquadId, activeTopNavTab } from '../../stores/navigation';
+import { isJoinRequestsHydrated, resetSquadJoinRequestStores } from '../../stores/squad-join-requests';
+import { deferredSquadRosterKeyParentIds } from '../../lib/squad/squad-roster-key-choice';
+import { loadPendingJoinRequestsFromMls } from '../../lib/squad/squad-join-mls';
+import { refreshPersonalAlertForSquad } from '../../stores/squad-hub-alerts';
+import { refreshGovActionPromptsForSquad } from '../../stores/gov-action-prompts';
+
+function squad(overrides: Partial<Squad> = {}): Squad {
+  return {
+    id: 'squad-1',
+    name: 'Alpha',
+    channels: [],
+    kind: 'squad',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('ParentNavbar', () => {
+  beforeEach(() => {
+    squads.set([]);
+    activeSquadId.set(null);
+    activeTopNavTab.set('commons');
+    deferredSquadRosterKeyParentIds.set([]);
+    resetSquadJoinRequestStores();
+    vi.mocked(loadPendingJoinRequestsFromMls).mockClear();
+    vi.mocked(refreshPersonalAlertForSquad).mockClear();
+    vi.mocked(refreshGovActionPromptsForSquad).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    squads.set([]);
+    activeSquadId.set(null);
+    activeTopNavTab.set('commons');
+    deferredSquadRosterKeyParentIds.set([]);
+    resetSquadJoinRequestStores();
+  });
+
+  it('hydrates join requests once per squad on the squads tab, and not again on switch-away-and-back', async () => {
+    squads.set([squad()]);
+    activeSquadId.set('squad-1');
+    activeTopNavTab.set('squads');
+
+    render(ParentNavbar);
+
+    // Wait for the real hydration guard to flip, not just for the call to start.
+    await waitFor(() => expect(isJoinRequestsHydrated('squad-1')).toBe(true));
+    expect(loadPendingJoinRequestsFromMls).toHaveBeenCalledTimes(1);
+    expect(loadPendingJoinRequestsFromMls).toHaveBeenCalledWith('squad-1');
+
+    // Switch away, then back — the guard (isJoinRequestsHydrated) must block a re-fetch.
+    activeTopNavTab.set('dms');
+    activeTopNavTab.set('squads');
+    await tick();
+
+    expect(loadPendingJoinRequestsFromMls).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hydrate join requests when not on the squads tab', async () => {
+    squads.set([squad()]);
+    activeSquadId.set('squad-1');
+    activeTopNavTab.set('dms');
+
+    render(ParentNavbar);
+
+    await tick();
+    expect(loadPendingJoinRequestsFromMls).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the personal alert and gov-action prompts for the active squad on the squads tab', async () => {
+    squads.set([squad()]);
+    activeSquadId.set('squad-1');
+    activeTopNavTab.set('squads');
+
+    render(ParentNavbar);
+
+    await waitFor(() => expect(refreshPersonalAlertForSquad).toHaveBeenCalled());
+    expect(refreshPersonalAlertForSquad).toHaveBeenCalledWith(expect.objectContaining({ id: 'squad-1' }));
+    expect(refreshGovActionPromptsForSquad).toHaveBeenCalledWith(expect.objectContaining({ id: 'squad-1' }));
+  });
+
+  it('does not refresh the personal alert when there is no active squad', async () => {
+    squads.set([squad()]);
+    activeSquadId.set(null);
+    activeTopNavTab.set('squads');
+
+    render(ParentNavbar);
+
+    await tick();
+    expect(refreshPersonalAlertForSquad).not.toHaveBeenCalled();
+    expect(refreshGovActionPromptsForSquad).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/ParentSidebar.svelte
+++ b/src/components/layout/ParentSidebar.svelte
@@ -15,77 +15,109 @@
     order: number;
   }
 
-  export let parentName = '';
-  export let parentIconUrl: string | undefined = undefined;
-  export let parentId = '';
-  export let subheading: string | undefined = undefined;
-  export let channels: ParentChannel[] = [];
-  export let activeChannelId: string | null = null;
-  /** Disambiguates selection when multiple channels share the active MLS group id. */
-  export let activeHubChannelName: string | null = null;
-  export let activeView = 'hub';
-  export let creating = false;
-  export let createError = '';
-  export let canRetryCreate = false;
-  export let canDiscardCreate = false;
-  export let retryingCreate = false;
-  export let emptyMessage = '';
-  /** When false, show empty state instead of header/channels. */
-  export let hasParent = false;
-  /**
-   * Error banners to show below the header. Each can have an optional dismiss handler.
-   * If onDismissBanner is provided, a dismiss button is shown.
-   */
-  export let errorBanners: { id: string; text: string }[] = [];
-  export let onDismissBanner: ((id: string) => void) | undefined = undefined;
+  interface Props {
+    parentName?: string;
+    parentIconUrl?: string;
+    parentId?: string;
+    subheading?: string;
+    channels?: ParentChannel[];
+    activeChannelId?: string | null;
+    /** Disambiguates selection when multiple channels share the active MLS group id. */
+    activeHubChannelName?: string | null;
+    activeView?: string;
+    creating?: boolean;
+    createError?: string;
+    canRetryCreate?: boolean;
+    canDiscardCreate?: boolean;
+    retryingCreate?: boolean;
+    emptyMessage?: string;
+    /** When false, show empty state instead of header/channels. */
+    hasParent?: boolean;
+    /**
+     * Error banners to show below the header. Each can have an optional dismiss handler.
+     * If onDismissBanner is provided, a dismiss button is shown.
+     */
+    errorBanners?: { id: string; text: string }[];
+    onDismissBanner?: (id: string) => void;
+    onSelectChannel?: (channel: ParentChannel) => void;
+    onCreateChannel?: () => void;
+    onRetryCreate?: () => void;
+    onDiscardCreate?: () => void;
+    onInvite?: () => void;
+    onExitSquad?: () => void;
+    /** Partner squad-pairs linked to the active hub. */
+    partnerSquads?: { id: string; name: string }[];
+    activePartnerSquadId?: string | null;
+    onSelectPartnerSquad?: (id: string) => void;
+    /** Show pair action on any hub with a pairable anchor squad. */
+    showPairWithSquadAction?: boolean;
+    onPairWithSquad?: () => void;
+  }
 
-  export let onSelectChannel: (channel: ParentChannel) => void = () => {};
-  export let onCreateChannel: () => void = () => {};
-  export let onRetryCreate: () => void = () => {};
-  export let onDiscardCreate: () => void = () => {};
-  export let onInvite: () => void = () => {};
-  export let onExitSquad: (() => void) | undefined = undefined;
+  let {
+    parentName = '',
+    parentIconUrl = undefined,
+    parentId = '',
+    subheading = undefined,
+    channels = [],
+    activeChannelId = null,
+    activeHubChannelName = null,
+    activeView = 'hub',
+    creating = false,
+    createError = '',
+    canRetryCreate = false,
+    canDiscardCreate = false,
+    retryingCreate = false,
+    emptyMessage = '',
+    hasParent = false,
+    errorBanners = [],
+    onDismissBanner,
+    onSelectChannel = () => {},
+    onCreateChannel = () => {},
+    onRetryCreate = () => {},
+    onDiscardCreate = () => {},
+    onInvite = () => {},
+    onExitSquad,
+    partnerSquads = [],
+    activePartnerSquadId = null,
+    onSelectPartnerSquad = () => {},
+    showPairWithSquadAction = false,
+    onPairWithSquad,
+  }: Props = $props();
 
-  /** Partner squad-pairs linked to the active hub. */
-  export let partnerSquads: { id: string; name: string }[] = [];
-  export let activePartnerSquadId: string | null = null;
-  export let onSelectPartnerSquad: (id: string) => void = () => {};
-
-  /** Show pair action on any hub with a pairable anchor squad. */
-  export let showPairWithSquadAction = false;
-  export let onPairWithSquad: (() => void) | undefined = undefined;
-
-  let menuOpen = false;
+  let menuOpen = $state(false);
   const createErrorId = 'parent-create-error';
 
-  $: groupIdDupCount = channels.reduce<Record<string, number>>((acc, c) => {
-    acc[c.groupId] = (acc[c.groupId] ?? 0) + 1;
-    return acc;
-  }, {});
-  $: firstNameByGroupId = (() => {
+  let groupIdDupCount = $derived(
+    channels.reduce<Record<string, number>>((acc, c) => {
+      acc[c.groupId] = (acc[c.groupId] ?? 0) + 1;
+      return acc;
+    }, {})
+  );
+  let firstNameByGroupId = $derived.by(() => {
     const m: Record<string, string> = {};
     for (const c of channels) {
       if (!(c.groupId in m)) m[c.groupId] = c.name;
     }
     return m;
-  })();
+  });
 
-  $: showPartnerSquads = partnerSquads.length > 0 || showPairWithSquadAction;
-  $: ({ defaultHubChannels, customChannels } = partitionHubSidebarChannels(channels));
-  $: hubAlertByChannelName = (() => {
+  let showPartnerSquads = $derived(partnerSquads.length > 0 || showPairWithSquadAction);
+  let { defaultHubChannels, customChannels } = $derived(partitionHubSidebarChannels(channels));
+  let hubAlertByChannelName = $derived.by(() => {
     const counts = $unreadCountsByChat;
     const out: Record<string, number> = {};
     for (const channel of [...defaultHubChannels, ...customChannels]) {
       out[channel.name] = counts[channel.groupId] ?? 0;
     }
     return out;
-  })();
-  $: showCustomChannelDivider = defaultHubChannels.length > 0 && customChannels.length > 0;
-  $: inviteLabel = $t('nav.parentSidebar.invite');
-  $: showExit = typeof onExitSquad === 'function';
-  $: exitLabel = $t('nav.parentSidebar.exit');
-  $: onExit = onExitSquad;
-  $: resolvedEmptyMessage = emptyMessage || $t('nav.parentSidebar.empty');
+  });
+  let showCustomChannelDivider = $derived(defaultHubChannels.length > 0 && customChannels.length > 0);
+  let inviteLabel = $derived($t('nav.parentSidebar.invite'));
+  let showExit = $derived(typeof onExitSquad === 'function');
+  let exitLabel = $derived($t('nav.parentSidebar.exit'));
+  let onExit = $derived(onExitSquad);
+  let resolvedEmptyMessage = $derived(emptyMessage || $t('nav.parentSidebar.empty'));
 </script>
 
 <svelte:window


### PR DESCRIPTION
## Summary

Converts the top-level squad/DM navbar shell — `Navbar.svelte`, `ParentNavbar.svelte`, and `ParentSidebar.svelte` — from Svelte 4 legacy syntax (`export let`, `$:`, implicit reactivity) to Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`). Part of the incremental runes migration (epic pacto-app-a7r); this unit was scheduled last among domain batches for being the densest by line count (2270 lines, 25 `export let`, 69 `$:`, 13 `bind:`). `TopNavbar.svelte` needed no changes — it already had zero legacy constructs.

No behavior change is intended. The riskiest part of this batch was ParentNavbar's five interdependent side-effect chains driving join-request hydration, roster-key-deferral refresh, and personal-alert refresh — Svelte 4's `$:` topologically sorts reactive statements, but a bare `$effect` doesn't get that ordering for free. Each "compute a sync key, then act on it" pair was kept as a `$derived` key feeding a guarded `$effect`, and the two genuinely externally-triggered syncs became bare effects, so the guard/ordering semantics are preserved rather than reproducing Svelte 4 timing bugs.

## Changes

- `Navbar.svelte`: local mutable UI state (squad-drag rail, organize-squad-modal form fields) moved to `$state`; computed labels/flags to `$derived`. The commons-broadcast sync-key effect follows the sentinel-guard shape (KTD3 case 3) with the sentinel write kept inside the effect body. The "focus the squad-name input" side effect moved into `openOrganizeSquadModal()`, since that's the only place the modal is ever opened (KTD3 case 2). The squad-recreate-request reaction stayed a bare effect (KTD3 case 4 — genuine external sync, self-resetting via `.set(null)`).
- `ParentNavbar.svelte`: `activeParent` and its dependents (`channels`, `creating`, `subheading`, `partnerSquads`, etc.) became `$derived`. Join-request hydration and roster-key-deferral refresh became bare effects (external syncs); the join-request sync-key and personal-alert-refresh-key reactions kept the `$derived`-feeds-`$effect` split the plan calls out. All local modal/form state became `$state`.
- `ParentSidebar.svelte`: all 25 `export let` props converted to a typed `$props()` destructure; the channel-partitioning/alert-count computations became `$derived`/`$derived.by`.

## Test plan

- `pnpm check` — 0 errors, 0 warnings.
- `pnpm lint` — clean.
- `pnpm test` — full suite green (241 files / 2189 tests, including 4 new tests), run repeatedly to confirm stability. A pre-existing, unrelated flake in `dialog-content.test.ts` (an unhandled `document is not defined` exception from a stray `bits-ui` timer firing after jsdom teardown) reproduces identically on the pre-change tree — confirmed by stashing this diff and re-running the full suite — so it is not caused by this change.
- New `ParentNavbar.test.ts` (jsdom + `@testing-library/svelte`) exercises both guarded side effects against the real `stores/squad-join-requests` module (only the backend-facing MLS calls are mocked):
  - join-request hydration fires once per squad on the squads tab and is *not* re-fetched on switch-away-and-back (proves the guard, not just that the effect ran);
  - hydration does not fire off the squads tab;
  - personal-alert/gov-action-prompt refresh fires for the active squad on the squads tab;
  - that refresh does not fire with no active squad.
- Manual QA the human reviewer should still do: cycling the top-level tabs in a running app to visually confirm the squad rail drag/drop, organize-squad modal, and partner-squad pairing flows still behave identically — these are covered by `pnpm check`'s type-level guarantees and the existing full test suite, but weren't independently smoke-tested end-to-end in a live app session as part of this change.

Closes pacto-app-a7r.20

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)