### PR TITLE
refactor(pacto-app-a7r.16): convert parent dashboard tabs and modals to Svelte 5 runes

### DIFF
--- a/src/components/parent/dashboard/DashboardCrewTab.svelte
+++ b/src/components/parent/dashboard/DashboardCrewTab.svelte
@@ -27,50 +27,76 @@
   import RpcReadErrorCard from './RpcReadErrorCard.svelte';
   import { rpcReadErrorKind } from '../../../lib/squad/rpc-read-error';
 
-  export let squad: Squad;
-  export let announcementsGroupId: string | null = null;
-  export let channelMembers: string[] = [];
-  export let loadingMembers = false;
-  export let settingsChainError = '';
-  export let settingsChainLoading = false;
-  export let settingsChainRefreshing = false;
-  export let squadMemberEvmByNpub: Record<string, string> = {};
-  export let memberHatByAddress: Record<string, string> = {};
-  export let memberRolesByAddress: Record<string, string> = {};
-  export let onOpenSquadRolesModal: () => void = () => {};
-  export let showManagePrivileges = false;
-  export let pactoGovRevision = '';
+  let {
+    squad,
+    announcementsGroupId = null,
+    channelMembers = [],
+    loadingMembers = false,
+    settingsChainError = '',
+    settingsChainLoading = false,
+    settingsChainRefreshing = false,
+    squadMemberEvmByNpub = {},
+    memberHatByAddress = {},
+    memberRolesByAddress = {},
+    onOpenSquadRolesModal = () => {},
+    showManagePrivileges = false,
+    pactoGovRevision = '',
+    sponsorExtStatus = null,
+    sponsorExtLoading = false,
+    sponsorExtError = '',
+    sponsorNetwork = '',
+    parentId = '',
+    onRefreshSponsorExt = () => {},
+    sponsorHatsMode = false,
+    hasSponsor = false,
+    captainWearers = [],
+    crewWearers = [],
+  }: {
+    squad: Squad;
+    announcementsGroupId?: string | null;
+    channelMembers?: string[];
+    loadingMembers?: boolean;
+    settingsChainError?: string;
+    settingsChainLoading?: boolean;
+    settingsChainRefreshing?: boolean;
+    squadMemberEvmByNpub?: Record<string, string>;
+    memberHatByAddress?: Record<string, string>;
+    memberRolesByAddress?: Record<string, string>;
+    onOpenSquadRolesModal?: () => void;
+    showManagePrivileges?: boolean;
+    pactoGovRevision?: string;
+    /** Sponsor Ext eligibility (null when no Ext sponsor / not loaded). */
+    sponsorExtStatus?: SquadSponsorExtStatusDto | null;
+    sponsorExtLoading?: boolean;
+    sponsorExtError?: string;
+    sponsorNetwork?: string;
+    parentId?: string;
+    onRefreshSponsorExt?: () => void;
+    /** Hats-linked sponsor: eligibility from captain/crew wear. */
+    sponsorHatsMode?: boolean;
+    hasSponsor?: boolean;
+    captainWearers?: string[];
+    crewWearers?: string[];
+  } = $props();
 
-  /** Sponsor Ext eligibility (null when no Ext sponsor / not loaded). */
-  export let sponsorExtStatus: SquadSponsorExtStatusDto | null = null;
-  export let sponsorExtLoading = false;
-  export let sponsorExtError = '';
-  export let sponsorNetwork = '';
-  export let parentId = '';
-  export let onRefreshSponsorExt: () => void = () => {};
-  /** Hats-linked sponsor: eligibility from captain/crew wear. */
-  export let sponsorHatsMode = false;
-  export let hasSponsor = false;
-  export let captainWearers: string[] = [];
-  export let crewWearers: string[] = [];
+  let sponsoringAddress = $state('');
+  let rosterKeyNeeded = $state(false);
 
-  let sponsoringAddress = '';
-  let rosterKeyNeeded = false;
-
-  $: myNpub = $currentUser?.npub ?? '';
-  $: displayEvmByNpub = squadMemberEvmForDisplay(squadMemberEvmByNpub, myNpub, rosterKeyNeeded);
-  $: myRosterEvm = (myNpub ? displayEvmByNpub[myNpub]?.trim() : '') || '';
-  $: npubByAddress = npubByEvmAddressFromSquadRoster(displayEvmByNpub);
-  $: permittedByAddress = permittedByAddressFromExtStatus(sponsorExtStatus?.memberPermits ?? []);
-  $: addressOwner = sponsorExtStatus?.addressOwner?.trim().toLowerCase() ?? '';
-  $: ownerNpub = addressOwner ? npubByAddress[addressOwner] : undefined;
-  $: iAmSponsorOwner =
-    !!addressOwner && !!myRosterEvm && myRosterEvm.toLowerCase() === addressOwner;
-  $: hatsWired = sponsorExtStatus?.hatsWired === true;
-  $: canManagePermits = iAmSponsorOwner && !hatsWired && !!sponsorNetwork && !!parentId;
-  $: showSponsoredCol = hasSponsor && (sponsorHatsMode || !!sponsorExtStatus || sponsorExtLoading || !!sponsorExtError);
-  $: sponsorExtRpcKind = rpcReadErrorKind(sponsorExtError);
-  $: settingsChainRpcKind = rpcReadErrorKind(settingsChainError);
+  const myNpub = $derived($currentUser?.npub ?? '');
+  const displayEvmByNpub = $derived(squadMemberEvmForDisplay(squadMemberEvmByNpub, myNpub, rosterKeyNeeded));
+  const myRosterEvm = $derived((myNpub ? displayEvmByNpub[myNpub]?.trim() : '') || '');
+  const npubByAddress = $derived(npubByEvmAddressFromSquadRoster(displayEvmByNpub));
+  const permittedByAddress = $derived(permittedByAddressFromExtStatus(sponsorExtStatus?.memberPermits ?? []));
+  const addressOwner = $derived(sponsorExtStatus?.addressOwner?.trim().toLowerCase() ?? '');
+  const ownerNpub = $derived(addressOwner ? npubByAddress[addressOwner] : undefined);
+  const iAmSponsorOwner = $derived(
+    !!addressOwner && !!myRosterEvm && myRosterEvm.toLowerCase() === addressOwner,
+  );
+  const hatsWired = $derived(sponsorExtStatus?.hatsWired === true);
+  const canManagePermits = $derived(iAmSponsorOwner && !hatsWired && !!sponsorNetwork && !!parentId);
+  const showSponsoredCol = $derived(hasSponsor && (sponsorHatsMode || !!sponsorExtStatus || sponsorExtLoading || !!sponsorExtError));
+  const sponsorExtRpcKind = $derived(rpcReadErrorKind(sponsorExtError));
+  const settingsChainRpcKind = $derived(rpcReadErrorKind(settingsChainError));
 
   onMount(() => {
     if (!parentId) return;

--- a/src/components/parent/dashboard/DashboardGovernanceTab.svelte
+++ b/src/components/parent/dashboard/DashboardGovernanceTab.svelte
@@ -8,25 +8,45 @@
   import { parseSupportedChainId } from '../../../lib/wallet/chains';
   import { isTreasuryProposalActive } from '../../../lib/governance/treasury-proposal-ui';
 
-  export let squadInfraRows: SquadInfraDto[] | undefined = undefined;
-  export let pactoPayload: PactoGovProviderPayloadV1 | null = null;
-  export let pactoGovChain: string | undefined = undefined;
-  export let parentId = '';
-  export let myAddress = '';
-  export let captainWearers: string[] = [];
-  export let crewWearers: string[] = [];
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let treasuryProposals: TreasuryProposalDto[] = [];
-  export let treasuryProposalsLoading = false;
-  export let treasuryProposalsRefreshing = false;
-  export let treasuryProposalsError = '';
-  export let onRefreshProposals: () => void = () => {};
-  export let onOpenLaunchpad: () => void = () => {};
-  export let hasSponsor = false;
+  interface Props {
+    squadInfraRows?: SquadInfraDto[];
+    pactoPayload?: PactoGovProviderPayloadV1 | null;
+    pactoGovChain?: string;
+    parentId?: string;
+    myAddress?: string;
+    captainWearers?: string[];
+    crewWearers?: string[];
+    memberEvmOptions?: { address: string; label: string }[];
+    treasuryProposals?: TreasuryProposalDto[];
+    treasuryProposalsLoading?: boolean;
+    treasuryProposalsRefreshing?: boolean;
+    treasuryProposalsError?: string;
+    onRefreshProposals?: () => void;
+    onOpenLaunchpad?: () => void;
+    hasSponsor?: boolean;
+  }
 
-  $: provider = resolveGovernanceProvider(squadInfraRows);
-  $: network = pactoGovChain ?? 'sepolia';
-  $: openCount = treasuryProposals.filter((p) => isTreasuryProposalActive(p.status)).length;
+  let {
+    squadInfraRows = undefined,
+    pactoPayload = null,
+    pactoGovChain = undefined,
+    parentId = '',
+    myAddress = '',
+    captainWearers = [],
+    crewWearers = [],
+    memberEvmOptions = [],
+    treasuryProposals = [],
+    treasuryProposalsLoading = false,
+    treasuryProposalsRefreshing = false,
+    treasuryProposalsError = '',
+    onRefreshProposals = () => {},
+    onOpenLaunchpad = () => {},
+    hasSponsor = false,
+  }: Props = $props();
+
+  const provider = $derived(resolveGovernanceProvider(squadInfraRows));
+  const network = $derived(pactoGovChain ?? 'sepolia');
+  const openCount = $derived(treasuryProposals.filter((p) => isTreasuryProposalActive(p.status)).length);
 </script>
 
 <section class="governance-section" aria-labelledby="governance-heading">

--- a/src/components/parent/dashboard/DashboardRolesTreeTab.svelte
+++ b/src/components/parent/dashboard/DashboardRolesTreeTab.svelte
@@ -13,29 +13,50 @@
   import RpcReadErrorCard from './RpcReadErrorCard.svelte';
   import { rpcReadErrorKind } from '../../../lib/squad/rpc-read-error';
 
-  export let squadInfraRows: unknown[] | undefined = undefined;
-  export let structureSummary: DashboardStructureSummary | null | undefined = undefined;
-  export let hatsTree: HatTreeNodeDto | null = null;
-  export let hatsTreeLoading = false;
-  export let hatsTreeRefreshing = false;
-  export let hatsTreeError = '';
-  export let roleLabelByHatId: Record<string, string> = {};
-  export let wearerAddressesByHatId: Record<string, string[]> = {};
-  export let executorRolesByAddress: Record<string, string> = {};
-  export let squadMemberEvmByNpub: Record<string, string> = {};
-  export let rolesTreeAnnotationsLoading = false;
-  export let rolesTreeAnnotationsRefreshing = false;
-  export let rolesTreeAnnotationsError = '';
-  export let onRefreshRolesTree: () => void = () => {};
-  export let onOpenLaunchpad: () => void = () => {};
-  /** Lowercase address → protocol module label for wearer chips. */
-  export let knownWearerLabels: Record<string, string> = {};
+  interface Props {
+    squadInfraRows?: unknown[];
+    structureSummary?: DashboardStructureSummary | null;
+    hatsTree?: HatTreeNodeDto | null;
+    hatsTreeLoading?: boolean;
+    hatsTreeRefreshing?: boolean;
+    hatsTreeError?: string;
+    roleLabelByHatId?: Record<string, string>;
+    wearerAddressesByHatId?: Record<string, string[]>;
+    executorRolesByAddress?: Record<string, string>;
+    squadMemberEvmByNpub?: Record<string, string>;
+    rolesTreeAnnotationsLoading?: boolean;
+    rolesTreeAnnotationsRefreshing?: boolean;
+    rolesTreeAnnotationsError?: string;
+    onRefreshRolesTree?: () => void;
+    onOpenLaunchpad?: () => void;
+    /** Lowercase address → protocol module label for wearer chips. */
+    knownWearerLabels?: Record<string, string>;
+  }
 
-  $: rolesTreeRefreshing = hatsTreeRefreshing || rolesTreeAnnotationsRefreshing;
-  $: rolesTreeLoading = hatsTreeLoading || rolesTreeAnnotationsLoading;
-  $: chainKey = structureSummary?.chainKey ?? null;
-  $: hatsTreeRpcKind = rpcReadErrorKind(hatsTreeError);
-  $: rolesAnnotationsRpcKind = rpcReadErrorKind(rolesTreeAnnotationsError);
+  let {
+    squadInfraRows = undefined,
+    structureSummary = undefined,
+    hatsTree = null,
+    hatsTreeLoading = false,
+    hatsTreeRefreshing = false,
+    hatsTreeError = '',
+    roleLabelByHatId = {},
+    wearerAddressesByHatId = {},
+    executorRolesByAddress = {},
+    squadMemberEvmByNpub = {},
+    rolesTreeAnnotationsLoading = false,
+    rolesTreeAnnotationsRefreshing = false,
+    rolesTreeAnnotationsError = '',
+    onRefreshRolesTree = () => {},
+    onOpenLaunchpad = () => {},
+    knownWearerLabels = {},
+  }: Props = $props();
+
+  const rolesTreeRefreshing = $derived(hatsTreeRefreshing || rolesTreeAnnotationsRefreshing);
+  const rolesTreeLoading = $derived(hatsTreeLoading || rolesTreeAnnotationsLoading);
+  const chainKey = $derived(structureSummary?.chainKey ?? null);
+  const hatsTreeRpcKind = $derived(rpcReadErrorKind(hatsTreeError));
+  const rolesAnnotationsRpcKind = $derived(rpcReadErrorKind(rolesTreeAnnotationsError));
 </script>
 
 {#if squadInfraRows !== undefined && !structureSummary}

--- a/src/components/parent/dashboard/DashboardTreasuryTab.svelte
+++ b/src/components/parent/dashboard/DashboardTreasuryTab.svelte
@@ -20,40 +20,61 @@
   import RpcReadErrorCard from './RpcReadErrorCard.svelte';
   import { rpcReadErrorKind } from '../../../lib/squad/rpc-read-error';
 
-  export let parentId = '';
-  export let network = 'sepolia';
-  export let sponsorRow: SquadInfraDto | null = null;
-  export let treasurySafes: TreasurySafeEntry[] = [];
-  export let displayedTreasurySafes: TreasurySafeEntry[] = [];
-  export let governanceTreasurySafe: TreasurySafeEntry | null = null;
-  export let pactoPayload: PactoGovProviderPayloadV1 | null = null;
-  export let announcementsGroupId = '';
-  export let myAddress = '';
-  export let captainWearers: string[] = [];
-  export let crewWearers: string[] = [];
-  export let onOpenSponsorDeploy: () => void = () => {};
-  export let onOpenDeploySafe: () => void = () => {};
-  export let onOpenImportSafe: () => void = () => {};
+  interface Props {
+    parentId?: string;
+    network?: string;
+    sponsorRow?: SquadInfraDto | null;
+    treasurySafes?: TreasurySafeEntry[];
+    displayedTreasurySafes?: TreasurySafeEntry[];
+    governanceTreasurySafe?: TreasurySafeEntry | null;
+    pactoPayload?: PactoGovProviderPayloadV1 | null;
+    announcementsGroupId?: string;
+    myAddress?: string;
+    captainWearers?: string[];
+    crewWearers?: string[];
+    onOpenSponsorDeploy?: () => void;
+    onOpenDeploySafe?: () => void;
+    onOpenImportSafe?: () => void;
+  }
 
-  let capabilitiesLoadKey = '';
-  let capabilities: Awaited<ReturnType<typeof getSquadCapabilities>> | null = null;
+  let {
+    parentId = '',
+    network = 'sepolia',
+    sponsorRow = null,
+    treasurySafes = [],
+    displayedTreasurySafes = [],
+    governanceTreasurySafe = null,
+    pactoPayload = null,
+    announcementsGroupId = '',
+    myAddress = '',
+    captainWearers = [],
+    crewWearers = [],
+    onOpenSponsorDeploy = () => {},
+    onOpenDeploySafe = () => {},
+    onOpenImportSafe = () => {},
+  }: Props = $props();
 
-  $: privilege = resolveGovernancePrivilege({
-    myAddress,
-    safeAddress: pactoPayload?.safe ?? '',
-    captainWearers,
-    crewWearers,
-    capabilities,
-  }) as GovernancePrivilege;
+  let capabilitiesLoadKey = $state('');
+  let capabilities = $state<Awaited<ReturnType<typeof getSquadCapabilities>> | null>(null);
 
-  $: {
+  const privilege = $derived(
+    resolveGovernancePrivilege({
+      myAddress,
+      safeAddress: pactoPayload?.safe ?? '',
+      captainWearers,
+      crewWearers,
+      capabilities,
+    }) as GovernancePrivilege,
+  );
+
+  $effect(() => {
     const pid = parentId.trim();
     const key = `${pid}|${network}`;
     if (pid && key !== capabilitiesLoadKey) {
       capabilitiesLoadKey = key;
       void loadCapabilities(pid);
     }
-  }
+  });
 
   async function loadCapabilities(pid: string) {
     const key = `${pid}|${network}`;
@@ -90,15 +111,17 @@
     if (url) openExternalUrl(url);
   }
 
-  $: treasuryFetchMeta = parentId ? ($treasurySafesFetchMetaByParentId[parentId] ?? null) : null;
-  $: treasurySafeRefreshKey = displayedTreasurySafes.map((e) => e.id).join('|');
-  $: if (treasurySafeRefreshKey) {
-    void refreshAllSafeStates(displayedTreasurySafes);
-  }
-  $: govSafeAddress = governanceTreasurySafe?.safeAddress ?? pactoPayload?.safe ?? '';
-  $: showGovTreasury = !!govSafeAddress.trim();
-  $: govExUrl = showGovTreasury ? explorerAddressUrl(parseSupportedChainId(network), govSafeAddress) : null;
-  $: govSafeAppUrl = showGovTreasury ? safeAppHomeUrl(parseSupportedChainId(network), govSafeAddress) : null;
+  const treasuryFetchMeta = $derived(parentId ? ($treasurySafesFetchMetaByParentId[parentId] ?? null) : null);
+  const treasurySafeRefreshKey = $derived(displayedTreasurySafes.map((e) => e.id).join('|'));
+  $effect(() => {
+    if (treasurySafeRefreshKey) {
+      void refreshAllSafeStates(displayedTreasurySafes);
+    }
+  });
+  const govSafeAddress = $derived(governanceTreasurySafe?.safeAddress ?? pactoPayload?.safe ?? '');
+  const showGovTreasury = $derived(!!govSafeAddress.trim());
+  const govExUrl = $derived(showGovTreasury ? explorerAddressUrl(parseSupportedChainId(network), govSafeAddress) : null);
+  const govSafeAppUrl = $derived(showGovTreasury ? safeAppHomeUrl(parseSupportedChainId(network), govSafeAddress) : null);
 </script>
 
 <SquadSponsorTreasuryPanel {parentId} {sponsorRow} onOpenDeploy={onOpenSponsorDeploy} />

--- a/src/components/parent/dashboard/GovernanceDeployCoordinator.svelte
+++ b/src/components/parent/dashboard/GovernanceDeployCoordinator.svelte
@@ -15,90 +15,106 @@
   import type { CombinedGovSponsorDeployComplete } from '../../../lib/governance/start-pacto-gov-and-sponsor-deploy';
   import ParentDashboardModals from './ParentDashboardModals.svelte';
 
-  export let parentId: string;
-  export let announcementsGroupId: string | null = null;
-  export let treasurySafeCount = 0;
-  export let hasSponsor = false;
-  export let hasPactoGov = false;
-  export let hasSquadAdmin = false;
-  export let squadAdminProxy = '';
-  export let squadAdminNetwork: SupportedChainId = DEFAULT_CHAIN_ID;
-  /** Established squad network; deploy modals pin to it, or prompt a pick when null. */
-  export let squadNetwork: SupportedChainId | null = null;
-  /** Sponsor clone address when sponsor infra is deployed. */
-  export let sponsorAddress = '';
-  /** Pacto Gov reference (Safe / proxy / top hat) when deployed. */
-  export let pactoGovAddress = '';
-  /** Top hat id of the deployed Pacto Gov row ('' before gov deploy). */
-  export let pactoGovTopHatId = '';
-  export let quartermaster = '';
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let captainMemberOptions: PactoGovCaptainOption[] = [];
+  interface Props {
+    parentId: string;
+    announcementsGroupId?: string | null;
+    treasurySafeCount?: number;
+    hasSponsor?: boolean;
+    hasPactoGov?: boolean;
+    hasSquadAdmin?: boolean;
+    squadAdminProxy?: string;
+    squadAdminNetwork?: SupportedChainId;
+    /** Established squad network; deploy modals pin to it, or prompt a pick when null. */
+    squadNetwork?: SupportedChainId | null;
+    /** Sponsor clone address when sponsor infra is deployed. */
+    sponsorAddress?: string;
+    /** Pacto Gov reference (Safe / proxy / top hat) when deployed. */
+    pactoGovAddress?: string;
+    /** Top hat id of the deployed Pacto Gov row ('' before gov deploy). */
+    pactoGovTopHatId?: string;
+    quartermaster?: string;
+    memberEvmOptions?: { address: string; label: string }[];
+    captainMemberOptions?: PactoGovCaptainOption[];
+    onConfirmImportSafe?: (params: {
+      safeAddress: string;
+      chain: string;
+      label: string;
+      entryId: string;
+      txHash?: string;
+    }) => Promise<void>;
+    onPactoGovDeployComplete?: (params: {
+      parentId: string;
+      announcementsGroupId: string;
+      chain: string;
+      topHatId: string;
+      providerPayload: string;
+      safeAddress: string;
+      txHash: string;
+      infraRowId?: string;
+    }) => Promise<void>;
+    onSponsorDeployComplete?: (params: {
+      parentId: string;
+      announcementsGroupId: string;
+      chain: string;
+      sponsorAddress: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+    onSquadAdminDeployComplete?: (params: {
+      parentId: string;
+      announcementsGroupId: string;
+      chain: string;
+      squadAdminProxy: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+    /** Navigate the dashboard after a deploy completes. */
+    onNavigate?: (view: SquadDashboardChannelMode) => void;
+    /** Warm member/EVM caches before a deploy wizard opens. */
+    onPrefetchDeployContext?: () => void;
+  }
 
-  export let onConfirmImportSafe:
-    | ((params: {
-        safeAddress: string;
-        chain: string;
-        label: string;
-        entryId: string;
-        txHash?: string;
-      }) => Promise<void>)
-    | undefined = undefined;
-  export let onPactoGovDeployComplete:
-    | ((params: {
-        parentId: string;
-        announcementsGroupId: string;
-        chain: string;
-        topHatId: string;
-        providerPayload: string;
-        safeAddress: string;
-        txHash: string;
-        infraRowId?: string;
-      }) => Promise<void>)
-    | undefined = undefined;
-  export let onSponsorDeployComplete:
-    | ((params: {
-        parentId: string;
-        announcementsGroupId: string;
-        chain: string;
-        sponsorAddress: string;
-        providerPayload: string;
-        infraRowId: string;
-      }) => Promise<void>)
-    | undefined = undefined;
-  export let onSquadAdminDeployComplete:
-    | ((params: {
-        parentId: string;
-        announcementsGroupId: string;
-        chain: string;
-        squadAdminProxy: string;
-        providerPayload: string;
-        infraRowId: string;
-      }) => Promise<void>)
-    | undefined = undefined;
+  let {
+    parentId,
+    announcementsGroupId = null,
+    treasurySafeCount = 0,
+    hasSponsor = false,
+    hasPactoGov = false,
+    hasSquadAdmin = false,
+    squadAdminProxy = '',
+    squadAdminNetwork = DEFAULT_CHAIN_ID,
+    squadNetwork = null,
+    sponsorAddress = '',
+    pactoGovAddress = '',
+    pactoGovTopHatId = '',
+    quartermaster = '',
+    memberEvmOptions = [],
+    captainMemberOptions = [],
+    onConfirmImportSafe = undefined,
+    onPactoGovDeployComplete = undefined,
+    onSponsorDeployComplete = undefined,
+    onSquadAdminDeployComplete = undefined,
+    onNavigate = () => {},
+    onPrefetchDeployContext = () => {},
+  }: Props = $props();
 
-  /** Navigate the dashboard after a deploy completes. */
-  export let onNavigate: (view: SquadDashboardChannelMode) => void = () => {};
-  /** Warm member/EVM caches before a deploy wizard opens. */
-  export let onPrefetchDeployContext: () => void = () => {};
+  let showSetSafeModal = $state(false);
+  let showDeploySafeModal = $state(false);
+  let showLaunchpad = $state(false);
+  let showPactoGovDeploy = $state(false);
+  let showGovAndSponsorDeploy = $state(false);
+  let showExtSponsorDeploy = $state(false);
+  let showSquadAdminDeploy = $state(false);
+  let showSquadRolesModal = $state(false);
 
-  let showSetSafeModal = false;
-  let showDeploySafeModal = false;
-  let showLaunchpad = false;
-  let showPactoGovDeploy = false;
-  let showGovAndSponsorDeploy = false;
-  let showExtSponsorDeploy = false;
-  let showSquadAdminDeploy = false;
-  let showSquadRolesModal = false;
-
-  let setSafeInput = '';
-  let setSafeChain: SupportedChainId = DEFAULT_CHAIN_ID;
-  let setSafeLabel = '';
-  let setSafeError = '';
-  let setSafeSaving = false;
+  let setSafeInput = $state('');
+  let setSafeChain = $state<SupportedChainId>(DEFAULT_CHAIN_ID);
+  let setSafeLabel = $state('');
+  let setSafeError = $state('');
+  let setSafeSaving = $state(false);
 
   /** Combined wizard finishes the hats sponsor only when gov exists without a sponsor. */
-  $: existingTopHatId = hasPactoGov && !hasSponsor ? pactoGovTopHatId : '';
+  const existingTopHatId = $derived(hasPactoGov && !hasSponsor ? pactoGovTopHatId : '');
 
   export function openLaunchpad(): void {
     if (!requireBackupVerified()) return;

--- a/src/components/parent/dashboard/MyDashboardAlertsTab.svelte
+++ b/src/components/parent/dashboard/MyDashboardAlertsTab.svelte
@@ -12,14 +12,18 @@
   import { squads } from '../../../stores/squads';
   import type { GovActionPrompt } from '../../../lib/governance/gov-action-prompts';
 
-  export let parentId = '';
-  export let announcementsGroupId: string | null = null;
+  interface Props {
+    parentId?: string;
+    announcementsGroupId?: string | null;
+  }
 
-  let showRosterCard = false;
-  let loading = true;
+  let { parentId = '', announcementsGroupId = null }: Props = $props();
 
-  $: prompts = ($govActionPromptsBySquadId[parentId] ?? []) as GovActionPrompt[];
-  $: hasGovPrompts = prompts.length > 0;
+  let showRosterCard = $state(false);
+  let loading = $state(true);
+
+  const prompts = $derived(($govActionPromptsBySquadId[parentId] ?? []) as GovActionPrompt[]);
+  const hasGovPrompts = $derived(prompts.length > 0);
 
   async function refreshNeed() {
     if (!parentId) {

--- a/src/components/parent/dashboard/MyDashboardStatusTab.svelte
+++ b/src/components/parent/dashboard/MyDashboardStatusTab.svelte
@@ -13,23 +13,27 @@
   /** Enable when squad key rotation backend is wired. */
   const ROTATE_SQUAD_KEY_ENABLED = false;
 
-  export let announcementsGroupId: string | null = null;
-  export let parentId = '';
-  export let squadMemberEvmByNpub: Record<string, string> = {};
+  interface Props {
+    announcementsGroupId?: string | null;
+    parentId?: string;
+    squadMemberEvmByNpub?: Record<string, string>;
+  }
 
-  let rotateModalOpen = false;
-  let rosterKeyNeeded: boolean | null = null;
+  let { announcementsGroupId = null, parentId = '', squadMemberEvmByNpub = {} }: Props = $props();
 
-  $: myNpub = $currentUser?.npub ?? '';
-  $: myRosterEvmRaw = myNpub ? squadMemberEvmByNpub[myNpub]?.trim() : '';
+  let rotateModalOpen = $state(false);
+  let rosterKeyNeeded = $state<boolean | null>(null);
+
+  const myNpub = $derived($currentUser?.npub ?? '');
+  const myRosterEvmRaw = $derived(myNpub ? squadMemberEvmByNpub[myNpub]?.trim() : '');
   /** Hide orphan auto-share until personal-alerts bind. */
-  $: myRosterEvm = rosterKeyNeeded === true ? '' : myRosterEvmRaw;
-  $: void $squadStateSyncRequestInFlightRevision;
-  $: syncRequesting = announcementsGroupId
-    ? isSquadStateSyncInFlight(announcementsGroupId)
-    : false;
+  const myRosterEvm = $derived(rosterKeyNeeded === true ? '' : myRosterEvmRaw);
+  const syncRequesting = $derived.by(() => {
+    void $squadStateSyncRequestInFlightRevision;
+    return announcementsGroupId ? isSquadStateSyncInFlight(announcementsGroupId) : false;
+  });
 
-  let copiedRosterEvm = false;
+  let copiedRosterEvm = $state(false);
 
   async function copyRosterEvm() {
     if (!myRosterEvm) return;

--- a/src/components/parent/dashboard/ParentDashboardMembersPanel.svelte
+++ b/src/components/parent/dashboard/ParentDashboardMembersPanel.svelte
@@ -3,9 +3,13 @@
   import { getProfileAvatarSrc, getProfileDisplayName } from '../../../lib/utils/profile';
   import { profiles } from '../../../stores/profiles';
 
-  export let open = false;
-  export let channelMembers: string[] = [];
-  export let loadingMembers = false;
+  interface Props {
+    open?: boolean;
+    channelMembers?: string[];
+    loadingMembers?: boolean;
+  }
+
+  let { open = false, channelMembers = [], loadingMembers = false }: Props = $props();
 </script>
 
 {#if open}

--- a/src/components/parent/dashboard/ParentDashboardModals.svelte
+++ b/src/components/parent/dashboard/ParentDashboardModals.svelte
@@ -15,112 +15,176 @@
   import type { PactoGovCaptainOption, PactoGovDeployComplete } from '../../../lib/governance/start-pacto-gov-deploy';
   import type { CombinedGovSponsorDeployComplete } from '../../../lib/governance/start-pacto-gov-and-sponsor-deploy';
 
-  export let parentId: string;
-  export let announcementsGroupId: string | null = null;
-  export let treasurySafeCount = 0;
-  export let hasSponsor = false;
-  export let hasPactoGov = false;
-  export let hasSquadAdmin = false;
-  export let squadAdminProxy = '';
-  export let squadAdminNetwork: SupportedChainId = DEFAULT_CHAIN_ID;
-  /** Established squad network; deploy modals pin to it, or prompt a pick when null. */
-  export let squadNetwork: SupportedChainId | null = null;
-  /** Sponsor clone address when sponsor infra is deployed. */
-  export let sponsorAddress = '';
-  /** Pacto Gov reference (Safe / proxy / top hat) when deployed. */
-  export let pactoGovAddress = '';
-  export let memberEvmOptions: { address: string; label: string }[] = [];
-  export let captainMemberOptions: PactoGovCaptainOption[] = [];
+  interface Props {
+    parentId: string;
+    announcementsGroupId?: string | null;
+    treasurySafeCount?: number;
+    hasSponsor?: boolean;
+    hasPactoGov?: boolean;
+    hasSquadAdmin?: boolean;
+    squadAdminProxy?: string;
+    squadAdminNetwork?: SupportedChainId;
+    /** Established squad network; deploy modals pin to it, or prompt a pick when null. */
+    squadNetwork?: SupportedChainId | null;
+    /** Sponsor clone address when sponsor infra is deployed. */
+    sponsorAddress?: string;
+    /** Pacto Gov reference (Safe / proxy / top hat) when deployed. */
+    pactoGovAddress?: string;
+    memberEvmOptions?: { address: string; label: string }[];
+    captainMemberOptions?: PactoGovCaptainOption[];
 
-  export let showDeploySafeModal = false;
-  export let showLaunchpad = false;
-  export let showPactoGovDeploy = false;
-  export let showGovAndSponsorDeploy = false;
-  export let showExtSponsorDeploy = false;
-  export let showSquadAdminDeploy = false;
-  export let showSquadRolesModal = false;
-  export let showSetSafeModal = false;
-  /** When set, combined wizard finishes hats sponsor only. */
-  export let existingTopHatId = '';
-  export let quartermaster = '';
+    showDeploySafeModal?: boolean;
+    showLaunchpad?: boolean;
+    showPactoGovDeploy?: boolean;
+    showGovAndSponsorDeploy?: boolean;
+    showExtSponsorDeploy?: boolean;
+    showSquadAdminDeploy?: boolean;
+    showSquadRolesModal?: boolean;
+    showSetSafeModal?: boolean;
+    /** When set, combined wizard finishes hats sponsor only. */
+    existingTopHatId?: string;
+    quartermaster?: string;
 
-  export let setSafeInput = '';
-  export let setSafeChain: SupportedChainId = DEFAULT_CHAIN_ID;
-  export let setSafeLabel = '';
-  export let setSafeError = '';
-  export let setSafeSaving = false;
+    setSafeInput?: string;
+    setSafeChain?: SupportedChainId;
+    setSafeLabel?: string;
+    setSafeError?: string;
+    setSafeSaving?: boolean;
 
-  export let onDeploySafeSuccess: (params: {
-    safeAddress: string;
-    chain: string;
-    label: string;
-    entryId: string;
-    txHash?: string;
-  }) => Promise<void> = async () => {};
-  export let onPactoGovComplete: (out: PactoGovDeployComplete) => Promise<void> = async () => {};
-  export let onGovAndSponsorComplete: (out: CombinedGovSponsorDeployComplete) => Promise<void> =
-    async () => {};
-  export let onSquadAdminComplete: (out: {
-    chain: string;
-    squadAdminProxy: string;
-    providerPayload: string;
-    infraRowId: string;
-  }) => Promise<void> = async () => {};
-  export let onExtSponsorComplete: (out: {
-    txHash: string;
-    chain: string;
-    sponsorAddress: string;
-    providerPayload: string;
-    infraRowId: string;
-  }) => Promise<void> = async () => {};
-  export let onConfirmSetSafe: () => void | Promise<void> = () => {};
-  export let onCloseSetSafe: () => void = () => {};
-  export let onCloseDeploySafe: () => void = () => {};
-  export let onCloseLaunchpad: () => void = () => {};
-  export let onClosePactoGovDeploy: () => void = () => {};
-  export let onCloseGovAndSponsorDeploy: () => void = () => {};
-  export let onCloseExtSponsorDeploy: () => void = () => {};
-  export let onCloseSquadAdminDeploy: () => void = () => {};
-  export let onCloseSquadRolesModal: () => void = () => {};
-  export let onDeploySquadAdmin: () => void = () => {};
-  export let onDeployPactoGov: () => void = () => {};
-  export let onDeployGovAndSponsor: () => void = () => {};
-  export let onDeployExtSponsor: () => void = () => {};
+    onDeploySafeSuccess?: (params: {
+      safeAddress: string;
+      chain: string;
+      label: string;
+      entryId: string;
+      txHash?: string;
+    }) => Promise<void>;
+    onPactoGovComplete?: (out: PactoGovDeployComplete) => Promise<void>;
+    onGovAndSponsorComplete?: (out: CombinedGovSponsorDeployComplete) => Promise<void>;
+    onSquadAdminComplete?: (out: {
+      chain: string;
+      squadAdminProxy: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+    onExtSponsorComplete?: (out: {
+      txHash: string;
+      chain: string;
+      sponsorAddress: string;
+      providerPayload: string;
+      infraRowId: string;
+    }) => Promise<void>;
+    onConfirmSetSafe?: () => void | Promise<void>;
+    onCloseSetSafe?: () => void;
+    onCloseDeploySafe?: () => void;
+    onCloseLaunchpad?: () => void;
+    onClosePactoGovDeploy?: () => void;
+    onCloseGovAndSponsorDeploy?: () => void;
+    onCloseExtSponsorDeploy?: () => void;
+    onCloseSquadAdminDeploy?: () => void;
+    onCloseSquadRolesModal?: () => void;
+    onDeploySquadAdmin?: () => void;
+    onDeployPactoGov?: () => void;
+    onDeployGovAndSponsor?: () => void;
+    onDeployExtSponsor?: () => void;
+  }
 
-  let DeploySafeModalComponent: Awaited<ReturnType<typeof loadDeploySafeModal>> | null = null;
-  let DeploySquadAdminComponent: Awaited<ReturnType<typeof loadDeploySquadAdminModal>> | null = null;
-  let DeployPactoGovModalComponent: Awaited<ReturnType<typeof loadDeployPactoGovModal>> | null = null;
-  let DeployGovAndSponsorComponent: Awaited<
-    ReturnType<typeof loadDeployPactoGovAndSponsorModal>
-  > | null = null;
-  let DeployExtSponsorComponent: Awaited<ReturnType<typeof loadDeploySquadSponsorExtModal>> | null =
-    null;
+  let {
+    parentId,
+    announcementsGroupId = null,
+    treasurySafeCount = 0,
+    hasSponsor = false,
+    hasPactoGov = false,
+    hasSquadAdmin = false,
+    squadAdminProxy = '',
+    squadAdminNetwork = DEFAULT_CHAIN_ID,
+    squadNetwork = null,
+    sponsorAddress = '',
+    pactoGovAddress = '',
+    memberEvmOptions = [],
+    captainMemberOptions = [],
 
-  $: if (showDeploySafeModal && !DeploySafeModalComponent) {
-    void loadDeploySafeModal().then((c) => {
-      DeploySafeModalComponent = c;
-    });
-  }
-  $: if (showPactoGovDeploy && !DeployPactoGovModalComponent) {
-    void loadDeployPactoGovModal().then((c) => {
-      DeployPactoGovModalComponent = c;
-    });
-  }
-  $: if (showGovAndSponsorDeploy && !DeployGovAndSponsorComponent) {
-    void loadDeployPactoGovAndSponsorModal().then((c) => {
-      DeployGovAndSponsorComponent = c;
-    });
-  }
-  $: if (showSquadAdminDeploy && !DeploySquadAdminComponent) {
-    void loadDeploySquadAdminModal().then((c) => {
-      DeploySquadAdminComponent = c;
-    });
-  }
-  $: if (showExtSponsorDeploy && !DeployExtSponsorComponent) {
-    void loadDeploySquadSponsorExtModal().then((c) => {
-      DeployExtSponsorComponent = c;
-    });
-  }
+    showDeploySafeModal = $bindable(false),
+    showLaunchpad = $bindable(false),
+    showPactoGovDeploy = $bindable(false),
+    showGovAndSponsorDeploy = $bindable(false),
+    showExtSponsorDeploy = $bindable(false),
+    showSquadAdminDeploy = $bindable(false),
+    showSquadRolesModal = $bindable(false),
+    showSetSafeModal = $bindable(false),
+    existingTopHatId = '',
+    quartermaster = '',
+
+    setSafeInput = $bindable(''),
+    setSafeChain = $bindable(DEFAULT_CHAIN_ID),
+    setSafeLabel = $bindable(''),
+    setSafeError = $bindable(''),
+    setSafeSaving = $bindable(false),
+
+    onDeploySafeSuccess = async () => {},
+    onPactoGovComplete = async () => {},
+    onGovAndSponsorComplete = async () => {},
+    onSquadAdminComplete = async () => {},
+    onExtSponsorComplete = async () => {},
+    onConfirmSetSafe = () => {},
+    onCloseSetSafe = () => {},
+    onCloseDeploySafe = () => {},
+    onCloseLaunchpad = () => {},
+    onClosePactoGovDeploy = () => {},
+    onCloseGovAndSponsorDeploy = () => {},
+    onCloseExtSponsorDeploy = () => {},
+    onCloseSquadAdminDeploy = () => {},
+    onCloseSquadRolesModal = () => {},
+    onDeploySquadAdmin = () => {},
+    onDeployPactoGov = () => {},
+    onDeployGovAndSponsor = () => {},
+    onDeployExtSponsor = () => {},
+  }: Props = $props();
+
+  let DeploySafeModalComponent = $state<Awaited<ReturnType<typeof loadDeploySafeModal>> | null>(null);
+  let DeploySquadAdminComponent = $state<Awaited<ReturnType<typeof loadDeploySquadAdminModal>> | null>(null);
+  let DeployPactoGovModalComponent = $state<Awaited<ReturnType<typeof loadDeployPactoGovModal>> | null>(null);
+  let DeployGovAndSponsorComponent = $state<
+    Awaited<ReturnType<typeof loadDeployPactoGovAndSponsorModal>> | null
+  >(null);
+  let DeployExtSponsorComponent = $state<Awaited<ReturnType<typeof loadDeploySquadSponsorExtModal>> | null>(
+    null,
+  );
+
+  $effect(() => {
+    if (showDeploySafeModal && !DeploySafeModalComponent) {
+      void loadDeploySafeModal().then((c) => {
+        DeploySafeModalComponent = c;
+      });
+    }
+  });
+  $effect(() => {
+    if (showPactoGovDeploy && !DeployPactoGovModalComponent) {
+      void loadDeployPactoGovModal().then((c) => {
+        DeployPactoGovModalComponent = c;
+      });
+    }
+  });
+  $effect(() => {
+    if (showGovAndSponsorDeploy && !DeployGovAndSponsorComponent) {
+      void loadDeployPactoGovAndSponsorModal().then((c) => {
+        DeployGovAndSponsorComponent = c;
+      });
+    }
+  });
+  $effect(() => {
+    if (showSquadAdminDeploy && !DeploySquadAdminComponent) {
+      void loadDeploySquadAdminModal().then((c) => {
+        DeploySquadAdminComponent = c;
+      });
+    }
+  });
+  $effect(() => {
+    if (showExtSponsorDeploy && !DeployExtSponsorComponent) {
+      void loadDeploySquadSponsorExtModal().then((c) => {
+        DeployExtSponsorComponent = c;
+      });
+    }
+  });
 </script>
 
 {#if showDeploySafeModal && parentId}

--- a/src/components/parent/dashboard/ParentDashboardModals.test.ts
+++ b/src/components/parent/dashboard/ParentDashboardModals.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import type * as DeployWizardModule from '../../../lib/parent/deploy-wizard-components';
+
+const FakeDeploySafeModal = () => {};
+
+vi.mock('../../../lib/parent/deploy-wizard-components', async (importOriginal) => {
+  const actual = await importOriginal<typeof DeployWizardModule>();
+  return {
+    ...actual,
+    loadDeploySafeModal: vi.fn(),
+  };
+});
+
+import ParentDashboardModals from './ParentDashboardModals.svelte';
+import { loadDeploySafeModal } from '../../../lib/parent/deploy-wizard-components';
+
+const baseProps = {
+  parentId: 'squad-1',
+  announcementsGroupId: 'group-1',
+  squadAdminProxy: '',
+};
+
+describe('ParentDashboardModals — deploy-safe wizard lazy-load gate', () => {
+  beforeEach(() => {
+    vi.mocked(loadDeploySafeModal).mockReset();
+    vi.mocked(loadDeploySafeModal).mockResolvedValue(FakeDeploySafeModal as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not load the deploy-safe (transaction submission) wizard while the modal is closed', () => {
+    render(ParentDashboardModals, { props: { ...baseProps, showDeploySafeModal: false } });
+    expect(loadDeploySafeModal).not.toHaveBeenCalled();
+  });
+
+  it('loads the deploy-safe wizard once on open, then reuses the cached component across close/reopen cycles', async () => {
+    const { rerender } = render(ParentDashboardModals, {
+      props: { ...baseProps, showDeploySafeModal: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(loadDeploySafeModal).toHaveBeenCalledTimes(1);
+    });
+
+    // User closes the modal, then cycles back and reopens it — the cached wizard
+    // component must not trigger a second network fetch.
+    await rerender({ ...baseProps, showDeploySafeModal: false });
+    await rerender({ ...baseProps, showDeploySafeModal: true });
+
+    expect(loadDeploySafeModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/parent/dashboard/RotateSquadKeyModal.svelte
+++ b/src/components/parent/dashboard/RotateSquadKeyModal.svelte
@@ -2,8 +2,12 @@
   import { t } from 'svelte-i18n';
   import Modal from '../../ui/Modal.svelte';
 
-  export let open = false;
-  export let onClose: () => void = () => {};
+  interface Props {
+    open?: boolean;
+    onClose?: () => void;
+  }
+
+  let { open = false, onClose = () => {} }: Props = $props();
 
   /** Enable when squad key rotation backend is wired. */
   const GENERATE_NEW_KEY_ENABLED = false;

--- a/src/components/parent/dashboard/SquadBotHoldersSection.svelte
+++ b/src/components/parent/dashboard/SquadBotHoldersSection.svelte
@@ -22,53 +22,68 @@
   } from '../../../lib/squad/squad-bot';
   import { refreshMlsGroupMembers } from '../../../stores/mls-group-members';
 
-  export let announcementsGroupId: string | null = null;
-  export let channelMembers: string[] = [];
-  export let squadAdminActive = false;
-  export let executorRolesLabel = '';
+  interface Props {
+    announcementsGroupId?: string | null;
+    channelMembers?: string[];
+    squadAdminActive?: boolean;
+    executorRolesLabel?: string;
+  }
 
-  let state: SquadBotState | null = null;
-  let loading = true;
-  let addNpub = '';
-  let error = '';
-  let copiedBotNpub = false;
+  let {
+    announcementsGroupId = null,
+    channelMembers = [],
+    squadAdminActive = false,
+    executorRolesLabel = '',
+  }: Props = $props();
 
-  $: squadId = announcementsGroupId?.trim() || '';
-  $: void $squadBotHolderActionInFlightRevision;
-  $: acting = squadId ? isSquadBotHolderActionInFlight(squadId) : false;
-  $: myNpub = $currentUser?.npub ?? '';
-  $: canManage = canManageBotHolders({
-    squadAdminActive,
-    executorRolesLabel,
-    state,
+  let botState = $state<SquadBotState | null>(null);
+  let loading = $state(true);
+  let addNpub = $state('');
+  let error = $state('');
+  let copiedBotNpub = $state(false);
+
+  const squadId = $derived(announcementsGroupId?.trim() || '');
+  const acting = $derived.by(() => {
+    void $squadBotHolderActionInFlightRevision;
+    return squadId ? isSquadBotHolderActionInFlight(squadId) : false;
   });
-  $: candidates = channelMembers.filter(
-    (n) => n && n !== myNpub && !(state?.holders ?? []).includes(n)
+  const myNpub = $derived($currentUser?.npub ?? '');
+  const canManage = $derived(
+    canManageBotHolders({
+      squadAdminActive,
+      executorRolesLabel,
+      state: botState,
+    }),
+  );
+  const candidates = $derived(
+    channelMembers.filter((n) => n && n !== myNpub && !(botState?.holders ?? []).includes(n)),
   );
 
   async function reload() {
     if (!squadId) {
-      state = null;
+      botState = null;
       loading = false;
       return;
     }
     loading = true;
     error = '';
     try {
-      state = (await getSquadBotState(squadId)) ?? (await ensureSquadBot(squadId));
+      botState = (await getSquadBotState(squadId)) ?? (await ensureSquadBot(squadId));
     } catch (e) {
       error = e instanceof Error ? e.message : tFn('governance.botHolders.toastLoadFailed');
-      state = null;
+      botState = null;
     } finally {
       loading = false;
     }
   }
 
-  let lastLoadedId = '';
-  $: if (squadId && squadId !== lastLoadedId) {
-    lastLoadedId = squadId;
-    void reload();
-  }
+  let lastLoadedId = $state('');
+  $effect(() => {
+    if (squadId && squadId !== lastLoadedId) {
+      lastLoadedId = squadId;
+      void reload();
+    }
+  });
 
   onMount(() => {
     if (squadId) void reload();
@@ -79,8 +94,8 @@
   }
 
   async function copyBotNpub() {
-    if (!state?.botNpub) return;
-    const ok = await copyTextToClipboard(state.botNpub);
+    if (!botState?.botNpub) return;
+    const ok = await copyTextToClipboard(botState.botNpub);
     if (ok) {
       copiedBotNpub = true;
       setTimeout(() => {
@@ -93,7 +108,7 @@
 
   async function onAdd() {
     if (!squadId || !addNpub || acting) return;
-    const block = canAddBotHolder(channelMembers, myNpub, addNpub, state?.holders ?? [], {
+    const block = canAddBotHolder(channelMembers, myNpub, addNpub, botState?.holders ?? [], {
       squadAdminActive,
       executorRolesLabel,
     });
@@ -106,7 +121,7 @@
       showToast(result.error);
       return;
     }
-    state = result.state;
+    botState = result.state;
     addNpub = '';
     showToast(tFn('governance.botHolders.toastAdded'));
   }
@@ -118,7 +133,7 @@
       showToast(result.error);
       return;
     }
-    state = result.state;
+    botState = result.state;
     showToast(tFn('governance.botHolders.toastRemoved'));
   }
 
@@ -130,7 +145,7 @@
       showToast(result.error);
       return;
     }
-    state = result.state;
+    botState = result.state;
     showToast(tFn('governance.botHolders.toastRotated'));
   }
 </script>
@@ -147,7 +162,7 @@
     <p class="muted" role="status">{$t('governance.common.loading')}</p>
   {:else if error}
     <p class="err" role="alert">{error}</p>
-  {:else if !state}
+  {:else if !botState}
     <p class="muted">{$t('governance.botHolders.botNotInitialized')}</p>
     <button type="button" class="btn" disabled={acting || !squadId} onclick={() => void reload()}>
       {$t('governance.botHolders.initialize')}
@@ -157,7 +172,7 @@
       <div class="bot-key-box">
         <span class="bot-key-box-label">{$t('governance.botHolders.botNpub')}</span>
         <div class="bot-key-value-row">
-          <code class="bot-key-value-full">{state.botNpub}</code>
+          <code class="bot-key-value-full">{botState.botNpub}</code>
           <button
             type="button"
             class="bot-key-copy-btn"
@@ -186,16 +201,16 @@
 
       <div class="bot-key-box bot-key-box-compact">
         <span class="bot-key-box-label">{$t('governance.botHolders.keyEpoch')}</span>
-        <span class="bot-key-box-value">{state.keyEpoch}</span>
+        <span class="bot-key-box-value">{botState.keyEpoch}</span>
       </div>
     </div>
 
     <h4 class="subhead">{$t('governance.botHolders.holders')}</h4>
     <ul class="holder-list">
-      {#each state.holders as npub (npub)}
+      {#each botState.holders as npub (npub)}
         <li>
           <span>{label(npub)}</span>
-          {#if canManage && state.holders.length > 1}
+          {#if canManage && botState.holders.length > 1}
             <button
               type="button"
               class="linkish danger"

--- a/src/components/parent/dashboard/SquadBotHoldersSection.test.ts
+++ b/src/components/parent/dashboard/SquadBotHoldersSection.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import type * as SquadBotModule from '../../../lib/squad/squad-bot';
+
+vi.mock('../../../lib/squad/squad-bot', async (importOriginal) => {
+  const actual = await importOriginal<typeof SquadBotModule>();
+  return {
+    ...actual,
+    getSquadBotState: vi.fn(),
+    ensureSquadBot: vi.fn(),
+  };
+});
+
+import SquadBotHoldersSection from './SquadBotHoldersSection.svelte';
+import { getSquadBotState, ensureSquadBot, type SquadBotState } from '../../../lib/squad/squad-bot';
+import { profiles } from '../../../stores/profiles';
+import { currentUser } from '../../../stores/auth';
+
+function botState(overrides: Partial<SquadBotState> = {}): SquadBotState {
+  return {
+    squadId: 'group-1',
+    botNpub: 'npub1botxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    holders: [],
+    keyEpoch: 1,
+    updatedAt: Date.now(),
+    hasLocalSecret: false,
+    iAmHolder: false,
+    ...overrides,
+  };
+}
+
+describe('SquadBotHoldersSection', () => {
+  beforeEach(() => {
+    profiles.set({});
+    currentUser.set(null);
+    vi.mocked(getSquadBotState).mockReset();
+    vi.mocked(ensureSquadBot).mockReset();
+    vi.mocked(getSquadBotState).mockResolvedValue(botState());
+    vi.mocked(ensureSquadBot).mockResolvedValue(botState());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not refetch bot-holder state when the same squad is re-rendered (no duplicate network activity across tab cycles)', async () => {
+    const { rerender } = render(SquadBotHoldersSection, {
+      props: {
+        announcementsGroupId: 'group-1',
+        channelMembers: ['npub1alice'],
+        squadAdminActive: false,
+        executorRolesLabel: '',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(getSquadBotState).toHaveBeenCalled();
+    });
+    const callsAfterMount = vi.mocked(getSquadBotState).mock.calls.length;
+
+    // Simulate cycling back to this tab: parent re-renders with the identical squad id.
+    await rerender({
+      announcementsGroupId: 'group-1',
+      channelMembers: ['npub1alice'],
+      squadAdminActive: false,
+      executorRolesLabel: '',
+    });
+    await rerender({
+      announcementsGroupId: 'group-1',
+      channelMembers: ['npub1alice'],
+      squadAdminActive: false,
+      executorRolesLabel: '',
+    });
+
+    expect(vi.mocked(getSquadBotState).mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it('reloads bot-holder state when the squad id actually changes', async () => {
+    const { rerender } = render(SquadBotHoldersSection, {
+      props: {
+        announcementsGroupId: 'group-1',
+        channelMembers: [],
+        squadAdminActive: false,
+        executorRolesLabel: '',
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(getSquadBotState).toHaveBeenCalled();
+    });
+    const callsForFirstSquad = vi.mocked(getSquadBotState).mock.calls.length;
+
+    await rerender({
+      announcementsGroupId: 'group-2',
+      channelMembers: [],
+      squadAdminActive: false,
+      executorRolesLabel: '',
+    });
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(getSquadBotState).mock.calls.length).toBeGreaterThan(callsForFirstSquad);
+    });
+    expect(vi.mocked(getSquadBotState)).toHaveBeenLastCalledWith('group-2');
+  });
+});

--- a/src/components/parent/dashboard/SquadBroadcastSettingsSection.svelte
+++ b/src/components/parent/dashboard/SquadBroadcastSettingsSection.svelte
@@ -25,48 +25,59 @@
   import type { CommonsBroadcastLocalState } from '../../../lib/commons/types';
   import type { Squad } from '../../../stores/squads';
 
-  export let squad: Squad;
+  interface Props {
+    squad: Squad;
+  }
+
+  let { squad }: Props = $props();
 
   type BroadcastMode = 'disabled' | 'enabled';
 
-  let mode: BroadcastMode = squad.visibility === 'public' ? 'enabled' : 'disabled';
-  let savingMode = false;
-  let activeBroadcast: CommonsBroadcastLocalState | null = null;
-  let loadingBroadcast = true;
-  let cancelling = false;
-  let messageExpanded = false;
-  let showBroadcastModal = false;
-  let refreshToken = 0;
-  let prevSquadId = '';
+  let mode = $state<BroadcastMode>(squad.visibility === 'public' ? 'enabled' : 'disabled');
+  let savingMode = $state(false);
+  let activeBroadcast = $state<CommonsBroadcastLocalState | null>(null);
+  let loadingBroadcast = $state(true);
+  let cancelling = $state(false);
+  let messageExpanded = $state(false);
+  let showBroadcastModal = $state(false);
+  let refreshToken = $state(0);
+  let prevSquadId = $state('');
 
-  $: broadcastEnabled = isPublicSquadForCommonsBroadcast(squad);
-  $: broadcastTarget = {
+  const broadcastEnabled = $derived(isPublicSquadForCommonsBroadcast(squad));
+  const broadcastTarget = $derived({
     id: squad.id,
     name: squad.name,
     kind: squad.kind,
     iconUrl: squad.iconUrl,
     visibility: squad.visibility,
     commonsTags: squad.commonsTags,
-  };
-  $: roleAllowed = canBroadcastSquad({ userNpub: $currentUser?.npub, squad: broadcastTarget });
-  $: broadcastDeniedReason =
+  });
+  const roleAllowed = $derived(canBroadcastSquad({ userNpub: $currentUser?.npub, squad: broadcastTarget }));
+  const broadcastDeniedReason = $derived(
     broadcastSquadRoleDeniedReason({ userNpub: $currentUser?.npub, squad: broadcastTarget }) ??
-    COMMONS_BROADCAST_ROLE_DENIED_REASON;
-  $: hasActive = !!activeBroadcast;
-  $: fullMessage = activeBroadcast?.message ?? '';
-  $: messageTruncated = isCommonsMessageTruncated(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX);
-  $: previewMessage = messageTruncated
-    ? truncateCommonsMessage(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX)
-    : fullMessage;
-  $: canStartBroadcast = broadcastEnabled && roleAllowed && !hasActive && !loadingBroadcast;
+      COMMONS_BROADCAST_ROLE_DENIED_REASON,
+  );
+  const hasActive = $derived(!!activeBroadcast);
+  const fullMessage = $derived(activeBroadcast?.message ?? '');
+  const messageTruncated = $derived(isCommonsMessageTruncated(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX));
+  const previewMessage = $derived(
+    messageTruncated ? truncateCommonsMessage(fullMessage, COMMONS_MESSAGE_PREVIEW_MAX) : fullMessage,
+  );
+  const canStartBroadcast = $derived(broadcastEnabled && roleAllowed && !hasActive && !loadingBroadcast);
 
-  $: if (squad.id !== prevSquadId) {
-    prevSquadId = squad.id;
-    mode = squad.visibility === 'public' ? 'enabled' : 'disabled';
-    refreshToken += 1;
-  }
+  $effect(() => {
+    if (squad.id !== prevSquadId) {
+      prevSquadId = squad.id;
+      mode = squad.visibility === 'public' ? 'enabled' : 'disabled';
+      refreshToken += 1;
+    }
+  });
 
-  $: squad.id, refreshToken, void loadBroadcast();
+  $effect(() => {
+    void squad.id;
+    void refreshToken;
+    void loadBroadcast();
+  });
 
   function relativeExpiry(expiresAt: number, tFn: (key: string, opts?: object) => string): string {
     const ms = expiresAt * 1000 - Date.now();


### PR DESCRIPTION
## Why

Part of the Svelte 5 runes migration epic (pacto-app-a7r). This unit converts the parent dashboard's tab panels and deploy modals — the most prop-dense batch in the migration, anchored by `ParentDashboardModals.svelte` (46 props) and `DashboardCrewTab.svelte` (23 props) — off legacy `export let` / `$:` / `bind:` syntax before those constructs are removed repo-wide.

## What changed

12 files under `src/components/parent/dashboard/` that still used Svelte 4 syntax are now runes-mode (the other 8 files in the directory were already converted and untouched):

- `DashboardCrewTab`, `DashboardGovernanceTab`, `DashboardRolesTreeTab`, `DashboardTreasuryTab` — tab panels lazy-loaded by `ParentDashboard.svelte`
- `MyDashboardAlertsTab`, `MyDashboardStatusTab`, `RotateSquadKeyModal` — member-facing status/alerts views
- `ParentDashboardMembersPanel`, `SquadBotHoldersSection`, `SquadBroadcastSettingsSection` — panel/section components
- `GovernanceDeployCoordinator` + `ParentDashboardModals` — the deploy-wizard coordinator pair

Each file moved through props -> computed -> effects -> slots in order, with side effects triaged per the KTD3 rubric:
- Pure derivations (the large majority — provider/network resolution, RPC-error classification, roster-key display state, treasury/broadcast display fields) became `$derived`/`$derived.by`.
- Sentinel-guarded blocks that both read and write their own guard variable (lazy wizard-component loading in `ParentDashboardModals`, treasury-capability loading in `DashboardTreasuryTab`, bot-holder reload-on-squad-change in `SquadBotHoldersSection`, broadcast mode resync in `SquadBroadcastSettingsSection`) became `$effect` with the guard write kept inside the guard — this is what prevents duplicate network calls when a tab is hidden/shown again rather than remounted.

**Bindable props:** `GovernanceDeployCoordinator` drives 13 `bind:` directives into `ParentDashboardModals` (deploy-modal visibility flags plus the "set treasury Safe" form fields). Those 13 corresponding props on `ParentDashboardModals` are now `$bindable()` so edits inside the modal (e.g. typing a Safe address) still propagate back up to the coordinator that owns the state.

**One deviation from the "named Props interface" pattern:** `DashboardCrewTab` is lazy-loaded through a shared `createLazyComponent<P extends Record<string, unknown>>` helper. With a named `interface Props { squad: Squad; ... }`, the generic assignability check failed (`Property 'squad' is missing in type 'Record<string, unknown>' but required in type 'Props'`) even though sibling lazy-loaded tabs with the same required-prop shape didn't trip it. Empirically, inlining the prop type directly in the destructuring signature (matching the already-converted `DashboardStatusTab.svelte` in the same loader file) resolves it cleanly, so that's the pattern used there — no changes were needed to the shared loader helper.

## Tests

Added two jsdom component tests (`@testing-library/svelte`) for the side-effect conversions that gate a transaction-submission wizard and a capability-adjacent credential-custody view, per this migration's R20 requirement:

- `ParentDashboardModals.test.ts` — the deploy-safe wizard is not lazy-loaded while its modal is closed, loads exactly once on open, and reuses the cached component across a close/reopen cycle (no duplicate fetch).
- `SquadBotHoldersSection.test.ts` — bot-holder state is not refetched when the same squad is re-rendered (simulating a tab cycle), but does reload when the squad id genuinely changes.

`pnpm check` (0 errors, 1 pre-existing-shaped `state_referenced_locally` warning — `SquadBroadcastSettingsSection`'s `mode` state intentionally captures its initial value once and is resynced by an effect on `squad.id` change, matching the original Svelte 4 behavior), `pnpm lint` (0 problems), and `pnpm test` (242 files / 2189 tests) are all green.

## Manual QA follow-up for reviewer

I mentally traced but could not execute in this environment:
- Cycling every dashboard tab twice in a running app to visually confirm no duplicate network requests fire (the `$effect` sentinel-guard conversions are the mechanism that should prevent this; validated via the two new tests above, not via a live network trace).
- `GovernanceDeployCoordinator`'s bound fields (Safe address/chain/label draft in the "set treasury Safe" form) propagating live edits back to the hosting shell — validated structurally via `$bindable()` wiring and existing test coverage, not via manual click-through in the desktop app.

Closes pacto-app-a7r.16
