### PR TITLE
feat: convert dm/ message-rendering components to svelte 5 runes

### DIFF
--- a/src/components/dm/FormattedMessageBody.svelte
+++ b/src/components/dm/FormattedMessageBody.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { afterUpdate } from 'svelte';
   import { formatMessageContent, formatMessageContentWithMentions } from '../../lib/utils/message-formatting';
   import { openExternalUrl } from '../../lib/utils/open-external';
   import { get } from 'svelte/store';
@@ -7,18 +6,25 @@
   import type { Mention } from '../../lib/messaging/mentions';
   import type { NostrProfile } from '../../lib/api/nostr';
 
-  export let content: string = '';
-  export let mentions: Mention[] | undefined = undefined;
-  export let profiles: Record<string, NostrProfile | undefined> | undefined = undefined;
-  export let rosterNpubs: string[] | Set<string> | undefined = undefined;
+  interface Props {
+    content?: string;
+    mentions?: Mention[];
+    profiles?: Record<string, NostrProfile | undefined>;
+    rosterNpubs?: string[] | Set<string>;
+  }
 
-  $: formatted = mentions && profiles && rosterNpubs
-    ? formatMessageContentWithMentions(content, mentions, profiles, rosterNpubs)
-    : formatMessageContent(content);
+  let { content = '', mentions = undefined, profiles = undefined, rosterNpubs = undefined }: Props = $props();
 
-  let bodyEl: HTMLDivElement | undefined;
+  let formatted = $derived(
+    mentions && profiles && rosterNpubs
+      ? formatMessageContentWithMentions(content, mentions, profiles, rosterNpubs)
+      : formatMessageContent(content),
+  );
 
-  afterUpdate(() => {
+  let bodyEl: HTMLDivElement | undefined = $state();
+
+  $effect(() => {
+    void formatted;
     if (!bodyEl) return;
     bodyEl.querySelectorAll('img.twemoji').forEach((img) => {
       if ((img as HTMLElement).dataset.fallbackBound) return;

--- a/src/components/dm/ImageViewer.svelte
+++ b/src/components/dm/ImageViewer.svelte
@@ -9,35 +9,104 @@
   import rotateIcon from '../../icons/rotate.svg';
   import downloadIcon from '../../icons/download.svg';
 
-  export let open = false;
-  export let src: string | undefined = undefined;
-  export let alt = '';
-  export let localPath: string | undefined = undefined;
-  /** Sender identity for the bottom-left bar; omitted entirely when no author name is given. */
-  export let authorName: string | undefined = undefined;
-  export let avatarSrc: string | undefined = undefined;
-  export let timestamp: string | undefined = undefined;
-  /** Needed for the download/save-as control and the "Show Message" menu action. */
-  export let chatId: string | undefined = undefined;
-  export let messageId: string | undefined = undefined;
-  export let attachmentId: string | undefined = undefined;
-  export let onShowMessage: (messageId: string) => void = () => {};
+  interface Props {
+    open?: boolean;
+    src?: string;
+    alt?: string;
+    localPath?: string;
+    /** Sender identity for the bottom-left bar; omitted entirely when no author name is given. */
+    authorName?: string;
+    avatarSrc?: string;
+    timestamp?: string;
+    /** Needed for the download/save-as control and the "Show Message" menu action. */
+    chatId?: string;
+    messageId?: string;
+    attachmentId?: string;
+    onShowMessage?: (messageId: string) => void;
+  }
 
-  let scale = 1;
-  let translateX = 0;
-  let translateY = 0;
-  let rotation = 0;
-  let dragging = false;
+  let {
+    open = $bindable(false),
+    src = undefined,
+    alt = '',
+    localPath = undefined,
+    authorName = undefined,
+    avatarSrc = undefined,
+    timestamp = undefined,
+    chatId = undefined,
+    messageId = undefined,
+    attachmentId = undefined,
+    onShowMessage = () => {},
+  }: Props = $props();
+
+  let scale = $state(1);
+  let translateX = $state(0);
+  let translateY = $state(0);
+  let rotation = $state(0);
+  let dragging = $state(false);
   let startX = 0;
   let startY = 0;
   let startTranslateX = 0;
   let startTranslateY = 0;
-  let backdropEl: HTMLDivElement | undefined;
-  let menuOpen = false;
-  let menuWrapperEl: HTMLDivElement | undefined;
-  let savingAs = false;
+  let backdropEl: HTMLDivElement | undefined = $state();
+  let menuOpen = $state(false);
+  let menuWrapperEl: HTMLDivElement | undefined = $state();
+  let savingAs = $state(false);
 
-  $: if (!open) resetView();
+  $effect(() => {
+    if (!open) resetView();
+  });
+
+  const FOCUSABLE_SELECTOR =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  /** Traps Tab within the dialog while open; restores focus to whatever was
+   * focused before the viewer opened once it closes or unmounts. */
+  $effect(() => {
+    if (!open || !backdropEl) return;
+    const dialogEl = backdropEl;
+    const previouslyFocused = document.activeElement;
+
+    function focusables(): HTMLElement[] {
+      return Array.from(dialogEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute('disabled'),
+      );
+    }
+
+    const list = focusables();
+    if (list.length > 0) {
+      list[0].focus();
+    } else {
+      dialogEl.focus();
+    }
+
+    function onDocumentKeydown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const nodes = focusables();
+      if (nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || active === dialogEl) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', onDocumentKeydown, true);
+
+    return () => {
+      document.removeEventListener('keydown', onDocumentKeydown, true);
+      if (previouslyFocused instanceof HTMLElement && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
+  });
 
   function resetView() {
     scale = 1;

--- a/src/components/dm/ImageViewer.test.ts
+++ b/src/components/dm/ImageViewer.test.ts
@@ -250,4 +250,47 @@ describe('ImageViewer', () => {
     removeSpy.mockRestore();
   });
 
+  it('focuses the first control on open and restores focus to the previously focused element on close', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'open viewer';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    try {
+      const { rerender } = render(ImageViewer, {
+        props: { open: true, src: 'https://example.com/img.png', alt: 'test' },
+      });
+
+      const closeBtn = screen.getByLabelText('Close image viewer');
+      await waitFor(() => {
+        expect(document.activeElement).toBe(closeBtn);
+      });
+
+      await rerender({ open: false, src: 'https://example.com/img.png', alt: 'test' });
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(trigger);
+      });
+    } finally {
+      trigger.remove();
+    }
+  });
+
+  it('wraps Tab focus at the dialog boundaries instead of escaping to the rest of the page', async () => {
+    render(ImageViewer, { props: { open: true, src: 'https://example.com/img.png', alt: 'test' } });
+
+    const closeBtn = screen.getByLabelText('Close image viewer');
+    const moreOptionsBtn = screen.getByLabelText('More options');
+    await waitFor(() => expect(document.activeElement).toBe(closeBtn));
+
+    moreOptionsBtn.focus();
+    await fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeBtn);
+
+    closeBtn.focus();
+    await fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(moreOptionsBtn);
+  });
+
 });

--- a/src/components/dm/LinkPreview.svelte
+++ b/src/components/dm/LinkPreview.svelte
@@ -3,10 +3,14 @@
   import { t } from 'svelte-i18n';
   import type { PreviewMetadata } from '../../stores/dm';
 
-  export let metadata: PreviewMetadata | null | undefined = undefined;
+  interface Props {
+    metadata?: PreviewMetadata | null;
+  }
 
-  $: displayTitle = metadata?.og_title || metadata?.title || '';
-  $: displayDescription = metadata?.og_description || metadata?.description || '';
+  let { metadata = undefined }: Props = $props();
+
+  let displayTitle = $derived(metadata?.og_title || metadata?.title || '');
+  let displayDescription = $derived(metadata?.og_description || metadata?.description || '');
   function isHttpUrl(url: string | null | undefined): boolean {
     try {
       const parsed = new URL(url ?? '');
@@ -16,17 +20,19 @@
     }
   }
 
-  $: displayImage = isHttpUrl(metadata?.og_image) ? (metadata?.og_image ?? '') : '';
-  $: linkUrl = metadata?.og_url || metadata?.domain || '';
-  $: displayDomain = (metadata?.domain ?? '').replace(/^https?:\/\//, '').replace(/\/$/, '');
-  $: hasContent = Boolean(displayTitle || displayDescription || displayImage);
+  let displayImage = $derived(isHttpUrl(metadata?.og_image) ? (metadata?.og_image ?? '') : '');
+  let linkUrl = $derived(metadata?.og_url || metadata?.domain || '');
+  let displayDomain = $derived((metadata?.domain ?? '').replace(/^https?:\/\//, '').replace(/\/$/, ''));
+  let hasContent = $derived(Boolean(displayTitle || displayDescription || displayImage));
 
-  let imageError = false;
-  let faviconError = false;
-  $: if (metadata) {
-    imageError = false;
-    faviconError = false;
-  }
+  let imageError = $state(false);
+  let faviconError = $state(false);
+  $effect(() => {
+    if (metadata) {
+      imageError = false;
+      faviconError = false;
+    }
+  });
 
   function handleClick(event: MouseEvent) {
     if (!linkUrl) return;

--- a/src/components/dm/LinkPreview.test.ts
+++ b/src/components/dm/LinkPreview.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import LinkPreview from './LinkPreview.svelte';
 import type { PreviewMetadata } from '../../stores/dm';
 
@@ -46,5 +46,19 @@ describe('LinkPreview', () => {
       props: { metadata: { ...baseMetadata, favicon: 'javascript:alert(1)' } },
     });
     expect(container.querySelector('img.link-preview-favicon')).toBeNull();
+  });
+
+  it('resolves a fresh preview after a broken image on the previous one, once metadata points at a new URL', async () => {
+    const metadata: PreviewMetadata = { ...baseMetadata, og_image: 'https://example.com/x.png' };
+    const { container, rerender } = render(LinkPreview, { props: { metadata } });
+
+    const img = container.querySelector('img.link-preview-image') as HTMLImageElement;
+    await fireEvent.error(img);
+    expect(container.querySelector('img.link-preview-image')).toBeNull();
+
+    // A distinct metadata object (a new preview, e.g. a different URL) resolves fresh and shows its own image.
+    await rerender({ metadata: { ...baseMetadata, og_image: 'https://example.com/y.png' } });
+    const nextImg = container.querySelector('img.link-preview-image') as HTMLImageElement;
+    expect(nextImg?.getAttribute('src')).toBe('https://example.com/y.png');
   });
 });

--- a/src/components/dm/Message.svelte
+++ b/src/components/dm/Message.svelte
@@ -17,49 +17,80 @@
   import { observeLinkPreview } from '../../lib/messaging/link-preview-observer';
   import { outboundDeliveryLabel } from '../../lib/dm/resolve-dm-message-presentation';
 
-  export let id: string = '';
-  export let authorName: string = '';
-  export let content: string = '';
-  export let body: string = '';
-  export let mentions: Mention[] | undefined = undefined;
-  export let rosterNpubs: string[] | Set<string> | undefined = undefined;
-  export let profiles: Record<string, NostrProfile | undefined> | undefined = undefined;
-  export let currentUserNpub: string | undefined = undefined;
-  export let isMentioned: boolean = false;
-  export let timestamp: string = '';
-  export let avatar: string = '';
-  /** Hide avatar + name/timestamp; nest under the previous message from the same author. */
-  export let compact: boolean = false;
-  /** When set, show a reply bar above the body (author + truncated content or "Attachment"). */
-  export let replyToId: string | undefined = undefined;
-  export let replyAuthorName: string | undefined = undefined;
-  export let replyPreview: string | undefined = undefined;
-  export let reactions: Reaction[] | undefined = undefined;
-  export let attachments: Attachment[] | undefined = undefined;
-  export let previewMetadata: PreviewMetadata | null | undefined = undefined;
-  export let chatId: string = '';
-  export let pending: boolean = false;
-  export let failed: boolean = false;
-  export let onReact: (messageId: string, emoji: string) => void = () => {};
-  export let onCopy: (messageId: string, text: string) => void = () => {};
-  export let onReply: (messageId: string) => void = () => {};
+  interface Props {
+    id?: string;
+    authorName?: string;
+    content?: string;
+    body?: string;
+    mentions?: Mention[];
+    rosterNpubs?: string[] | Set<string>;
+    profiles?: Record<string, NostrProfile | undefined>;
+    currentUserNpub?: string;
+    isMentioned?: boolean;
+    timestamp?: string;
+    avatar?: string;
+    /** Hide avatar + name/timestamp; nest under the previous message from the same author. */
+    compact?: boolean;
+    /** When set, show a reply bar above the body (author + truncated content or "Attachment"). */
+    replyToId?: string;
+    replyAuthorName?: string;
+    replyPreview?: string;
+    reactions?: Reaction[];
+    attachments?: Attachment[];
+    previewMetadata?: PreviewMetadata | null;
+    chatId?: string;
+    pending?: boolean;
+    failed?: boolean;
+    onReact?: (messageId: string, emoji: string) => void;
+    onCopy?: (messageId: string, text: string) => void;
+    onReply?: (messageId: string) => void;
+  }
 
-  $: displayContent = body || content;
-  $: deliveryLabel = outboundDeliveryLabel({ pending, failed }, $t);
+  let {
+    id = '',
+    authorName = '',
+    content = '',
+    body = '',
+    mentions = undefined,
+    rosterNpubs = undefined,
+    profiles = undefined,
+    currentUserNpub = undefined,
+    isMentioned = false,
+    timestamp = '',
+    avatar = '',
+    compact = false,
+    replyToId = undefined,
+    replyAuthorName = undefined,
+    replyPreview = undefined,
+    reactions = undefined,
+    attachments = undefined,
+    previewMetadata = undefined,
+    chatId = '',
+    pending = false,
+    failed = false,
+    onReact = () => {},
+    onCopy = () => {},
+    onReply = () => {},
+  }: Props = $props();
+
+  let displayContent = $derived(body || content);
+  let deliveryLabel = $derived(outboundDeliveryLabel({ pending, failed }, $t));
   /** Only fields `requestLinkPreview` reads are populated; viewport-triggered via `observeLinkPreview`. */
-  $: linkPreviewParams = chatId && id
-    ? { chatId, message: { id, content, pending, preview_metadata: previewMetadata } as DmMessage }
-    : undefined;
-  $: structuredNotice = summarizeStructuredMessageContent(displayContent, $t);
-  $: aggregated = aggregateReactions(reactions ?? [], currentUserNpub ?? '');
+  let linkPreviewParams = $derived(
+    chatId && id
+      ? { chatId, message: { id, content, pending, preview_metadata: previewMetadata } as DmMessage }
+      : undefined,
+  );
+  let structuredNotice = $derived(summarizeStructuredMessageContent(displayContent, $t));
+  let aggregated = $derived(aggregateReactions(reactions ?? [], currentUserNpub ?? ''));
   /** Telegram-style reactions overlay onto the last attachment when it's an image/video tile; otherwise they sit in normal flow below the content. */
-  $: lastAttachmentIsTile = (() => {
+  let lastAttachmentIsTile = $derived.by(() => {
     if (!attachments || attachments.length === 0) return false;
     const last = attachments[attachments.length - 1];
     const kind = attachmentKind(last.extension, last.img_meta != null);
     return kind === 'image' || kind === 'video';
-  })();
-  $: reactionsOverlayMedia = lastAttachmentIsTile && aggregated.length > 0;
+  });
+  let reactionsOverlayMedia = $derived(lastAttachmentIsTile && aggregated.length > 0);
 
   function jumpToMessage(targetId: string) {
     const el = document.getElementById(`msg-${targetId}`);
@@ -71,15 +102,15 @@
     jumpToMessage(replyToId);
   }
 
-  let menuOpen = false;
-  let menuX = 0;
-  let menuY = 0;
-  let popoverEl: HTMLElement | undefined;
+  let menuOpen = $state(false);
+  let menuX = $state(0);
+  let menuY = $state(0);
+  let popoverEl: HTMLElement | undefined = $state();
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
 
   /** Combined menu has two panels: the quick-reaction bar + action list, or the expanded emoji picker. */
-  let pickerExpanded = false;
-  let emojiSearchQuery = '';
+  let pickerExpanded = $state(false);
+  let emojiSearchQuery = $state('');
 
   const QUICK_REACTIONS = ['🥰', '❤️', '👍', '👎', '🔥', '👏', '😁'];
   const COMMON_REACTIONS = ['👍', '❤️', '😂', '😮', '😢', '😡', '🎉', '👏'];
@@ -96,17 +127,17 @@
     return out;
   })();
 
-  $: recentEmojis = $recentEmojisStore.map((e) => e.emoji);
-  $: emojiSearchResults = emojiSearchQuery.trim()
-    ? searchEmojis(emojiSearchQuery.trim()).slice(0, EMOJI_PICKER_LIMIT)
-    : [];
-  $: quickReactedSet = new Set(aggregated.filter((r) => r.includesMe).map((r) => r.emoji));
+  let recentEmojis = $derived($recentEmojisStore.map((e) => e.emoji));
+  let emojiSearchResults = $derived(
+    emojiSearchQuery.trim() ? searchEmojis(emojiSearchQuery.trim()).slice(0, EMOJI_PICKER_LIMIT) : [],
+  );
+  let quickReactedSet = $derived(new Set(aggregated.filter((r) => r.includesMe).map((r) => r.emoji)));
 
   let longPressStartX = 0;
   let longPressStartY = 0;
 
   /** Reactor-list tooltip: at most one chip's tooltip is open at a time. */
-  let reactionTooltipEmoji: string | null = null;
+  let reactionTooltipEmoji: string | null = $state(null);
   const REACTOR_TOOLTIP_LIMIT = 8;
   let chipLongPressTimer: ReturnType<typeof setTimeout> | undefined;
   let chipLongPressTriggered = false;

--- a/src/components/dm/MessageActionsMenu.svelte
+++ b/src/components/dm/MessageActionsMenu.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import { t } from 'svelte-i18n';
 
-  export let messageId: string;
-  export let text: string = '';
-  export let onCopy: (messageId: string, text: string) => void = () => {};
-  export let onReply: (messageId: string) => void = () => {};
+  interface Props {
+    messageId: string;
+    text?: string;
+    onCopy?: (messageId: string, text: string) => void;
+    onReply?: (messageId: string) => void;
+  }
+
+  let { messageId, text = '', onCopy = () => {}, onReply = () => {} }: Props = $props();
 </script>
 
 <div class="message-actions-menu" role="group" aria-label="Message actions">

--- a/src/components/dm/MessageAttachment.svelte
+++ b/src/components/dm/MessageAttachment.svelte
@@ -3,7 +3,7 @@
   import { downloadAttachment, decodeBlurhash, saveAttachmentAs } from '../../lib/api/nostr';
   import { showToast } from '../../stores/toast';
   import { t } from 'svelte-i18n';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import type { Attachment } from '../../stores/dm';
   import { attachmentKind, attachmentDisplayName, type AttachmentKind } from '../../lib/messaging/attachment-display';
   import ImageViewer from './ImageViewer.svelte';
@@ -13,14 +13,26 @@
   import saveIcon from '../../icons/download.svg';
   import { fetchGifBlobUrl, isKlipyMediaUrl } from '../../lib/api/klipy';
 
-  export let attachment: Attachment;
-  export let chatId: string = '';
-  export let messageId: string = '';
-  /** Sender identity, threaded straight into the image viewer's bottom-left bar. */
-  export let authorName: string = '';
-  export let avatarSrc: string = '';
-  export let timestamp: string = '';
-  export let onShowMessage: (messageId: string) => void = () => {};
+  interface Props {
+    attachment: Attachment;
+    chatId?: string;
+    messageId?: string;
+    /** Sender identity, threaded straight into the image viewer's bottom-left bar. */
+    authorName?: string;
+    avatarSrc?: string;
+    timestamp?: string;
+    onShowMessage?: (messageId: string) => void;
+  }
+
+  let {
+    attachment,
+    chatId = '',
+    messageId = '',
+    authorName = '',
+    avatarSrc = '',
+    timestamp = '',
+    onShowMessage = () => {},
+  }: Props = $props();
 
   const KIND_LABEL_KEY: Record<AttachmentKind, string> = {
     image: 'messaging.attachment.image',
@@ -32,30 +44,35 @@
     file: 'messaging.attachment.file',
   };
 
-  $: kind = attachmentKind(attachment.extension, attachment.img_meta != null);
-  $: isImage = kind === 'image';
-  $: isVideo = kind === 'video';
-  $: isAudio = kind === 'audio';
+  let kind = $derived(attachmentKind(attachment.extension, attachment.img_meta != null));
+  let isImage = $derived(kind === 'image');
+  let isVideo = $derived(kind === 'video');
+  let isAudio = $derived(kind === 'audio');
   /** Image and video share the poster-tile surface; audio and documents are rows. */
-  $: isTile = isImage || isVideo;
-  $: displayName = attachmentDisplayName(attachment, (key) => $t(key));
-  $: kindLabel = $t(KIND_LABEL_KEY[kind]);
+  let isTile = $derived(isImage || isVideo);
+  let displayName = $derived(attachmentDisplayName(attachment, (key) => $t(key)));
+  let kindLabel = $derived($t(KIND_LABEL_KEY[kind]));
 
   /** Klipy GIFs arrive as a plaintext provider URL — empty `key`/`nonce` marks
    * "do not decrypt" (see `message::klipy_gif_message`). Rendering fetches
    * through the Rust egress chokepoint only when the URL's host is on
    * Klipy's CDN allowlist; the authoritative check lives in Rust
    * (`klipy_fetch_media`), this is a client-side convenience gate. */
-  $: isKlipyGif = attachment.key === '' && attachment.nonce === '' && isKlipyMediaUrl(attachment.url);
+  let isKlipyGif = $derived(attachment.key === '' && attachment.nonce === '' && isKlipyMediaUrl(attachment.url));
 
-  let klipyBlobSrc: string | undefined;
-  let klipyUnavailable = false;
-  let klipyFetchedForUrl: string | undefined;
+  let klipyBlobSrc: string | undefined = $state();
+  let klipyUnavailable = $state(false);
+  let klipyFetchedForUrl: string | undefined = $state();
 
-  $: if (isKlipyGif && attachment.url !== klipyFetchedForUrl) {
-    klipyFetchedForUrl = attachment.url;
-    void loadKlipyMedia(attachment.url);
-  }
+  $effect(() => {
+    if (isKlipyGif && attachment.url !== klipyFetchedForUrl) {
+      const url = attachment.url;
+      klipyFetchedForUrl = url;
+      // The fetch reads/writes klipyBlobSrc; untrack so those don't become
+      // hidden effect dependencies alongside the url sentinel above.
+      untrack(() => void loadKlipyMedia(url));
+    }
+  });
 
   /** Fetches the GIF into memory and renders it as a blob URL. Never written to
    * disk, per Klipy's no-retain terms. A fetch failure — e.g. a purged slug —
@@ -77,50 +94,57 @@
     if (klipyBlobSrc) URL.revokeObjectURL(klipyBlobSrc);
   });
 
+  let viewerOpen = $state(false);
+  let downloading = $state(false);
+  let blurhashRequested = $state(false);
+  let savingAs = $state(false);
+  /** Set once the user asks to play; the element mounts as soon as the file is local. */
+  let playRequested = $state(false);
+
   /** Decrypted local file (`download_attachment`), or the in-memory Klipy
    * blob once fetched — never a decrypted file for a Klipy GIF. */
-  $: localSrc = isKlipyGif
-    ? klipyBlobSrc
-    : attachment.downloaded && attachment.path
-      ? toDisplaySrc(attachment.path)
-      : undefined;
-  $: onDisk = localSrc != null;
-  $: busy = downloading || attachment.downloading === true;
+  let localSrc = $derived(
+    isKlipyGif
+      ? klipyBlobSrc
+      : attachment.downloaded && attachment.path
+        ? toDisplaySrc(attachment.path)
+        : undefined,
+  );
+  let onDisk = $derived(localSrc != null);
+  let busy = $derived(downloading || attachment.downloading === true);
 
   /** Blurred stand-in shown until the real file is on disk. */
-  let blurSrc: string | undefined;
-  $: posterSrc = (isImage ? localSrc : undefined) ?? blurSrc;
-
-  let viewerOpen = false;
-  let downloading = false;
-  let blurhashRequested = false;
-  let savingAs = false;
-  /** Set once the user asks to play; the element mounts as soon as the file is local. */
-  let playRequested = false;
+  let blurSrc: string | undefined = $state();
+  let posterSrc = $derived((isImage ? localSrc : undefined) ?? blurSrc);
 
   // The blob on the media host is ciphertext, so there is nothing to show until
   // the backend has fetched and decrypted it. Until then, fall back to the
   // blurhash carried in the message itself. Video needs it even once the file
   // is local, because a video element is not a poster.
-  $: if (isTile && posterSrc == null && !blurhashRequested && attachment.img_meta?.blurhash) {
-    blurhashRequested = true;
-    void loadBlurhash(attachment.img_meta.blurhash, attachment.img_meta.width, attachment.img_meta.height);
-  }
+  $effect(() => {
+    if (isTile && posterSrc == null && !blurhashRequested && attachment.img_meta?.blurhash) {
+      blurhashRequested = true;
+      void loadBlurhash(attachment.img_meta.blurhash, attachment.img_meta.width, attachment.img_meta.height);
+    }
+  });
 
   /** Real dimensions when the sender supplied them, so the tile reserves the right box. */
-  $: tileAspect =
+  let tileAspect = $derived(
     attachment.img_meta && attachment.img_meta.width > 0 && attachment.img_meta.height > 0
       ? `${attachment.img_meta.width} / ${attachment.img_meta.height}`
-      : '4 / 3';
+      : '4 / 3',
+  );
 
-  $: sizeLabel = formatBytes(attachment.size);
+  let sizeLabel = $derived(formatBytes(attachment.size));
 
   /** Exactly one accessible name per tile state: fetch, play, or view. */
-  $: tileActionLabel = !onDisk
-    ? $t('messaging.attachment.download', { values: { name: displayName } })
-    : isVideo
-      ? $t('messaging.attachment.play', { values: { name: displayName } })
-      : $t('messaging.attachment.open', { values: { name: displayName } });
+  let tileActionLabel = $derived(
+    !onDisk
+      ? $t('messaging.attachment.download', { values: { name: displayName } })
+      : isVideo
+        ? $t('messaging.attachment.play', { values: { name: displayName } })
+        : $t('messaging.attachment.open', { values: { name: displayName } }),
+  );
 
   async function loadBlurhash(hash: string, width: number, height: number) {
     try {
@@ -242,7 +266,7 @@
         {/if}
       {:else}
       {#if isVideo && playRequested && localSrc}
-        <!-- svelte-ignore a11y-media-has-caption -->
+        <!-- svelte-ignore a11y_media_has_caption -->
         <video
           class="tile-media"
           src={localSrc}

--- a/src/components/dm/MessageAttachment.test.ts
+++ b/src/components/dm/MessageAttachment.test.ts
@@ -503,5 +503,38 @@ describe('MessageAttachment', () => {
       expect(screen.queryByLabelText('Save as…')).toBeNull();
       expect(mockedSaveAttachmentAs).not.toHaveBeenCalled();
     });
+
+    it('fetches the Klipy blob once for a given attachment, not again on unrelated re-renders', async () => {
+      mockedFetchGifBlobUrl.mockResolvedValueOnce('blob://mock-gif');
+      const { rerender } = render(MessageAttachment, {
+        props: { attachment: klipyAttachment, chatId: 'npub1abc', messageId: 'm1' },
+      });
+
+      await waitFor(() => {
+        expect(mockedFetchGifBlobUrl).toHaveBeenCalledTimes(1);
+      });
+
+      // Unrelated prop changes (and even a fresh attachment object with the same url) must not re-trigger the fetch.
+      await rerender({
+        attachment: { ...klipyAttachment },
+        chatId: 'npub1abc',
+        messageId: 'm1',
+        authorName: 'Alice',
+      });
+      await rerender({
+        attachment: { ...klipyAttachment },
+        chatId: 'npub1abc',
+        messageId: 'm1',
+        authorName: 'Alice',
+      });
+
+      // Prove the rerenders actually reached the component (not a silent no-op that would
+      // make the "not called again" assertion below vacuous): the new authorName shows up
+      // once the viewer opens.
+      await fireEvent.click(screen.getByLabelText('Open Image.gif'));
+      expect(screen.queryByText('Alice')).not.toBeNull();
+
+      expect(mockedFetchGifBlobUrl).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Migrates the DM message-rendering surface — `Message`, `MessageAttachment`, `ImageViewer`, `FormattedMessageBody`, `LinkPreview`, and `MessageActionsMenu` — from Svelte 4 legacy reactivity (`export let` / `$:` / `afterUpdate`) to Svelte 5 runes (`$props` / `$state` / `$derived` / `$effect`), part of the broader runes migration epic.

This is a behavior-preserving conversion with one addition: `ImageViewer` now traps focus inside the dialog while open (Tab wraps at the boundaries) and restores focus to whatever was focused before it opened, matching the pattern already used by the shared `Modal` component. The viewer previously had no focus management at all.

## Changes

- Converted all six components' prop declarations to `$props()` with a typed `Props` interface, preserving every original default (required vs optional, `''` vs `undefined`) exactly.
- Converted pure `$:` computations (reaction aggregation, delivery labels, attachment kind/name/labels, link-preview display fields) to `$derived` / `$derived.by`.
- Converted the two async-fetch-keyed-on-a-prop cases in `MessageAttachment` (Klipy GIF blob fetch, blurhash decode) to `$effect` blocks guarded by a sentinel that converges after one re-run — an attachment still fetches exactly once per URL/blurhash, not once per re-render. The Klipy fetch call is `untrack`ed so the async read/write of its result doesn't become a hidden effect dependency.
- Converted `LinkPreview`'s image/favicon error-flag reset and `FormattedMessageBody`'s twemoji-fallback wiring (previously `afterUpdate`) to `$effect`.
- Converted `ImageViewer`'s `open`-driven view reset to `$effect`, and added a new focus-trap + focus-restore `$effect`.
- Added jsdom coverage for the three behaviors called out in this unit's acceptance criteria: attachment fetch dedup across re-renders, link-preview re-resolution on a genuinely new URL, and the new focus trap/restore.

## Test plan

- `pnpm check` — 0 errors, 0 warnings.
- `pnpm lint` — 0 problems.
- `pnpm test` — 240 files / 2189 tests, all green (full suite, not just this batch).
- Manually traced the Klipy/blurhash sentinel effects and the focus-trap effect for convergence (no infinite-loop risk) as part of self-review.

## Manual QA follow-up for reviewer

Not exercised by automated tests (jsdom has no layout/paint), worth a hands-on pass:
- Opening a DM thread with real images/GIFs/links and confirming the visual attachment tile states (blurhash → poster → play/open) and link-preview card render as before.
- Pinch/wheel zoom and drag-to-pan on the image viewer.
- Screen-reader pass over the new focus trap (this PR verifies focus targets via `document.activeElement` and Tab-key simulation in jsdom, not actual assistive-tech behavior).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
