### PR TITLE
feat: migrate wallet/ components to svelte 5 runes mode

### DIFF
--- a/src/components/wallet/ChainIdSelect.svelte
+++ b/src/components/wallet/ChainIdSelect.svelte
@@ -2,10 +2,14 @@
   import { WALLET_ASSETS_CHAIN_IDS, getWalletNetworkDisplayName } from '../../lib/wallet/assets';
   import type { SupportedChainId } from '../../lib/wallet/chains';
 
-  export let id: string | undefined = undefined;
-  export let value: SupportedChainId;
-  export let disabled = false;
-  export let selectClass = 'input-select';
+  interface Props {
+    id?: string;
+    value: SupportedChainId;
+    disabled?: boolean;
+    selectClass?: string;
+  }
+
+  let { id = undefined, value = $bindable(), disabled = false, selectClass = 'input-select' }: Props = $props();
 </script>
 
 <select {id} class={selectClass} bind:value {disabled}>

--- a/src/components/wallet/WalletAdvancedPanel.svelte
+++ b/src/components/wallet/WalletAdvancedPanel.svelte
@@ -36,42 +36,47 @@
 
   const tFn = get(t);
 
-  export let enabledChainIds: SupportedChainId[] = [...WALLET_ASSETS_CHAIN_IDS];
-  /** When true, show Settings cross-links (external wallet disclaimer). */
-  export let embeddedInSettings = false;
+  interface Props {
+    enabledChainIds?: SupportedChainId[];
+    /** When true, show Settings cross-links (external wallet disclaimer). */
+    embeddedInSettings?: boolean;
+  }
 
-  let advancedAccounts: EvmAccountRow[] = [];
-  let activeAdvancedAddress: string | null = null;
-  let squadInfraRefs: string[] = [];
+  let { enabledChainIds = [...WALLET_ASSETS_CHAIN_IDS], embeddedInSettings = false }: Props = $props();
 
-  let network: SupportedChainId = DEFAULT_CHAIN_ID;
-  let toAddress = '';
-  let valueEth = '0';
-  let calldataMode: 'raw' | 'abi' = 'raw';
-  let dataHex = '0x';
-  let abiRef = 'erc20-minimal';
-  let abiJson = '';
-  let functionName = 'balanceOf';
-  let argsJson = '[]';
-  let builtCalldata = '0x';
+  let advancedAccounts: EvmAccountRow[] = $state([]);
+  let activeAdvancedAddress: string | null = $state(null);
+  let squadInfraRefs: string[] = $state([]);
 
-  let simulating = false;
-  let simulateOk: boolean | null = null;
-  let simulateMessage = '';
-  let sending = false;
-  let confirmOpen = false;
-  let infraWarningAck = false;
+  let network: SupportedChainId = $state(DEFAULT_CHAIN_ID);
+  let toAddress = $state('');
+  let valueEth = $state('0');
+  let calldataMode: 'raw' | 'abi' = $state('raw');
+  let dataHex = $state('0x');
+  let abiRef = $state('erc20-minimal');
+  let abiJson = $state('');
+  let functionName = $state('balanceOf');
+  let argsJson = $state('[]');
+  let builtCalldata = $state('0x');
+
+  let simulating = $state(false);
+  let simulateOk: boolean | null = $state(null);
+  let simulateMessage = $state('');
+  let sending = $state(false);
+  let confirmOpen = $state(false);
+  let infraWarningAck = $state(false);
 
   const shippedAbis = listShippedAbiRefs();
 
-  $: accountNpub = $currentUser?.npub ?? null;
-  $: hasAdvancedSigner = !!activeAdvancedAddress && advancedAccounts.length > 0;
-  $: infraTarget = isSquadInfraTargetAddress(toAddress, squadInfraRefs);
-  $: canSend =
+  const accountNpub = $derived($currentUser?.npub ?? null);
+  const hasAdvancedSigner = $derived(!!activeAdvancedAddress && advancedAccounts.length > 0);
+  const infraTarget = $derived(isSquadInfraTargetAddress(toAddress, squadInfraRefs));
+  const canSend = $derived(
     hasAdvancedSigner &&
-    toAddress.trim().length > 0 &&
-    (!infraTarget || infraWarningAck) &&
-    enabledChainIds.includes(network);
+      toAddress.trim().length > 0 &&
+      (!infraTarget || infraWarningAck) &&
+      enabledChainIds.includes(network)
+  );
 
   async function refreshAdvancedState() {
     if (!accountNpub) {
@@ -96,7 +101,10 @@
     });
   });
 
-  $: accountNpub, void refreshAdvancedState();
+  $effect(() => {
+    void accountNpub;
+    void refreshAdvancedState();
+  });
 
   function shortAddr(a: string): string {
     const t = a.trim();
@@ -132,7 +140,15 @@
     }
   }
 
-  $: calldataMode, dataHex, abiRef, abiJson, functionName, argsJson, rebuildCalldataPreview();
+  $effect(() => {
+    void calldataMode;
+    void dataHex;
+    void abiRef;
+    void abiJson;
+    void functionName;
+    void argsJson;
+    rebuildCalldataPreview();
+  });
 
   async function onSimulate() {
     if (!activeAdvancedAddress) return;

--- a/src/components/wallet/WalletBar.svelte
+++ b/src/components/wallet/WalletBar.svelte
@@ -44,39 +44,44 @@
 
   const tFn = get(t);
 
-  /** Active DM counterparty npub */
-  export let npub: string;
+  interface Props {
+    /** Active DM counterparty npub */
+    npub: string;
+    /** Send structured DM text to the active thread (same path as the composer). */
+    postDmPlaintext?: ((content: string) => Promise<boolean>) | undefined;
+  }
 
-  /** Send structured DM text to the active thread (same path as the composer). */
-  export let postDmPlaintext: ((content: string) => Promise<boolean>) | undefined = undefined;
+  let { npub, postDmPlaintext = undefined }: Props = $props();
 
-  let sendModalOpen = false;
-  let requestModalOpen = false;
-  let importTokensModalOpen = false;
+  let sendModalOpen = $state(false);
+  let requestModalOpen = $state(false);
+  let importTokensModalOpen = $state(false);
   /** Form prefill when opening Send from Accept on a payment request card. */
-  let sendModalPrefill: WalletSendPrefillPayload | null = null;
+  let sendModalPrefill: WalletSendPrefillPayload | null = $state(null);
 
   function truncateNpub(n: string): string {
     if (n.length <= 16) return n;
     return n.slice(0, 8) + '…' + n.slice(-4);
   }
 
-  $: contactProfile = npub ? $profiles[npub] : null;
-  $: contactAvatarSrc = getProfileAvatarSrc(contactProfile);
-  $: contactDisplayName = contactProfile
-    ? getProfileDisplayName(contactProfile)
-    : npub
-      ? truncateNpub(npub)
-      : tFn('wallet.anonymous');
+  const contactProfile = $derived(npub ? $profiles[npub] : null);
+  const contactAvatarSrc = $derived(getProfileAvatarSrc(contactProfile));
+  const contactDisplayName = $derived(
+    contactProfile
+      ? getProfileDisplayName(contactProfile)
+      : npub
+        ? truncateNpub(npub)
+        : tFn('wallet.anonymous')
+  );
 
-  let summaryLoading = true;
-  let summaryError: string | null = null;
-  let summary: WalletSummary | null = null;
+  let summaryLoading = $state(true);
+  let summaryError: string | null = $state(null);
+  let summary: WalletSummary | null = $state(null);
 
   const STORAGE_NETWORK = 'pacto_wallet_bar_network_filter';
 
   /** `all` = every chain; otherwise one `SupportedChainId`. */
-  let networkFilter: 'all' | SupportedChainId = 'all';
+  let networkFilter: 'all' | SupportedChainId = $state('all');
 
   function parseNetworkFilter(raw: string | null): 'all' | SupportedChainId {
     if (!raw || raw === 'all') return 'all';
@@ -95,14 +100,16 @@
   }
 
   /** Logged-in account: watched ERC-20 list is keyed by this npub. */
-  $: accountNpub = $currentUser?.npub ?? null;
+  const accountNpub = $derived($currentUser?.npub ?? null);
 
-  let watchedErc20Rows: WatchedErc20Row[] = [];
+  let watchedErc20Rows: WatchedErc20Row[] = $state([]);
 
-  let peerWalletReady = false;
+  let peerWalletReady = $state(false);
 
-  $: void $walletPeerInfoRequestInFlightRevision;
-  $: peerInfoRequestInFlight = npub ? isWalletPeerInfoRequestInFlight(npub) : false;
+  const peerInfoRequestInFlight = $derived.by(() => {
+    void $walletPeerInfoRequestInFlightRevision;
+    return npub ? isWalletPeerInfoRequestInFlight(npub) : false;
+  });
 
   /** Unlock Send/Request only after pairwise `dm_peer_evm` exchange. */
   async function syncPeerWalletReady() {
@@ -121,7 +128,11 @@
     }
   }
 
-  $: npub, $dmWalletPeerExchangeTick, void syncPeerWalletReady();
+  $effect(() => {
+    void npub;
+    void $dmWalletPeerExchangeTick;
+    void syncPeerWalletReady();
+  });
 
   async function sendWalletInfoRequest() {
     const me = get(currentUser)?.npub;
@@ -166,25 +177,24 @@
       : defaultWatchedErc20Rows();
   }
 
-  $: {
-    accountNpub;
-    reloadWatchedRows();
-  }
-
-  let enabledChainSet: Set<SupportedChainId> = new Set(WALLET_ASSETS_CHAIN_IDS as SupportedChainId[]);
-  $: {
+  $effect(() => {
     void accountNpub;
+    reloadWatchedRows();
+  });
+
+  const enabledChainSet = $derived.by(() => {
     void $walletUiEnabledChainsTick;
-    enabledChainSet = new Set(
+    return new Set(
       accountNpub ? loadWalletEnabledChains(accountNpub) : [...WALLET_ASSETS_CHAIN_IDS]
     );
-  }
+  });
 
   /** If the stored filter points at a chain the user disabled in Wallet view, fall back to "all". */
-  $: if (networkFilter !== 'all' && !enabledChainSet.has(networkFilter)) {
+  $effect(() => {
+    if (networkFilter === 'all' || enabledChainSet.has(networkFilter)) return;
     networkFilter = 'all';
     saveNetworkFilter();
-  }
+  });
 
   function networksForBalanceList(
     s: WalletSummary | null,
@@ -196,8 +206,7 @@
     return nets.filter((n) => (filter === 'all' ? true : n.network === filter));
   }
 
-  let networksForBalance: WalletSummaryNetwork[] = [];
-  $: networksForBalance = networksForBalanceList(summary, networkFilter, enabledChainSet);
+  const networksForBalance = $derived(networksForBalanceList(summary, networkFilter, enabledChainSet));
 
   /** Friendly per-network read failure copy (raw RPC text stays off the primary line). */
   function networkErrorMessage(net: WalletSummaryNetwork): string {
@@ -209,26 +218,26 @@
    * Network dropdown matches Wallet settings toggles (enabled chains), not only chains that appear
    * in the latest summary (zero-balance or missing RPC rows would otherwise disappear from the list).
    */
-  let networkDropdownChainIds: SupportedChainId[] = [];
-  $: networkDropdownChainIds = WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledChainSet.has(id));
+  const networkDropdownChainIds = $derived(
+    WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledChainSet.has(id))
+  );
 
   /** Total USD for listed networks only (matches toggles in Wallet view). */
-  let barTotalUsdApprox: number | null = null;
-  let barPricingStatus: 'complete' | 'partial' | 'unavailable' = 'unavailable';
-  $: {
+  const barPricing = $derived.by(() => {
     if (networkFilter === 'all' && summary) {
-      barPricingStatus = summary.usdPricingStatus ?? 'unavailable';
-      barTotalUsdApprox =
-        barPricingStatus === 'unavailable' ? null : summary.totalUsdApprox;
-      if (barTotalUsdApprox == null && barPricingStatus !== 'unavailable') {
-        barTotalUsdApprox = sumPricedUsd(networksForBalance);
+      const status = summary.usdPricingStatus ?? 'unavailable';
+      let total = status === 'unavailable' ? null : summary.totalUsdApprox;
+      if (total == null && status !== 'unavailable') {
+        total = sumPricedUsd(networksForBalance);
       }
-    } else {
-      barPricingStatus = pricingStatusForNetworks(networksForBalance);
-      barTotalUsdApprox =
-        barPricingStatus === 'unavailable' ? null : sumPricedUsd(networksForBalance);
+      return { status, total };
     }
-  }
+    const status = pricingStatusForNetworks(networksForBalance);
+    const total = status === 'unavailable' ? null : sumPricedUsd(networksForBalance);
+    return { status, total };
+  });
+  const barPricingStatus = $derived(barPricing.status);
+  const barTotalUsdApprox = $derived(barPricing.total);
 
   async function refreshSummary() {
     const wire = watchedRowsToWire(watchedErc20Rows);

--- a/src/components/wallet/WalletHomeSendModal.svelte
+++ b/src/components/wallet/WalletHomeSendModal.svelte
@@ -37,108 +37,121 @@
 
   const tFn = get(t);
 
-  export let open: boolean;
-  export let onClose: () => void;
-  export let watchedAssetRows: WatchedErc20Row[] = [];
-  /** Chains enabled in Wallet settings (catalog order subset). */
-  export let enabledChainIds: SupportedChainId[] = [...WALLET_ASSETS_CHAIN_IDS];
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+    watchedAssetRows?: WatchedErc20Row[];
+    /** Chains enabled in Wallet settings (catalog order subset). */
+    enabledChainIds?: SupportedChainId[];
+  }
+
+  let {
+    open,
+    onClose,
+    watchedAssetRows = [],
+    enabledChainIds = [...WALLET_ASSETS_CHAIN_IDS],
+  }: Props = $props();
 
   const titleId = 'wallet-home-send-title';
   const descId = 'wallet-home-send-desc';
 
-  let toAddress = '';
-  let chainId: SupportedChainId = DEFAULT_CHAIN_ID;
-  let assetCode = 'ETH';
-  let amountStr = '';
+  let toAddress = $state('');
+  let chainId: SupportedChainId = $state(DEFAULT_CHAIN_ID);
+  let assetCode = $state('ETH');
+  let amountStr = $state('');
 
-  $: chainsForUi =
-    enabledChainIds.length > 0 ? enabledChainIds : [...WALLET_ASSETS_CHAIN_IDS];
+  const chainsForUi = $derived(
+    enabledChainIds.length > 0 ? enabledChainIds : [...WALLET_ASSETS_CHAIN_IDS]
+  );
 
-  $: if (!chainsForUi.includes(chainId)) {
+  $effect(() => {
+    if (chainsForUi.includes(chainId)) return;
     chainId = chainsForUi[0] ?? DEFAULT_CHAIN_ID;
-  }
+  });
 
-  $: recipientValid = (() => {
-    const t = toAddress.trim();
-    if (!t) return false;
+  const recipientValid = $derived.by(() => {
+    const trimmed = toAddress.trim();
+    if (!trimmed) return false;
     try {
-      return isAddress(getAddress(t as `0x${string}`));
+      return isAddress(getAddress(trimmed as `0x${string}`));
     } catch {
       return false;
     }
-  })();
+  });
 
-  let pricesResult:
-    | { ok: true; prices: WalletUsdSpotPrices }
-    | { ok: false; message: string }
-    | null = null;
-  let pricesFetchKey = '';
-  let pricesFetchGen = 0;
+  let pricesResult = $state<
+    { ok: true; prices: WalletUsdSpotPrices } | { ok: false; message: string } | null
+  >(null);
+  let pricesFetchKey = $state('');
+  let pricesFetchGen = $state(0);
 
-  $: if (!open) {
-    pricesFetchKey = '';
-    pricesResult = null;
-  } else {
-    const key = chainId;
-    if (key !== pricesFetchKey) {
-      pricesFetchKey = key;
-      pricesFetchGen += 1;
-      const gen = pricesFetchGen;
+  /** Refetches USD prices once per chain while the modal is open; clears on close so a
+   * stale quote never carries into the next open. */
+  $effect(() => {
+    if (!open) {
+      pricesFetchKey = '';
       pricesResult = null;
-      getWalletUsdSpotPrices(chainId).then((r) => {
-        if (gen !== pricesFetchGen) return;
-        pricesResult = r;
-      });
+      return;
     }
-  }
+    const key = chainId;
+    if (key === pricesFetchKey) return;
+    pricesFetchKey = key;
+    pricesFetchGen += 1;
+    const gen = pricesFetchGen;
+    pricesResult = null;
+    getWalletUsdSpotPrices(chainId).then((r) => {
+      if (gen !== pricesFetchGen) return;
+      pricesResult = r;
+    });
+  });
 
-  $: assetOptions = listWalletAssetOptionsForChainWithWatched(
-    chainId,
-    watchedAssetRows
-  ) as WalletAssetOptionRow[];
+  const assetOptions = $derived(
+    listWalletAssetOptionsForChainWithWatched(chainId, watchedAssetRows) as WalletAssetOptionRow[]
+  );
 
-  $: {
+  $effect(() => {
     const codes = assetOptions.map((o) => o.code);
     if (codes.length > 0 && !codes.includes(assetCode)) {
       assetCode = codes[0] ?? 'ETH';
     }
-  }
+  });
 
-  $: selectedOpt = assetOptions.find((o) => o.code === assetCode);
+  const selectedOpt = $derived(assetOptions.find((o) => o.code === assetCode));
 
-  let sendBalanceSummary: WalletSummary | null = null;
-  let sendBalanceError: string | null = null;
-  let sendBalanceLoading = false;
-  let sendBalanceFetchKey = '';
-  let sendBalanceFetchGen = 0;
+  let sendBalanceSummary: WalletSummary | null = $state(null);
+  let sendBalanceError: string | null = $state(null);
+  let sendBalanceLoading = $state(false);
+  let sendBalanceFetchKey = $state('');
+  let sendBalanceFetchGen = $state(0);
 
-  $: watchedWireForBalances = watchedRowsToWire(watchedAssetRows);
+  const watchedWireForBalances = $derived(watchedRowsToWire(watchedAssetRows));
 
-  $: if (!open) {
-    sendBalanceFetchKey = '';
-    sendBalanceSummary = null;
-    sendBalanceError = null;
-    sendBalanceLoading = false;
-  } else {
-    const key = `${chainId}|${watchedWireFingerprint(watchedWireForBalances)}`;
-    if (key !== sendBalanceFetchKey) {
-      sendBalanceFetchKey = key;
-      sendBalanceFetchGen += 1;
-      const gen = sendBalanceFetchGen;
-      sendBalanceLoading = true;
+  $effect(() => {
+    if (!open) {
+      sendBalanceFetchKey = '';
+      sendBalanceSummary = null;
       sendBalanceError = null;
-      getWalletSummary(watchedWireForBalances, [chainId]).then((r) => {
-        if (gen !== sendBalanceFetchGen) return;
-        sendBalanceLoading = false;
-        if (r.ok) {
-          sendBalanceSummary = r.summary;
-        } else {
-          sendBalanceSummary = null;
-          sendBalanceError = r.message;
-        }
-      });
+      sendBalanceLoading = false;
+      return;
     }
-  }
+    const key = `${chainId}|${watchedWireFingerprint(watchedWireForBalances)}`;
+    if (key === sendBalanceFetchKey) return;
+    sendBalanceFetchKey = key;
+    sendBalanceFetchGen += 1;
+    const gen = sendBalanceFetchGen;
+    sendBalanceLoading = true;
+    sendBalanceError = null;
+    getWalletSummary(watchedWireForBalances, [chainId]).then((r) => {
+      if (gen !== sendBalanceFetchGen) return;
+      sendBalanceLoading = false;
+      if (r.ok) {
+        sendBalanceSummary = r.summary;
+      } else {
+        sendBalanceSummary = null;
+        sendBalanceError = r.message;
+      }
+    });
+  });
 
   function findBalanceForAsset(
     summary: WalletSummary | null,
@@ -153,7 +166,7 @@
     return { balanceRaw: asset.balanceRaw, balanceDecimal: asset.balanceDecimal };
   }
 
-  $: selectedBalanceRow = findBalanceForAsset(sendBalanceSummary, chainId, assetCode);
+  const selectedBalanceRow = $derived(findBalanceForAsset(sendBalanceSummary, chainId, assetCode));
 
   function amountExceedsBalance(amountTrimmed: string, balanceRaw: string, decimals: number): boolean {
     try {
@@ -173,24 +186,27 @@
     return n;
   }
 
-  $: amountValid = parsePositiveAmount(amountStr) !== null;
-  let sending = false;
-  let sendError: { message: string; txHash?: string; code?: string } | null = null;
+  const amountValid = $derived(parsePositiveAmount(amountStr) !== null);
+  let sending = $state(false);
+  let sendError = $state<{ message: string; txHash?: string; code?: string } | null>(null);
 
-  $: insufficientFunds =
+  const insufficientFunds = $derived(
     amountValid &&
-    selectedOpt != null &&
-    selectedBalanceRow != null &&
-    amountExceedsBalance(amountStr.trim(), selectedBalanceRow.balanceRaw, selectedOpt.decimals);
+      selectedOpt != null &&
+      selectedBalanceRow != null &&
+      amountExceedsBalance(amountStr.trim(), selectedBalanceRow.balanceRaw, selectedOpt.decimals)
+  );
 
-  $: canConfirm =
-    recipientValid && amountValid && !sending && selectedOpt != null && !insufficientFunds;
+  const canConfirm = $derived(
+    recipientValid && amountValid && !sending && selectedOpt != null && !insufficientFunds
+  );
 
-  $: explorerLinkForError =
+  const explorerLinkForError = $derived(
     sendError?.txHash != null && sendError.txHash.length > 0
       ? getExplorerTxUrl(chainId, sendError.txHash)
-      : null;
-  $: explorerLinkLabel = explorerTxLinkLabel(chainId);
+      : null
+  );
+  const explorerLinkLabel = $derived(explorerTxLinkLabel(chainId));
 
   async function copyErrorTxHash() {
     const h = sendError?.txHash;
@@ -199,15 +215,17 @@
     showToast(ok ? tFn('wallet.txHashCopied') : tFn('wallet.couldNotCopyHash'));
   }
 
-  $: canRetryAfterError =
-    sendError != null && !sending && sendError.code !== 'RECEIPT_TIMEOUT';
+  const canRetryAfterError = $derived(
+    sendError != null && !sending && sendError.code !== 'RECEIPT_TIMEOUT'
+  );
 
-  $: approxUsd =
+  const approxUsd = $derived(
     pricesResult?.ok === true && amountValid
       ? amountToApproxUsd(amountStr, assetCode, pricesResult.prices)
-      : null;
+      : null
+  );
 
-  $: usdLine =
+  const usdLine = $derived(
     pricesResult === null
       ? tFn('wallet.loadingUsdRates')
       : !pricesResult.ok
@@ -218,7 +236,8 @@
             ? tFn('wallet.enterAmountForUsd')
             : amountValid
               ? tFn('wallet.usdUnavailable')
-              : tFn('wallet.enterAmountForUsd');
+              : tFn('wallet.enterAmountForUsd')
+  );
 
   function onAmountInput(e: Event) {
     const el = e.currentTarget as HTMLInputElement;
@@ -282,11 +301,14 @@
     }
   }
 
-  $: if (!open) {
+  /** Clears the form once the modal is closed, so the next open starts blank instead of
+   * carrying over a stale address/amount/error; never fires while the user is still editing. */
+  $effect(() => {
+    if (open) return;
     toAddress = '';
     amountStr = '';
     sendError = null;
-  }
+  });
 </script>
 
 {#if open}

--- a/src/components/wallet/WalletHomeSendModal.test.ts
+++ b/src/components/wallet/WalletHomeSendModal.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('../../lib/wallet', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/wallet')>();
+  return {
+    ...actual,
+    getWalletSummary: vi.fn(async () => ({ ok: false, message: 'not fetched in test' })),
+    walletBuildAndSendTransaction: vi.fn(),
+    walletWaitForTransaction: vi.fn(),
+  };
+});
+
+vi.mock('../../lib/wallet/pricing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/wallet/pricing')>();
+  return {
+    ...actual,
+    getWalletUsdSpotPrices: vi.fn(async () => ({ ok: false, message: 'not fetched in test' })),
+  };
+});
+
+import WalletHomeSendModal from './WalletHomeSendModal.svelte';
+import type { WatchedErc20Row } from '../../lib/wallet/watched-tokens';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('WalletHomeSendModal reset guard', () => {
+  it('never overwrites in-progress edits while the modal stays open across an unrelated re-render', async () => {
+    const onClose = vi.fn();
+    const rows: WatchedErc20Row[] = [];
+    const { rerender } = render(WalletHomeSendModal, {
+      props: { open: true, onClose, watchedAssetRows: rows, enabledChainIds: ['mainnet', 'sepolia'] },
+    });
+
+    const addressInput = screen.getByLabelText('Recipient EVM address') as HTMLInputElement;
+    const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
+
+    await fireEvent.input(addressInput, { target: { value: '0x1234567890123456789012345678901234567890' } });
+    await fireEvent.input(amountInput, { target: { value: '2.5' } });
+    expect(addressInput.value).toBe('0x1234567890123456789012345678901234567890');
+    expect(amountInput.value).toBe('2.5');
+
+    // Unrelated re-render (new watchedAssetRows array reference, modal stays open) must not
+    // re-run the close-reset guard and wipe what the user just typed -- this is the same
+    // loop/overwrite risk a bare $effect on `open` alone would introduce if it also read
+    // toAddress/amountStr.
+    await rerender({ open: true, onClose, watchedAssetRows: [...rows], enabledChainIds: ['mainnet', 'sepolia'] });
+
+    expect(addressInput.value).toBe('0x1234567890123456789012345678901234567890');
+    expect(amountInput.value).toBe('2.5');
+  });
+
+  it('clears the form once the modal closes so the next open starts blank', async () => {
+    const onClose = vi.fn();
+    const { rerender } = render(WalletHomeSendModal, {
+      props: { open: true, onClose, watchedAssetRows: [], enabledChainIds: ['mainnet', 'sepolia'] },
+    });
+
+    const addressInput = screen.getByLabelText('Recipient EVM address') as HTMLInputElement;
+    await fireEvent.input(addressInput, { target: { value: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' } });
+    expect(addressInput.value).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+
+    // Close, then reopen.
+    await rerender({ open: false, onClose, watchedAssetRows: [], enabledChainIds: ['mainnet', 'sepolia'] });
+    await rerender({ open: true, onClose, watchedAssetRows: [], enabledChainIds: ['mainnet', 'sepolia'] });
+
+    const addressInputAfterReopen = screen.getByLabelText('Recipient EVM address') as HTMLInputElement;
+    expect(addressInputAfterReopen.value).toBe('');
+  });
+});

--- a/src/components/wallet/WalletImportTokensModal.svelte
+++ b/src/components/wallet/WalletImportTokensModal.svelte
@@ -14,39 +14,58 @@
   } from '../../lib/wallet/watched-tokens';
   import { appConfig } from '../../stores/app-config';
 
-  export let open = false;
-  export let onClose: () => void;
-  /** Mirrors WalletBar network filter: limits Search results and Custom default chain. */
-  export let networkScope: 'all' | SupportedChainId = 'all';
-  export let accountNpub: string | null = null;
-  export let onSaved: () => void;
+  interface Props {
+    open?: boolean;
+    onClose: () => void;
+    /** Mirrors WalletBar network filter: limits Search results and Custom default chain. */
+    networkScope?: 'all' | SupportedChainId;
+    accountNpub?: string | null;
+    onSaved: () => void;
+  }
+
+  let {
+    open = false,
+    onClose,
+    networkScope = 'all',
+    accountNpub = null,
+    onSaved,
+  }: Props = $props();
 
   const titleId = 'wallet-import-tokens-title';
   const descId = 'wallet-import-tokens-desc';
 
-  let tab: 'search' | 'custom' = 'search';
-  let searchQuery = '';
-  let selectedCatalogIds = new Set<string>();
+  let tab: 'search' | 'custom' = $state('search');
+  let searchQuery = $state('');
+  let selectedCatalogIds = $state(new Set<string>());
 
-  let customNetwork: SupportedChainId = 'mainnet';
-  let customAddress = '';
-  let customSymbol = '';
-  let customDecimalsStr = '18';
+  let customNetwork: SupportedChainId = $state('mainnet');
+  let customAddress = $state('');
+  let customSymbol = $state('');
+  let customDecimalsStr = $state('18');
 
-  let lastOpened = false;
+  let lastOpened = $state(false);
 
-  $: customTokenSymbolMaxLength = $appConfig.customTokenSymbolMaxLength;
+  const customTokenSymbolMaxLength = $derived($appConfig.customTokenSymbolMaxLength);
 
-  $: catalog = buildCatalogSearchEntries();
+  const catalog = buildCatalogSearchEntries();
 
-  $: filteredCatalog = catalog.filter((e) => {
-    if (networkScope !== 'all' && e.network !== networkScope) return false;
-    const q = searchQuery.trim().toLowerCase();
-    if (!q) return true;
-    return e.searchText.includes(q) || e.symbol.toLowerCase().includes(q);
-  }) as CatalogSearchEntry[];
+  const filteredCatalog = $derived(
+    catalog.filter((e) => {
+      if (networkScope !== 'all' && e.network !== networkScope) return false;
+      const q = searchQuery.trim().toLowerCase();
+      if (!q) return true;
+      return e.searchText.includes(q) || e.symbol.toLowerCase().includes(q);
+    }) as CatalogSearchEntry[]
+  );
 
-  $: if (open && !lastOpened) {
+  /** Resets the form to a clean state exactly once per open, and re-arms on close so the
+   * next open starts fresh too. */
+  $effect(() => {
+    if (!open) {
+      lastOpened = false;
+      return;
+    }
+    if (lastOpened) return;
     lastOpened = true;
     if (accountNpub) {
       const rows = loadWatchedErc20Rows(accountNpub);
@@ -55,8 +74,7 @@
     tab = 'search';
     searchQuery = '';
     if (networkScope !== 'all') customNetwork = networkScope;
-  }
-  $: if (!open) lastOpened = false;
+  });
 
   function isHexAddress(s: string): boolean {
     const t = s.trim();
@@ -109,18 +127,20 @@
     onClose();
   }
 
-  $: customDecimalsValid = (() => {
+  const customDecimalsValid = $derived.by(() => {
     const d = Number.parseInt(customDecimalsStr, 10);
     return Number.isInteger(d) && d >= 0 && d <= 36;
-  })();
+  });
 
-  $: customSymbolValid = customSymbol.trim().length > 0 && customSymbol.trim().length <= customTokenSymbolMaxLength && /^[A-Z0-9]+$/.test(customSymbol.trim().toUpperCase());
+  const customSymbolValid = $derived(
+    customSymbol.trim().length > 0 &&
+      customSymbol.trim().length <= customTokenSymbolMaxLength &&
+      /^[A-Z0-9]+$/.test(customSymbol.trim().toUpperCase())
+  );
 
-  $: canSaveCustom =
-    accountNpub != null &&
-    isHexAddress(customAddress) &&
-    customSymbolValid &&
-    customDecimalsValid;
+  const canSaveCustom = $derived(
+    accountNpub != null && isHexAddress(customAddress) && customSymbolValid && customDecimalsValid
+  );
 </script>
 
 {#if open}

--- a/src/components/wallet/WalletPeerExchangeCard.svelte
+++ b/src/components/wallet/WalletPeerExchangeCard.svelte
@@ -5,21 +5,26 @@
    * Thread card for private wallet-address exchange (request / grant / decline).
    * Structured content is still parsed for persistence; this is the human-visible summary.
    */
-  export let variant:
-    | 'request-in'
-    | 'request-out'
-    | 'grant-in'
-    | 'grant-out'
-    | 'decline-in'
-    | 'decline-out';
-  export let peerName: string;
-  /** For request-in only. */
-  export let status: 'pending' | 'accepted' | 'declined' = 'pending';
-  export let accepting = false;
-  export let onAccept: (() => void) | undefined = undefined;
-  export let onDecline: (() => void) | undefined = undefined;
+  interface Props {
+    variant: 'request-in' | 'request-out' | 'grant-in' | 'grant-out' | 'decline-in' | 'decline-out';
+    peerName: string;
+    /** For request-in only. */
+    status?: 'pending' | 'accepted' | 'declined';
+    accepting?: boolean;
+    onAccept?: (() => void) | undefined;
+    onDecline?: (() => void) | undefined;
+  }
 
-  $: title = (() => {
+  let {
+    variant,
+    peerName,
+    status = 'pending',
+    accepting = false,
+    onAccept = undefined,
+    onDecline = undefined,
+  }: Props = $props();
+
+  const title = $derived.by(() => {
     switch (variant) {
       case 'request-in':
         return $t('wallet.peerRequestInTitle');
@@ -36,9 +41,9 @@
       default:
         return $t('wallet.walletTitle');
     }
-  })();
+  });
 
-  $: body = (() => {
+  const body = $derived.by(() => {
     switch (variant) {
       case 'request-in':
         return $t('wallet.peerRequestInBody', { values: { peerName } });
@@ -55,9 +60,9 @@
       default:
         return '';
     }
-  })();
+  });
 
-  $: collapsed = variant === 'request-in' && (status === 'accepted' || status === 'declined');
+  const collapsed = $derived(variant === 'request-in' && (status === 'accepted' || status === 'declined'));
 </script>
 
 <div class="wpeer-card" class:collapsed role="article">

--- a/src/components/wallet/WalletReceiveModal.svelte
+++ b/src/components/wallet/WalletReceiveModal.svelte
@@ -2,14 +2,18 @@
   import { t } from 'svelte-i18n';
   import Modal from '../ui/Modal.svelte';
 
-  export let open: boolean;
-  export let address: string;
-  export let onClose: () => void;
+  interface Props {
+    open: boolean;
+    address: string;
+    onClose: () => void;
+  }
+
+  let { open, address, onClose }: Props = $props();
 
   const titleId = 'wallet-receive-title';
   const descId = 'wallet-receive-desc';
 
-  let copied = false;
+  let copied = $state(false);
   async function copyAddress() {
     try {
       await navigator.clipboard.writeText(address.trim());

--- a/src/components/wallet/WalletRequestModal.svelte
+++ b/src/components/wallet/WalletRequestModal.svelte
@@ -2,11 +2,21 @@
   import WalletTransferStubModal from './WalletTransferStubModal.svelte';
   import type { WatchedErc20Row } from '../../lib/wallet/watched-tokens';
 
-  export let npub: string;
-  export let peerDisplayName: string;
-  export let onClose: () => void;
-  export let postDmPlaintext: ((content: string) => Promise<boolean>) | undefined = undefined;
-  export let watchedAssetRows: WatchedErc20Row[] = [];
+  interface Props {
+    npub: string;
+    peerDisplayName: string;
+    onClose: () => void;
+    postDmPlaintext?: ((content: string) => Promise<boolean>) | undefined;
+    watchedAssetRows?: WatchedErc20Row[];
+  }
+
+  let {
+    npub,
+    peerDisplayName,
+    onClose,
+    postDmPlaintext = undefined,
+    watchedAssetRows = [],
+  }: Props = $props();
 </script>
 
 <WalletTransferStubModal

--- a/src/components/wallet/WalletSendModal.svelte
+++ b/src/components/wallet/WalletSendModal.svelte
@@ -3,15 +3,27 @@
   import type { WatchedErc20Row } from '../../lib/wallet/watched-tokens';
   import type { WalletSendPrefillPayload } from '../../stores/app';
 
-  export let npub: string;
-  export let peerDisplayName: string;
-  export let onClose: () => void;
-  export let watchedAssetRows: WatchedErc20Row[] = [];
-  /** From Accept on a payment request: network, asset, amount, request id. */
-  export let formPrefill: WalletSendPrefillPayload | null = null;
-  export let postDmPlaintext: ((content: string) => Promise<boolean>) | undefined = undefined;
-  /** Refresh balances after a send confirms in the background. */
-  export let onBalanceRefresh: (() => void | Promise<void>) | undefined = undefined;
+  interface Props {
+    npub: string;
+    peerDisplayName: string;
+    onClose: () => void;
+    watchedAssetRows?: WatchedErc20Row[];
+    /** From Accept on a payment request: network, asset, amount, request id. */
+    formPrefill?: WalletSendPrefillPayload | null;
+    postDmPlaintext?: ((content: string) => Promise<boolean>) | undefined;
+    /** Refresh balances after a send confirms in the background. */
+    onBalanceRefresh?: (() => void | Promise<void>) | undefined;
+  }
+
+  let {
+    npub,
+    peerDisplayName,
+    onClose,
+    watchedAssetRows = [],
+    formPrefill = null,
+    postDmPlaintext = undefined,
+    onBalanceRefresh = undefined,
+  }: Props = $props();
 </script>
 
 <WalletTransferStubModal

--- a/src/components/wallet/WalletTransferStubModal.svelte
+++ b/src/components/wallet/WalletTransferStubModal.svelte
@@ -44,19 +44,31 @@
 
   const tFn = get(t);
 
-  export let mode: 'send' | 'request';
-  export let npub: string;
-  export let peerDisplayName: string;
-  export let onClose: () => void;
-  /** Request mode: post JSON DM (`wallet_tx_request`). Same path as normal DM send. */
-  export let postDmPlaintext: ((content: string) => Promise<boolean>) | undefined = undefined;
-  /** Send mode: from Accept on a `wallet_tx_request` (applied once per open). */
-  export let formPrefill: WalletSendPrefillPayload | null = null;
-  /** Send mode: refresh balances after confirmation (chat note is handled in background). */
-  export let onBalanceRefresh: (() => void | Promise<void>) | undefined = undefined;
+  interface Props {
+    mode: 'send' | 'request';
+    npub: string;
+    peerDisplayName: string;
+    onClose: () => void;
+    /** Request mode: post JSON DM (`wallet_tx_request`). Same path as normal DM send. */
+    postDmPlaintext?: ((content: string) => Promise<boolean>) | undefined;
+    /** Send mode: from Accept on a `wallet_tx_request` (applied once per open). */
+    formPrefill?: WalletSendPrefillPayload | null;
+    /** Send mode: refresh balances after confirmation (chat note is handled in background). */
+    onBalanceRefresh?: (() => void | Promise<void>) | undefined;
+    /** ERC-20 rows the user watches (from Import tokens); native ETH is always offered. */
+    watchedAssetRows?: WatchedErc20Row[];
+  }
 
-  /** ERC-20 rows the user watches (from Import tokens); native ETH is always offered. */
-  export let watchedAssetRows: WatchedErc20Row[] = [];
+  let {
+    mode,
+    npub,
+    peerDisplayName,
+    onClose,
+    postDmPlaintext = undefined,
+    formPrefill = null,
+    onBalanceRefresh = undefined,
+    watchedAssetRows = [],
+  }: Props = $props();
 
   function truncateNpub(n: string): string {
     if (n.length <= 20) return n;
@@ -66,102 +78,107 @@
   const titleId = `wallet-${mode}-title`;
   const descId = `wallet-${mode}-desc`;
 
-  let chainId: SupportedChainId = DEFAULT_CHAIN_ID;
-  let assetCode = 'ETH';
-  let amountStr = '';
+  let chainId: SupportedChainId = $state(DEFAULT_CHAIN_ID);
+  let assetCode = $state('ETH');
+  let amountStr = $state('');
 
-  let appliedPrefillKey = '';
-  let linkedRequestId = '';
+  let appliedPrefillKey = $state('');
+  let linkedRequestId = $state('');
 
-  $: prefillKey =
+  const prefillKey = $derived(
     mode === 'send' && formPrefill
       ? `${formPrefill.requestMessageId}:${formPrefill.requestId}`
-      : '';
+      : ''
+  );
 
-  $: if (mode === 'send' && formPrefill && prefillKey !== appliedPrefillKey) {
+  /** Applies an incoming prefill exactly once per key, and clears the applied key once the
+   * prefill is withdrawn, without re-applying on every render. */
+  $effect(() => {
+    if (mode !== 'send') return;
+    if (!formPrefill) {
+      appliedPrefillKey = '';
+      linkedRequestId = '';
+      return;
+    }
+    if (prefillKey === appliedPrefillKey) return;
     appliedPrefillKey = prefillKey;
     chainId = formPrefill.network;
     assetCode = formPrefill.asset;
     amountStr = normalizeLeadingDotDecimalInput(formPrefill.amount.trim());
     linkedRequestId = formPrefill.requestId;
-  }
+  });
 
-  $: if (mode === 'send' && !formPrefill) {
-    appliedPrefillKey = '';
-    linkedRequestId = '';
-  }
+  let pricesResult = $state<
+    { ok: true; prices: WalletUsdSpotPrices } | { ok: false; message: string } | null
+  >(null);
+  let pricesFetchKey = $state('');
+  let pricesFetchGen = $state(0);
 
-  let pricesResult:
-    | { ok: true; prices: WalletUsdSpotPrices }
-    | { ok: false; message: string }
-    | null = null;
-  let pricesFetchKey = '';
-  let pricesFetchGen = 0;
-
-  $: {
+  $effect(() => {
     const key = `${mode}|${chainId}`;
     if (mode !== 'send') {
       pricesFetchKey = '';
       pricesResult = null;
-    } else if (key !== pricesFetchKey) {
-      pricesFetchKey = key;
-      pricesFetchGen += 1;
-      const gen = pricesFetchGen;
-      pricesResult = null;
-      getWalletUsdSpotPrices(chainId).then((r) => {
-        if (gen !== pricesFetchGen) return;
-        pricesResult = r;
-      });
+      return;
     }
-  }
+    if (key === pricesFetchKey) return;
+    pricesFetchKey = key;
+    pricesFetchGen += 1;
+    const gen = pricesFetchGen;
+    pricesResult = null;
+    getWalletUsdSpotPrices(chainId).then((r) => {
+      if (gen !== pricesFetchGen) return;
+      pricesResult = r;
+    });
+  });
 
-  $: assetOptions = listWalletAssetOptionsForChainWithWatched(
-    chainId,
-    watchedAssetRows
-  ) as WalletAssetOptionRow[];
+  const assetOptions = $derived(
+    listWalletAssetOptionsForChainWithWatched(chainId, watchedAssetRows) as WalletAssetOptionRow[]
+  );
 
-  $: {
+  $effect(() => {
     const codes = assetOptions.map((o) => o.code);
     if (codes.length > 0 && !codes.includes(assetCode)) {
       assetCode = codes[0] ?? 'ETH';
     }
-  }
+  });
 
-  $: selectedOpt = assetOptions.find((o) => o.code === assetCode);
+  const selectedOpt = $derived(assetOptions.find((o) => o.code === assetCode));
 
-  let sendBalanceSummary: WalletSummary | null = null;
-  let sendBalanceError: string | null = null;
-  let sendBalanceLoading = false;
-  let sendBalanceFetchKey = '';
-  let sendBalanceFetchGen = 0;
+  let sendBalanceSummary: WalletSummary | null = $state(null);
+  let sendBalanceError: string | null = $state(null);
+  let sendBalanceLoading = $state(false);
+  let sendBalanceFetchKey = $state('');
+  let sendBalanceFetchGen = $state(0);
 
-  $: watchedWireForBalances = watchedRowsToWire(watchedAssetRows);
+  const watchedWireForBalances = $derived(watchedRowsToWire(watchedAssetRows));
 
-  $: if (mode !== 'send') {
-    sendBalanceFetchKey = '';
-    sendBalanceSummary = null;
-    sendBalanceError = null;
-    sendBalanceLoading = false;
-  } else {
-    const key = `${chainId}|${watchedWireFingerprint(watchedWireForBalances)}`;
-    if (key !== sendBalanceFetchKey) {
-      sendBalanceFetchKey = key;
-      sendBalanceFetchGen += 1;
-      const gen = sendBalanceFetchGen;
-      sendBalanceLoading = true;
+  $effect(() => {
+    if (mode !== 'send') {
+      sendBalanceFetchKey = '';
+      sendBalanceSummary = null;
       sendBalanceError = null;
-      getWalletSummary(watchedWireForBalances, [chainId]).then((r) => {
-        if (gen !== sendBalanceFetchGen) return;
-        sendBalanceLoading = false;
-        if (r.ok) {
-          sendBalanceSummary = r.summary;
-        } else {
-          sendBalanceSummary = null;
-          sendBalanceError = r.message;
-        }
-      });
+      sendBalanceLoading = false;
+      return;
     }
-  }
+    const key = `${chainId}|${watchedWireFingerprint(watchedWireForBalances)}`;
+    if (key === sendBalanceFetchKey) return;
+    sendBalanceFetchKey = key;
+    sendBalanceFetchGen += 1;
+    const gen = sendBalanceFetchGen;
+    sendBalanceLoading = true;
+    sendBalanceError = null;
+    getWalletSummary(watchedWireForBalances, [chainId]).then((r) => {
+      if (gen !== sendBalanceFetchGen) return;
+      sendBalanceLoading = false;
+      if (r.ok) {
+        sendBalanceSummary = r.summary;
+      } else {
+        sendBalanceSummary = null;
+        sendBalanceError = r.message;
+      }
+    });
+  });
 
   function findBalanceForAsset(
     summary: WalletSummary | null,
@@ -176,8 +193,9 @@
     return { balanceRaw: asset.balanceRaw, balanceDecimal: asset.balanceDecimal };
   }
 
-  $: selectedBalanceRow =
-    mode === 'send' ? findBalanceForAsset(sendBalanceSummary, chainId, assetCode) : null;
+  const selectedBalanceRow = $derived(
+    mode === 'send' ? findBalanceForAsset(sendBalanceSummary, chainId, assetCode) : null
+  );
 
   /** Compare human amount to `balance_raw` (integer string) using asset decimals. */
   function amountExceedsBalance(amountTrimmed: string, balanceRaw: string, decimals: number): boolean {
@@ -198,30 +216,33 @@
     return n;
   }
 
-  $: amountValid = parsePositiveAmount(amountStr) !== null;
-  let sending = false;
+  const amountValid = $derived(parsePositiveAmount(amountStr) !== null);
+  let sending = $state(false);
   /** Request mode: brief resolve of signer address before optimistic post. */
-  let requestPosting = false;
-  let sendError: { message: string; txHash?: string; code?: string } | null = null;
+  let requestPosting = $state(false);
+  let sendError = $state<{ message: string; txHash?: string; code?: string } | null>(null);
 
-  $: insufficientFunds =
+  const insufficientFunds = $derived(
     mode === 'send' &&
-    amountValid &&
-    selectedOpt != null &&
-    selectedBalanceRow != null &&
-    amountExceedsBalance(amountStr.trim(), selectedBalanceRow.balanceRaw, selectedOpt.decimals);
+      amountValid &&
+      selectedOpt != null &&
+      selectedBalanceRow != null &&
+      amountExceedsBalance(amountStr.trim(), selectedBalanceRow.balanceRaw, selectedOpt.decimals)
+  );
 
-  $: canConfirm =
+  const canConfirm = $derived(
     amountValid &&
-    !sending &&
-    !requestPosting &&
-    selectedOpt != null &&
-    (mode === 'request' || !insufficientFunds);
-  $: explorerLinkForError =
+      !sending &&
+      !requestPosting &&
+      selectedOpt != null &&
+      (mode === 'request' || !insufficientFunds)
+  );
+  const explorerLinkForError = $derived(
     sendError?.txHash != null && sendError.txHash.length > 0
       ? getExplorerTxUrl(chainId, sendError.txHash)
-      : null;
-  $: explorerLinkLabel = explorerTxLinkLabel(chainId);
+      : null
+  );
+  const explorerLinkLabel = $derived(explorerTxLinkLabel(chainId));
 
   async function copyErrorTxHash() {
     const h = sendError?.txHash;
@@ -231,11 +252,12 @@
   }
 
   /** Receipt timeout: tx was already broadcast; another Confirm would risk a duplicate send. */
-  $: canRetryAfterError =
+  const canRetryAfterError = $derived(
     sendError != null &&
-    !sending &&
-    !requestPosting &&
-    (mode === 'request' || sendError.code !== 'RECEIPT_TIMEOUT');
+      !sending &&
+      !requestPosting &&
+      (mode === 'request' || sendError.code !== 'RECEIPT_TIMEOUT')
+  );
 
   async function retryFailedSend() {
     if (!sendError || sending || !canRetryAfterError) return;
@@ -243,12 +265,13 @@
     await handleConfirm();
   }
 
-  $: approxUsd =
+  const approxUsd = $derived(
     pricesResult?.ok === true && amountValid
       ? amountToApproxUsd(amountStr, assetCode, pricesResult.prices)
-      : null;
+      : null
+  );
 
-  $: usdLine =
+  const usdLine = $derived(
     pricesResult === null
       ? tFn('wallet.loadingUsdRates')
       : !pricesResult.ok
@@ -259,7 +282,8 @@
             ? tFn('wallet.enterAmountForUsd')
             : amountValid
               ? tFn('wallet.usdUnavailable')
-              : tFn('wallet.enterAmountForUsd');
+              : tFn('wallet.enterAmountForUsd')
+  );
 
   function onAmountInput(e: Event) {
     const el = e.currentTarget as HTMLInputElement;

--- a/src/components/wallet/WalletTransferStubModal.test.ts
+++ b/src/components/wallet/WalletTransferStubModal.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+
+vi.mock('../../lib/wallet', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/wallet')>();
+  return {
+    ...actual,
+    getWalletSummary: vi.fn(async () => ({ ok: false, message: 'not fetched in test' })),
+    walletBuildAndSendTransaction: vi.fn(),
+  };
+});
+
+vi.mock('../../lib/wallet/pricing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/wallet/pricing')>();
+  return {
+    ...actual,
+    getWalletUsdSpotPrices: vi.fn(async () => ({ ok: false, message: 'not fetched in test' })),
+  };
+});
+
+import WalletTransferStubModal from './WalletTransferStubModal.svelte';
+import type { WalletSendPrefillPayload } from '../../stores/app';
+
+afterEach(() => {
+  cleanup();
+});
+
+function prefill(overrides: Partial<WalletSendPrefillPayload> = {}): WalletSendPrefillPayload {
+  return {
+    targetNpub: 'npub1peer',
+    network: 'mainnet',
+    asset: 'ETH',
+    amount: '1.5',
+    requestId: 'req-1',
+    requestMessageId: 'msg-1',
+    ...overrides,
+  };
+}
+
+describe('WalletTransferStubModal prefill guard', () => {
+  it('applies formPrefill once on open and never overwrites an edit made after it lands', async () => {
+    const onClose = vi.fn();
+    const { rerender } = render(WalletTransferStubModal, {
+      props: {
+        mode: 'send',
+        npub: 'npub1peer',
+        peerDisplayName: 'Peer',
+        onClose,
+        formPrefill: prefill(),
+      },
+    });
+
+    const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
+    const networkSelect = screen.getByLabelText('Network') as HTMLSelectElement;
+    expect(amountInput.value).toBe('1.5');
+    expect(networkSelect.value).toBe('mainnet');
+
+    // User edits the amount after the prefill has already been applied.
+    await fireEvent.input(amountInput, { target: { value: '9.99' } });
+    expect(amountInput.value).toBe('9.99');
+
+    // An unrelated re-render (same prefill request) must not re-run the guard and
+    // stomp the user's edit -- this is the exact loop/overwrite risk a naive bare
+    // $effect on formPrefill would introduce.
+    await rerender({
+      mode: 'send',
+      npub: 'npub1peer',
+      peerDisplayName: 'Peer (renamed)',
+      onClose,
+      formPrefill: prefill(),
+    });
+
+    expect(amountInput.value).toBe('9.99');
+    expect(networkSelect.value).toBe('mainnet');
+  });
+
+  it('applies a new prefill (distinct request) after the previous one was cleared', async () => {
+    const onClose = vi.fn();
+    const { rerender } = render(WalletTransferStubModal, {
+      props: {
+        mode: 'send',
+        npub: 'npub1peer',
+        peerDisplayName: 'Peer',
+        onClose,
+        formPrefill: prefill(),
+      },
+    });
+
+    const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
+    expect(amountInput.value).toBe('1.5');
+
+    // Prefill withdrawn (e.g. Send opened directly, no accepted request).
+    await rerender({
+      mode: 'send',
+      npub: 'npub1peer',
+      peerDisplayName: 'Peer',
+      onClose,
+      formPrefill: null,
+    });
+
+    // A second, distinct request arrives -- must apply since it is a new key.
+    await rerender({
+      mode: 'send',
+      npub: 'npub1peer',
+      peerDisplayName: 'Peer',
+      onClose,
+      formPrefill: prefill({ amount: '3', requestId: 'req-2', requestMessageId: 'msg-2' }),
+    });
+
+    expect(amountInput.value).toBe('3');
+  });
+});

--- a/src/components/wallet/WalletTxAnnouncementCard.svelte
+++ b/src/components/wallet/WalletTxAnnouncementCard.svelte
@@ -9,24 +9,31 @@
   import { copyTextToClipboard } from '../../lib/wallet/clipboard-copy';
   import { showToast } from '../../stores/toast';
 
-  export let payload: WalletTxAnnouncementPayload;
-  /** DM counterparty display name (thread peer). */
-  export let peerDisplayName: string;
-  /** True when the signed-in user posted this announcement (`from_npub`). */
-  export let viewerIsSender: boolean;
-  /** Pending on-chain confirmation (optimistic outbound). */
-  export let pending = false;
-  /** Send or confirmation failed. */
-  export let failed = false;
+  interface Props {
+    payload: WalletTxAnnouncementPayload;
+    /** DM counterparty display name (thread peer). */
+    peerDisplayName: string;
+    /** True when the signed-in user posted this announcement (`from_npub`). */
+    viewerIsSender: boolean;
+    /** Pending on-chain confirmation (optimistic outbound). */
+    pending?: boolean;
+    /** Send or confirmation failed. */
+    failed?: boolean;
+  }
 
-  $: networkLabel = getWalletNetworkDisplayName(payload.network);
-  $: badgeLabel = failed ? $t('wallet.transferFailed') : pending ? $t('wallet.transferPending') : $t('wallet.transferConfirmed');
-  $: iconGlyph = failed ? '!' : pending ? '…' : '✓';
-  $: fromAddr = payload.from_evm_address.trim();
-  $: fromAddrShort =
-    fromAddr.length > 14 ? `${fromAddr.slice(0, 8)}…${fromAddr.slice(-6)}` : fromAddr;
-  $: explorerUrl = getExplorerTxUrl(payload.network, payload.tx_hash);
-  $: explorerLabel = explorerTxLinkLabel(payload.network);
+  let { payload, peerDisplayName, viewerIsSender, pending = false, failed = false }: Props = $props();
+
+  const networkLabel = $derived(getWalletNetworkDisplayName(payload.network));
+  const badgeLabel = $derived(
+    failed ? $t('wallet.transferFailed') : pending ? $t('wallet.transferPending') : $t('wallet.transferConfirmed')
+  );
+  const iconGlyph = $derived(failed ? '!' : pending ? '…' : '✓');
+  const fromAddr = $derived(payload.from_evm_address.trim());
+  const fromAddrShort = $derived(
+    fromAddr.length > 14 ? `${fromAddr.slice(0, 8)}…${fromAddr.slice(-6)}` : fromAddr
+  );
+  const explorerUrl = $derived(getExplorerTxUrl(payload.network, payload.tx_hash));
+  const explorerLabel = $derived(explorerTxLinkLabel(payload.network));
 
   async function copyHash() {
     const ok = await copyTextToClipboard(payload.tx_hash);

--- a/src/components/wallet/WalletTxRequestCard.svelte
+++ b/src/components/wallet/WalletTxRequestCard.svelte
@@ -3,26 +3,33 @@
   import type { WalletTxRequestPayload } from '../../lib/wallet/dm-messages';
   import { getWalletNetworkDisplayName } from '../../lib/wallet/assets';
 
-  export let payload: WalletTxRequestPayload;
-  export let isMine: boolean;
-  /** Display name of the counterparty (the other person in the DM). */
-  export let peerDisplayName: string;
-  export let status: 'pending' | 'declined' | 'fulfilled' | 'sending';
-  export let accepting: boolean;
-  export let onAccept: () => void;
-  export let onDecline: () => void;
+  interface Props {
+    payload: WalletTxRequestPayload;
+    isMine: boolean;
+    /** Display name of the counterparty (the other person in the DM). */
+    peerDisplayName: string;
+    status: 'pending' | 'declined' | 'fulfilled' | 'sending';
+    accepting: boolean;
+    onAccept: () => void;
+    onDecline: () => void;
+  }
 
-  $: networkLabel = getWalletNetworkDisplayName(payload.network);
-  $: title = `${payload.amount} ${payload.asset}`;
-  $: fromAddr = payload.from_evm_address.trim();
-  $: fromAddrShort =
-    fromAddr.length > 14 ? `${fromAddr.slice(0, 8)}…${fromAddr.slice(-6)}` : fromAddr;
-  $: subtitle = `${networkLabel} · ${fromAddrShort}`;
-  $: bodyText = isMine
-    ? $t('wallet.requestedPaymentOn', { values: { networkLabel, fromAddrShort } })
-    : $t('wallet.peerRequestedPayment', { values: { peerName: peerDisplayName, fromAddrShort } });
+  let { payload, isMine, peerDisplayName, status, accepting, onAccept, onDecline }: Props = $props();
+
+  const networkLabel = $derived(getWalletNetworkDisplayName(payload.network));
+  const title = $derived(`${payload.amount} ${payload.asset}`);
+  const fromAddr = $derived(payload.from_evm_address.trim());
+  const fromAddrShort = $derived(
+    fromAddr.length > 14 ? `${fromAddr.slice(0, 8)}…${fromAddr.slice(-6)}` : fromAddr
+  );
+  const subtitle = $derived(`${networkLabel} · ${fromAddrShort}`);
+  const bodyText = $derived(
+    isMine
+      ? $t('wallet.requestedPaymentOn', { values: { networkLabel, fromAddrShort } })
+      : $t('wallet.peerRequestedPayment', { values: { peerName: peerDisplayName, fromAddrShort } })
+  );
   /** Declined stays expanded; fulfilled compacts to amount + Paid. */
-  $: collapsed = status === 'fulfilled';
+  const collapsed = $derived(status === 'fulfilled');
 </script>
 
 <div

--- a/src/components/wallet/WalletView.svelte
+++ b/src/components/wallet/WalletView.svelte
@@ -44,36 +44,40 @@
 
   const tFn = get(t);
 
-  /** When true, omit the standalone page title (embedded under Settings → EVM). */
-  export let embeddedInSettings = false;
+  interface Props {
+    /** When true, omit the standalone page title (embedded under Settings → EVM). */
+    embeddedInSettings?: boolean;
+  }
 
-  let importModalOpen = false;
-  let homeSendOpen = false;
-  let receiveOpen = false;
-  let watchedRows: WatchedErc20Row[] = [];
-  let enabledSet = new Set<SupportedChainId>(defaultWalletEnabledChains());
-  let tokenNetworkFilter: 'all' | SupportedChainId = DEFAULT_PREFERRED_NETWORK;
+  let { embeddedInSettings = false }: Props = $props();
 
-  $: walletAccountLabelMaxLength = $appConfig.walletAccountLabelMaxLength;
+  let importModalOpen = $state(false);
+  let homeSendOpen = $state(false);
+  let receiveOpen = $state(false);
+  let watchedRows: WatchedErc20Row[] = $state([]);
+  let enabledSet = $state(new Set<SupportedChainId>(defaultWalletEnabledChains()));
+  let tokenNetworkFilter: 'all' | SupportedChainId = $state(DEFAULT_PREFERRED_NETWORK);
 
-  $: accountNpub = $currentUser?.npub ?? null;
+  const walletAccountLabelMaxLength = $derived($appConfig.walletAccountLabelMaxLength);
 
-  let evmAddress: string | null = null;
+  const accountNpub = $derived($currentUser?.npub ?? null);
 
-  let evmAccountList: EvmAccountRow[] = [];
-  let accountsLoading = false;
-  let importKeyModalOpen = false;
-  let importKeyInput = '';
-  let importKeyBusy = false;
+  let evmAddress: string | null = $state(null);
+
+  let evmAccountList: EvmAccountRow[] = $state([]);
+  let accountsLoading = $state(false);
+  let importKeyModalOpen = $state(false);
+  let importKeyInput = $state('');
+  let importKeyBusy = $state(false);
 
   /** Unified add / edit account modal (same fields as add). */
-  let accountFormMode: 'add' | 'edit' | null = null;
-  let accountFormPurpose: EvmAccountPurpose = 'squad';
-  let accountFormEditId: string | null = null;
-  let accountFormLabel = '';
-  let accountFormSetSigning = false;
-  let accountFormSetReceiving = false;
-  let accountFormBusy = false;
+  let accountFormMode: 'add' | 'edit' | null = $state(null);
+  let accountFormPurpose = $state<EvmAccountPurpose>('squad');
+  let accountFormEditId: string | null = $state(null);
+  let accountFormLabel = $state('');
+  let accountFormSetSigning = $state(false);
+  let accountFormSetReceiving = $state(false);
+  let accountFormBusy = $state(false);
 
   async function loadEvmAccountsList() {
     if (!accountNpub) {
@@ -107,7 +111,10 @@
     await loadEvmAccountsList();
   }
 
-  $: accountNpub, void refreshEvmAddress();
+  $effect(() => {
+    void accountNpub;
+    void refreshEvmAddress();
+  });
 
   function syncFromDisk() {
     if (!accountNpub) return;
@@ -115,19 +122,23 @@
     enabledSet = new Set(loadWalletEnabledChains(accountNpub));
   }
 
-  $: accountNpub, $walletUiEnabledChainsTick, syncFromDisk();
+  $effect(() => {
+    void accountNpub;
+    void $walletUiEnabledChainsTick;
+    syncFromDisk();
+  });
 
-  $: if (
-    embeddedInSettings &&
-    ($settingsSectionCollapsed['settings-evm'] ?? true)
-  ) {
+  /** Auto-closes account/import modals once the EVM settings section collapses. */
+  $effect(() => {
+    if (!embeddedInSettings) return;
+    if (!($settingsSectionCollapsed['settings-evm'] ?? true)) return;
     if (accountFormMode) closeAccountFormModal();
     if (importKeyModalOpen && !importKeyBusy) {
       importKeyModalOpen = false;
       importKeyInput = '';
     }
     if (importModalOpen) importModalOpen = false;
-  }
+  });
 
   onMount(syncFromDisk);
 
@@ -276,13 +287,15 @@
   }
 
   /** Enabled chains in catalog order (Send network list + settings). */
-  $: enabledChainsOrdered = WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledSet.has(id));
+  const enabledChainsOrdered = $derived(WALLET_ASSETS_CHAIN_IDS.filter((id) => enabledSet.has(id)));
 
   /** Kind 0 / profile default; when unset, receiving matches the signing address. */
-  $: profileDefaultEvmAddress = evmAccountList.find((a) => a.isDefaultShared)?.address?.trim() || null;
-  $: displayReceivingAddress = profileDefaultEvmAddress ?? evmAddress;
-  $: squadAccountList = squadEvmAccounts(evmAccountList);
-  $: accountFormIsAdvanced = accountFormPurpose === 'advanced';
+  const profileDefaultEvmAddress = $derived(
+    evmAccountList.find((a) => a.isDefaultShared)?.address?.trim() || null
+  );
+  const displayReceivingAddress = $derived(profileDefaultEvmAddress ?? evmAddress);
+  const squadAccountList = $derived(squadEvmAccounts(evmAccountList));
+  const accountFormIsAdvanced = $derived(accountFormPurpose === 'advanced');
 </script>
 
 <div class="wallet-view" class:wallet-view--embedded={embeddedInSettings} aria-labelledby={embeddedInSettings ? undefined : 'wallet-view-title'}>


### PR DESCRIPTION
## Summary

Converts all 13 files under `src/components/wallet/` (5001 lines) from Svelte 4 legacy reactivity (`export let`, `$:`) to Svelte 5 runes (`$props`, `$state`, `$derived`, `$effect`). Part of the epic-wide runes migration (pacto-app-a7r); this unit covers the DM wallet bar, both send modals, the advanced contract-call panel, token import, and the tx request/announcement cards.

The highest-risk pattern in this batch is a form-prefill guard shared by both send modals: a reactive block that compares a computed key against a previously-applied key, applies the prefill once, and writes the applied key back — a shape that loops if converted naively to a bare `$effect` (it writes a value it also reads). `WalletTransferStubModal.svelte` was converted first to derive the safe guarded-effect pattern (compare-then-write, sentinel write kept inside the guard), then the same pattern was applied to `WalletHomeSendModal.svelte`'s close/reopen reset guard, `WalletBar.svelte`'s network-filter fallback, and the asset/chain self-correction effects repeated across the batch. Every other non-derivable reactive statement was triaged individually: pure computations became `$derived`/`$derived.by`, and genuine external-sync statements (peer-readiness polling, watched-token reloads) became plain `$effect`s.

`WalletAdvancedPanel.svelte`'s 11 `bind:` usages all target native form elements bound to local component state, not component props, so none needed `$bindable()`. `ChainIdSelect.svelte` does receive a two-way `bind:value` from a parent (`ParentDashboardModals.svelte`, out of scope) and its `value` prop was made `$bindable()` accordingly.

## Changes

- `WalletTransferStubModal.svelte`, `WalletHomeSendModal.svelte`: props to `$props()`, ~30 reactive statements triaged (mostly `$derived`, four guarded `$effect`s each for prefill-apply, price/balance fetch keys, and asset self-correction).
- `WalletBar.svelte`: same triage for peer-readiness, watched-row reload, enabled-chain-set, and network-filter-fallback guards.
- `WalletAdvancedPanel.svelte`: props/state conversion; calldata-rebuild and account-refresh side effects converted to explicit-dependency `$effect`s (no `$bindable()` needed since all `bind:` targets are native elements).
- `WalletView.svelte`: same triage, including a settings-collapse guard that closes open sub-modals.
- `ChainIdSelect.svelte`: `value` prop made `$bindable()` for its cross-file parent binding.
- `WalletImportTokensModal.svelte`, `WalletPeerExchangeCard.svelte`, `WalletTxAnnouncementCard.svelte`, `WalletTxRequestCard.svelte`, `WalletReceiveModal.svelte`, `WalletRequestModal.svelte`, `WalletSendModal.svelte`: mechanical prop/derived conversion (no side effects beyond `WalletImportTokensModal`'s open-once form-reset guard, converted with the same pattern).
- Two new jsdom component tests (`WalletTransferStubModal.test.ts`, `WalletHomeSendModal.test.ts`) that specifically exercise the prefill/reset guards: prefill applies once and survives an unrelated re-render without wiping a user's in-progress edit, a new prefill (distinct request) still applies, and the home-send form clears on close/reopen but not while the user is mid-edit.

## Test plan

- `pnpm check` -- 0 errors (2 pre-existing informational `state_referenced_locally` warnings on non-reactive title/desc IDs, unrelated to correctness).
- `pnpm lint` -- 0 problems.
- `pnpm test` -- full suite green (242 files / 2189 tests), including the two new guard tests.
- By hand (reasoned through code paths, not run against a live wallet): send flow from the wallet bar and from a transfer request both route through the same guarded prefill/apply logic now covered by tests; chain switching re-triggers the asset/balance/price guards via their key comparisons unchanged from the Svelte 4 behavior; insufficient-funds derivation is a straight `$derived` port with no logic change; failed-tx error text is passed through verbatim from the Tauri backend (redaction happens server-side in `src-tauri`, untouched by this PR) so no RPC URL exposure risk was introduced.

Manual QA follow-up for a human reviewer: the chain-switching, insufficient-funds, and real testnet send/request flows were verified by code-path reasoning and the automated suite, not exercised against a live wallet/testnet in this session.

Closes pacto-app-a7r.13

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
