### PR TITLE
fix: stop reclassifying failed MLS welcome retries as transient

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2383,14 +2383,14 @@ impl WelcomeOutcome {
 
 /// Classify a `process_welcome` error message as permanent (no retry will ever help)
 /// or transient (may succeed later). Once a welcome permanently fails (e.g. no
-/// matching key package after a seed restore), the MDK engine marks the wrapper
-/// event processed/failed forever; these replay errors carry no new information.
+/// matching key package after a seed restore), mdk-core's `process_welcome` refuses
+/// to retry it and instead returns `Error::WelcomePreviouslyFailed(reason)` on every
+/// later call — Display `"welcome previously failed to process: {reason}"`, with the
+/// original failure text interpolated in, so it can only be matched by prefix, never
+/// by exact equality (mdk-core 0.8.0's `welcomes.rs`, `process_welcome`'s retry guard).
 fn classify_welcome_error(msg: &str) -> WelcomeOutcome {
-    const PERMANENT_ERRORS: [&str; 2] = [
-        "missing welcome for processed welcome",
-        "processed welcome not found",
-    ];
-    if PERMANENT_ERRORS.contains(&msg) {
+    const PERMANENT_RETRY_PREFIX: &str = "welcome previously failed to process:";
+    if msg.starts_with(PERMANENT_RETRY_PREFIX) {
         WelcomeOutcome::PermanentFailure
     } else {
         WelcomeOutcome::TransientFailure
@@ -2402,17 +2402,19 @@ mod welcome_outcome_tests {
     use super::{classify_welcome_error, WelcomeOutcome};
 
     #[test]
-    fn classifies_missing_welcome_for_processed_welcome_as_permanent() {
+    fn classifies_welcome_previously_failed_as_permanent() {
         assert_eq!(
-            classify_welcome_error("missing welcome for processed welcome"),
+            classify_welcome_error(
+                "welcome previously failed to process: Error previewing welcome: Welcome(\"No matching key package was found in the key store.\")"
+            ),
             WelcomeOutcome::PermanentFailure
         );
     }
 
     #[test]
-    fn classifies_processed_welcome_not_found_as_permanent() {
+    fn classifies_bare_permanent_prefix_with_no_reason_as_permanent() {
         assert_eq!(
-            classify_welcome_error("processed welcome not found"),
+            classify_welcome_error("welcome previously failed to process:"),
             WelcomeOutcome::PermanentFailure
         );
     }


### PR DESCRIPTION
## Value

Dev-sandbox MLS console noise: `[MLS] Failed to process welcome: Error previewing welcome: Welcome("No matching key package was found in the key store.")` reprinted on every app login/resync, forever, for the same welcome. Root cause was a real bug, not sandbox/environment drift.

## Root cause

`classify_welcome_error` (`src-tauri/src/lib.rs`) matched two literal error strings from an older `mdk-core` API to decide whether a failed welcome should be treated as permanent (never retried, marked handled) vs. transient (retried, re-logged):

- `"missing welcome for processed welcome"` — that variant no longer exists; `mdk-core 0.8.0` (the currently pinned version, see `Cargo.toml`) renamed it to `Error::WelcomePreviouslyFailed(reason)`, whose `Display` embeds the *original* failure text: `"welcome previously failed to process: {reason}"`.
- `"processed welcome not found"` — that variant exists in 0.8.0 but is dead code, never constructed by `process_welcome`.

Neither literal ever matched, so every retry of an already-permanently-failed welcome was misclassified as `TransientFailure`. Consequence: `should_mark_handled()` returned false, the wrapper event was never marked handled, and it got reprocessed and re-logged on every login/historical resync indefinitely.

## Fix

Match by prefix on the actual mdk-core 0.8.0 message (`"welcome previously failed to process:"`) instead of exact equality against a string the crate no longer produces. Since the embedded reason is dynamic, prefix matching is the only correct approach.

## Verification

- `cargo test --lib welcome_outcome_tests`: 4/4 pass, including a new case with the exact embedded reason from the reported log line.
- `cargo check --lib`: clean.

Underlying condition (a genuinely orphaned keypackage never becomes processable) is unchanged — see `docs/TAURI_MCP_INTEGRATION.md`'s troubleshooting table for that scenario. This fix only stops misclassifying and re-logging an already-permanent failure as if it might succeed later.