### PR TITLE
feat: dual-publish MLS key packages on kind 30443, accept legacy 443

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -4922,6 +4922,15 @@ mod legacy_mls_store_harvest_tests {
                 metadata TEXT NOT NULL DEFAULT '{}',
                 muted INTEGER NOT NULL DEFAULT 0
             );
+            CREATE TABLE mls_keypackages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_pubkey TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                keypackage_ref TEXT NOT NULL,
+                fetched_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL
+            );
+            CREATE INDEX idx_keypackages_owner ON mls_keypackages(owner_pubkey);
             CREATE TABLE events (
                 id TEXT PRIMARY KEY,
                 kind INTEGER NOT NULL,
@@ -5273,13 +5282,15 @@ pub async fn save_mls_keypackages<R: Runtime>(
             .get("keypackage_ref")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        let keypackage_ref_secondary = pkg.get("keypackage_ref_secondary").and_then(|v| v.as_str());
+        let keypackage_d_tag = pkg.get("keypackage_d_tag").and_then(|v| v.as_str());
         let fetched_at = pkg.get("fetched_at").and_then(|v| v.as_u64()).unwrap_or(0);
         let expires_at = pkg.get("expires_at").and_then(|v| v.as_u64()).unwrap_or(0);
 
         conn.execute(
-            "INSERT INTO mls_keypackages (owner_pubkey, device_id, keypackage_ref, fetched_at, expires_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            rusqlite::params![owner_pubkey, device_id, keypackage_ref, fetched_at as i64, expires_at as i64],
+            "INSERT INTO mls_keypackages (owner_pubkey, device_id, keypackage_ref, keypackage_ref_secondary, keypackage_d_tag, fetched_at, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![owner_pubkey, device_id, keypackage_ref, keypackage_ref_secondary, keypackage_d_tag, fetched_at as i64, expires_at as i64],
         ).map_err(|e| format!("Failed to insert MLS keypackage: {}", e))?;
     }
 
@@ -5295,17 +5306,21 @@ pub async fn load_mls_keypackages<R: Runtime>(
     let conn = crate::account_manager::get_db_connection(handle)?;
 
     let mut stmt = conn.prepare(
-        "SELECT owner_pubkey, device_id, keypackage_ref, fetched_at, expires_at FROM mls_keypackages"
+        "SELECT owner_pubkey, device_id, keypackage_ref, keypackage_ref_secondary, keypackage_d_tag, fetched_at, expires_at FROM mls_keypackages"
     ).map_err(|e| format!("Failed to prepare MLS keypackages query: {}", e))?;
 
     let rows = stmt
         .query_map([], |row| {
-            let fetched_at: i64 = row.get(3)?;
-            let expires_at: i64 = row.get(4)?;
+            let keypackage_ref_secondary: Option<String> = row.get(3)?;
+            let keypackage_d_tag: Option<String> = row.get(4)?;
+            let fetched_at: i64 = row.get(5)?;
+            let expires_at: i64 = row.get(6)?;
             Ok(serde_json::json!({
                 "owner_pubkey": row.get::<_, String>(0)?,
                 "device_id": row.get::<_, String>(1)?,
                 "keypackage_ref": row.get::<_, String>(2)?,
+                "keypackage_ref_secondary": keypackage_ref_secondary,
+                "keypackage_d_tag": keypackage_d_tag,
                 "fetched_at": fetched_at as u64,
                 "expires_at": expires_at as u64,
             }))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9059,86 +9059,87 @@ async fn regenerate_device_keypackage(cache: bool) -> Result<serde_json::Value, 
         }
     }
 
-    // If caching is requested, attempt to load and verify an existing KeyPackage
+    // If caching is requested, attempt to load and verify an existing KeyPackage. Dual
+    // publish mints two event ids from the same content — a 30443 (spec, primary) and a
+    // 443 (legacy, secondary) — so both must independently still verify before the cache
+    // is trusted. An entry recorded before this feature shipped has no secondary ref and
+    // falls through to republish, which is how it picks up 30443 coverage.
     if cache {
-        // Load existing keypackage index and verify it exists on relay before returning cached
-        let cached_kp_ref: Option<String> = {
+        let cached_entry: Option<serde_json::Value> = {
             let index = db::load_mls_keypackages(&handle).await.unwrap_or_default();
-
-            index
-                .iter()
-                .find(|entry| {
-                    entry.get("owner_pubkey").and_then(|v| v.as_str())
-                        == Some(owner_pubkey_b32.as_str())
-                        && entry.get("device_id").and_then(|v| v.as_str())
-                            == Some(device_id.as_str())
-                })
-                .and_then(|existing| {
-                    existing
-                        .get("keypackage_ref")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                })
+            index.into_iter().find(|entry| {
+                entry.get("owner_pubkey").and_then(|v| v.as_str()) == Some(owner_pubkey_b32.as_str())
+                    && entry.get("device_id").and_then(|v| v.as_str()) == Some(device_id.as_str())
+            })
         };
 
-        // If we have a cached reference, verify it exists on the relay
-        if let Some(ref_id) = cached_kp_ref {
-            println!(
-                "[MLS][KeyPackage] Found cached reference {}, verifying on relay...",
-                ref_id
-            );
+        if let Some(entry) = cached_entry {
+            let primary_ref = entry
+                .get("keypackage_ref")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let secondary_ref = entry
+                .get("keypackage_ref_secondary")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
 
-            // Try to fetch the event from the relay to verify it exists
-            if let Ok(event_id) = nostr_sdk::EventId::from_hex(&ref_id) {
-                let filter = Filter::new()
-                    .id(event_id)
-                    .kind(Kind::MlsKeyPackage)
-                    .limit(1);
-
-                match client
-                    .stream_events_from(
-                        trusted_relays::trusted_relays().to_vec(),
-                        filter,
-                        std::time::Duration::from_secs(5),
-                    )
-                    .await
-                {
-                    Ok(mut events) => {
-                        // Check if we got any events - if so, confirm the current MLS
-                        // engine can still parse it before trusting the cache. A legacy
-                        // event (e.g. missing the MIP-00/02 encoding tag) must fall
-                        // through to republish instead of short-circuiting forever.
-                        if let Some(event) = events.next().await {
-                            let usable = {
-                                let mls_service =
-                                    MlsService::new_persistent_for_keypackage_refresh(&handle)
-                                        .map_err(|e| e.to_string())?;
-                                mls_service.key_package_event_usable(&event)
-                            }; // mls_service dropped here before any await
-
-                            match usable {
-                                Ok(()) => {
-                                    return Ok(serde_json::json!({
-                                        "device_id": device_id,
-                                        "owner_pubkey": owner_pubkey_b32,
-                                        "keypackage_ref": ref_id,
-                                        "cached": true
-                                    }));
-                                }
-                                Err(e) => {
-                                    eprintln!(
-                                        "[MLS][KeyPackage] Cached event {} no longer parses ({}); republishing",
-                                        ref_id, e
-                                    );
-                                }
-                            }
+            if let (Some(primary_hex), Some(secondary_hex)) =
+                (primary_ref.as_deref(), secondary_ref.as_deref())
+            {
+                println!(
+                    "[MLS][KeyPackage] Found cached references (30443={}, 443={}), verifying on relay...",
+                    primary_hex, secondary_hex
+                );
+                // Short-circuit: the secondary ref's verdict cannot change the outcome once
+                // the primary has already failed, and each check is a relay round trip plus
+                // an MLS store open.
+                match keypackage_ref_still_usable(&client, &handle, primary_hex).await {
+                    Ok(()) => match keypackage_ref_still_usable(&client, &handle, secondary_hex).await {
+                        Ok(()) => {
+                            return Ok(serde_json::json!({
+                                "device_id": device_id,
+                                "owner_pubkey": owner_pubkey_b32,
+                                "keypackage_ref": primary_hex,
+                                "keypackage_ref_secondary": secondary_hex,
+                                "cached": true
+                            }));
                         }
-                    }
-                    _ => {}
+                        Err(e) => eprintln!(
+                            "[MLS][KeyPackage] Cached 443 reference {} no longer usable ({}); republishing",
+                            secondary_hex, e
+                        ),
+                    },
+                    Err(e) => eprintln!(
+                        "[MLS][KeyPackage] Cached 30443 reference {} no longer usable ({}); republishing",
+                        primary_hex, e
+                    ),
                 }
+            } else {
+                println!(
+                    "[MLS][KeyPackage] Cached entry missing dual-kind (30443+443) coverage; republishing"
+                );
             }
         }
     }
+
+    // Reuse this device's addressable (kind 30443) `d` tag across rotations — NIP-33
+    // replacement only fires when successive publishes share the same (kind, pubkey, d)
+    // tuple, so a fresh random `d` every rotation would leave every past KeyPackage this
+    // device ever published live and addressable on the relay forever.
+    let existing_d_tag: Option<String> = db::load_mls_keypackages(&handle)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .find(|entry| {
+            entry.get("owner_pubkey").and_then(|v| v.as_str()) == Some(owner_pubkey_b32.as_str())
+                && entry.get("device_id").and_then(|v| v.as_str()) == Some(device_id.as_str())
+        })
+        .and_then(|entry| {
+            entry
+                .get("keypackage_d_tag")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
 
     // Create device KeyPackage using persistent MLS engine inside a no-await scope
     let kp_data = {
@@ -9151,23 +9152,64 @@ async fn regenerate_device_keypackage(cache: bool) -> Result<serde_json::Value, 
             .map_err(|e| e.to_string())?
     }; // engine and mls_service dropped here before any await
 
-    // Build and sign event with nostr client
-    let kp_event = client
-        // `Kind::MlsKeyPackage` is 443, so the tag set without the `d` tag is the right one.
+    let d_tag = existing_d_tag.unwrap_or_else(|| kp_data.d_tag.clone());
+    let mut tags_30443 = kp_data.tags_30443;
+    if let Some(pos) = tags_30443.iter().position(|t| t.kind() == TagKind::d()) {
+        tags_30443[pos] = Tag::identifier(&d_tag);
+    }
+
+    // Sign and publish both the spec (30443, addressable) and legacy (443) events from the
+    // same KeyPackage content, so clients that still only understand 443 and clients that
+    // already require 30443 can both resolve this device. Both events share one timestamp
+    // so `mls::sort_keypackage_candidates`'s "prefer 30443 on a tie" actually applies —
+    // signed separately, they would otherwise straddle a second boundary and let the
+    // legacy event's later timestamp win instead.
+    let published_at = Timestamp::now();
+    let kp_event_30443 = client
         .sign_event_builder(
-            EventBuilder::new(Kind::MlsKeyPackage, kp_data.content).tags(kp_data.tags_443),
+            EventBuilder::new(mls::MLS_KEY_PACKAGE_KIND_30443, kp_data.content.clone())
+                .tags(tags_30443)
+                .custom_created_at(published_at),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    let kp_event_443 = client
+        .sign_event_builder(
+            EventBuilder::new(mls::MLS_KEY_PACKAGE_KIND_LEGACY, kp_data.content)
+                .tags(kp_data.tags_443)
+                .custom_created_at(published_at),
         )
         .await
         .map_err(|e| e.to_string())?;
 
-    // Publish to the trusted relay set
-    let send_output = client
-        .send_event_to(trusted_relays::trusted_relays().iter().cloned(), &kp_event)
+    // Publish both to the trusted relay set. A publish every relay rejects must not be
+    // cached as if it succeeded — the cache check above requires both refs to
+    // independently verify, so caching an id no relay holds would just force every future
+    // call to republish anyway, without ever telling the caller why.
+    let send_output_30443 = client
+        .send_event_to(trusted_relays::trusted_relays().iter().cloned(), &kp_event_30443)
         .await
         .map_err(|e| e.to_string())?;
-    record_send_outcome(&kp_event, &send_output);
+    record_send_outcome(&kp_event_30443, &send_output_30443);
+    if send_output_30443.success.is_empty() {
+        return Err(format!(
+            "No trusted relay accepted the kind 30443 KeyPackage: {:?}",
+            send_output_30443.failed
+        ));
+    }
+    let send_output_443 = client
+        .send_event_to(trusted_relays::trusted_relays().iter().cloned(), &kp_event_443)
+        .await
+        .map_err(|e| e.to_string())?;
+    record_send_outcome(&kp_event_443, &send_output_443);
+    if send_output_443.success.is_empty() {
+        return Err(format!(
+            "No trusted relay accepted the legacy 443 KeyPackage: {:?}",
+            send_output_443.failed
+        ));
+    }
 
-    // Upsert into mls_keypackage_index
+    // Upsert into mls_keypackage_index, recording both event ids and the reusable `d` tag
     {
         let mut index = db::load_mls_keypackages(&handle).await.unwrap_or_default();
         index.retain(|entry| {
@@ -9180,7 +9222,9 @@ async fn regenerate_device_keypackage(cache: bool) -> Result<serde_json::Value, 
         index.push(serde_json::json!({
             "owner_pubkey": owner_pubkey_b32,
             "device_id": device_id,
-            "keypackage_ref": kp_event.id.to_hex(),
+            "keypackage_ref": kp_event_30443.id.to_hex(),
+            "keypackage_ref_secondary": kp_event_443.id.to_hex(),
+            "keypackage_d_tag": d_tag,
             "fetched_at": now,
             "expires_at": 0u64
         }));
@@ -9202,9 +9246,43 @@ async fn regenerate_device_keypackage(cache: bool) -> Result<serde_json::Value, 
     Ok(serde_json::json!({
         "device_id": device_id,
         "owner_pubkey": owner_pubkey_b32,
-        "keypackage_ref": kp_event.id.to_hex(),
+        "keypackage_ref": kp_event_30443.id.to_hex(),
+        "keypackage_ref_secondary": kp_event_443.id.to_hex(),
         "cached": false
     }))
+}
+
+/// Fetch a KeyPackage event by id across both the spec (30443) and legacy (443) kinds and
+/// confirm the current MLS engine can still parse it. `regenerate_device_keypackage`'s cache
+/// check calls this once per dual-published ref, so one kind being pruned from a relay does
+/// not silently pass the check on the strength of the other still resolving. Returns the
+/// rejection reason on failure so the caller can log why the cache was invalidated.
+async fn keypackage_ref_still_usable(
+    client: &nostr_sdk::Client,
+    handle: &AppHandle,
+    ref_id_hex: &str,
+) -> Result<(), String> {
+    let event_id = nostr_sdk::EventId::from_hex(ref_id_hex)
+        .map_err(|e| format!("invalid keypackage ref: {}", e))?;
+    let filter = Filter::new()
+        .id(event_id)
+        .kinds(mls::mls_key_package_kinds())
+        .limit(1);
+    let mut events = client
+        .stream_events_from(
+            trusted_relays::trusted_relays().to_vec(),
+            filter,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .map_err(|e| format!("relay fetch failed: {}", e))?;
+    let event = events
+        .next()
+        .await
+        .ok_or_else(|| "not found on the trusted relays".to_string())?;
+    let mls_service = MlsService::new_persistent_for_keypackage_refresh(handle)
+        .map_err(|e| e.to_string())?;
+    mls_service.key_package_event_usable(&event)
 }
 
 /// Re-fetch pending pre-reset welcomes by id. Forward sync is time-windowed,
@@ -10235,8 +10313,11 @@ async fn leave_mls_group(group_id: String) -> Result<(), String> {
     .map_err(|e| format!("Task join error: {}", e))?
 }
 
-//// Refresh keypackages for a contact from the trusted relay set
-//// Fetches Kind::MlsKeyPackage from the contact, updates local index, and returns (device_id, keypackage_ref)
+/// Refresh keypackages for a contact from the trusted relay set.
+/// Fetches KeyPackage events (kind 30443, or legacy 443) from the contact, updates the local
+/// index, and returns (device_id, keypackage_ref) pairs, newest first. The 30443/443 pair
+/// from one dual publish collapses into a single entry; separate rotations do not, so a
+/// contact who has republished multiple times may still return more than one entry.
 #[tauri::command]
 async fn refresh_keypackages_for_contact(npub: String) -> Result<Vec<(String, String)>, String> {
     // Resolve contact pubkey
@@ -10245,12 +10326,13 @@ async fn refresh_keypackages_for_contact(npub: String) -> Result<Vec<(String, St
     // Access client
     let client = get_nostr_client().map_err(|_| "Nostr client not initialized")?;
 
-    // Build filter: author(contact) + MlsKeyPackage
+    // Build filter: author(contact) + both KeyPackage kinds (dual publish). A generous
+    // limit tolerates a contact having several real devices, each visible under both
+    // kinds.
     let filter = Filter::new()
         .author(contact_pubkey)
-        .kind(Kind::MlsKeyPackage)
-        // Only need the newest KeyPackage
-        .limit(1);
+        .kinds(mls::mls_key_package_kinds())
+        .limit(50);
 
     // Fetch from the trusted relay set with a short timeout
     let mut events = client
@@ -10262,12 +10344,30 @@ async fn refresh_keypackages_for_contact(npub: String) -> Result<Vec<(String, St
         .await
         .map_err(|e| e.to_string())?;
 
+    let mut raw_events: Vec<Event> = Vec::new();
+    while let Some(e) = events.next().await {
+        raw_events.push(e);
+    }
+
+    // A dual-published device yields two distinct event ids (30443 + 443) carrying identical
+    // content. Collapse those into one logical device, keeping the sort order intact —
+    // downstream callers (create_group_chat, invite_member_to_group) treat the first
+    // returned entry as the device to use, so an unordered dedupe (e.g. draining a HashMap)
+    // could hand back a stale duplicate instead of the newest one.
+    let mut seen_content: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut deduped: Vec<Event> = Vec::new();
+    for event in mls::sort_keypackage_candidates(raw_events) {
+        if seen_content.insert(event.content.clone()) {
+            deduped.push(event);
+        }
+    }
+
     // Prepare results and index entries
     let owner_pubkey_b32 = contact_pubkey.to_bech32().map_err(|e| e.to_string())?;
     let mut results: Vec<(String, String)> = Vec::new();
     let mut new_entries: Vec<serde_json::Value> = Vec::new();
 
-    while let Some(e) = events.next().await {
+    for e in deduped {
         // Use event id as synthetic device_id when not explicitly provided by remote
         let device_id = e.id.to_hex();
         let keypackage_ref = e.id.to_hex();

--- a/src-tauri/src/migrations/V20260820200347__mls_keypackage_secondary_ref.sql
+++ b/src-tauri/src/migrations/V20260820200347__mls_keypackage_secondary_ref.sql
@@ -1,0 +1,13 @@
+-- Dual kind:30443/kind:443 KeyPackage publishing republishes the same device KeyPackage
+-- under both event kinds, minted as two distinct event ids from identical content.
+-- keypackage_ref_secondary holds the second id alongside the existing `keypackage_ref`, so
+-- self-device cache verification can confirm both are still resolvable instead of trusting
+-- one kind's survival for both. NULL for contact-resolved rows, which only ever track a
+-- single fetched event.
+--
+-- keypackage_d_tag holds the addressable (kind:30443) `d` tag value for a self-device row.
+-- Reusing the same value across rotations is what makes kind:30443 actually replace the
+-- previous event on relays (NIP-33); without it every rotation would mint a new, permanently
+-- live address. NULL for contact-resolved rows.
+ALTER TABLE mls_keypackages ADD COLUMN keypackage_ref_secondary TEXT;
+ALTER TABLE mls_keypackages ADD COLUMN keypackage_d_tag TEXT;

--- a/src-tauri/src/migrations/mod.rs
+++ b/src-tauri/src/migrations/mod.rs
@@ -300,6 +300,15 @@ mod tests {
                 metadata TEXT NOT NULL DEFAULT '{}',
                 muted INTEGER NOT NULL DEFAULT 0
             );
+            CREATE TABLE mls_keypackages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                owner_pubkey TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                keypackage_ref TEXT NOT NULL,
+                fetched_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL
+            );
+            CREATE INDEX idx_keypackages_owner ON mls_keypackages(owner_pubkey);
             CREATE TABLE events (
                 id TEXT PRIMARY KEY,
                 kind INTEGER NOT NULL,

--- a/src-tauri/src/mls.rs
+++ b/src-tauri/src/mls.rs
@@ -12,7 +12,7 @@
 //! - group_id, engine_group_id, creator_pubkey, name, avatar_ref, created_at, updated_at, evicted
 //!
 //! ### mls_keypackages table (plaintext)
-//! - owner_pubkey, device_id, keypackage_ref, fetched_at, expires_at
+//! - owner_pubkey, device_id, keypackage_ref, keypackage_ref_secondary, keypackage_d_tag, fetched_at, expires_at
 //!
 //! ### mls_event_cursors table (plaintext)
 //! - group_id, last_seen_event_id, last_seen_at
@@ -87,6 +87,34 @@ pub(crate) fn mls_wrapper_failure_reason(event_id: &[u8; 32]) -> Option<String> 
     .flatten()
 }
 
+/// Spec kind (NIP-33 addressable) for MLS KeyPackage events per MIP-00. mdk-core's matching
+/// constant is private to that crate, so Pacto mirrors it here for filter construction.
+pub(crate) const MLS_KEY_PACKAGE_KIND_30443: nostr_sdk::Kind = nostr_sdk::Kind::Custom(30443);
+
+/// Legacy kind for MLS KeyPackage events, accepted by mdk-core through the transition period.
+/// Same numeric value as `nostr_sdk::Kind::MlsKeyPackage`.
+pub(crate) const MLS_KEY_PACKAGE_KIND_LEGACY: nostr_sdk::Kind = nostr_sdk::Kind::MlsKeyPackage;
+
+/// Both KeyPackage kinds, for fetch filters during the dual-publish transition: Pacto
+/// publishes 30443 and legacy 443 from the same KeyPackage content, and must accept either
+/// when resolving a peer's — or another NIP-EE client's — published KeyPackage.
+pub(crate) fn mls_key_package_kinds() -> [nostr_sdk::Kind; 2] {
+    [MLS_KEY_PACKAGE_KIND_30443, MLS_KEY_PACKAGE_KIND_LEGACY]
+}
+
+/// Sort KeyPackage candidates newest-first; ties (e.g. a simultaneous dual publish) prefer
+/// the spec kind (30443) over the legacy one.
+pub(crate) fn sort_keypackage_candidates(mut events: Vec<nostr_sdk::Event>) -> Vec<nostr_sdk::Event> {
+    events.sort_by(|a, b| {
+        b.created_at.cmp(&a.created_at).then_with(|| {
+            let a_is_30443 = a.kind == MLS_KEY_PACKAGE_KIND_30443;
+            let b_is_30443 = b.kind == MLS_KEY_PACKAGE_KIND_30443;
+            b_is_30443.cmp(&a_is_30443)
+        })
+    });
+    events
+}
+
 /// MLS group metadata stored encrypted in "mls_groups"
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MlsGroupMetadata {
@@ -113,6 +141,16 @@ struct KeyPackageIndexEntry {
     owner_pubkey: String,
     device_id: String,
     keypackage_ref: String,
+    /// The other kind's event id for the same dual-published KeyPackage: the 443 id when
+    /// `keypackage_ref` is the 30443 one, or `None` for contact-resolved rows, which only
+    /// ever track a single fetched event.
+    #[serde(default)]
+    keypackage_ref_secondary: Option<String>,
+    /// The addressable (kind 30443) `d` tag value for a self-device row, reused across
+    /// rotations so republishing actually replaces the previous 30443 event on relays
+    /// (NIP-33) instead of leaving it live forever. `None` for contact-resolved rows.
+    #[serde(default)]
+    keypackage_d_tag: Option<String>,
     fetched_at: u64,
     expires_at: u64,
 }
@@ -549,7 +587,7 @@ impl MlsService {
       1) Resolve creator pubkey and build NostrGroupConfigData scoped to the trusted relay set.
       2) Resolve each member device to its KeyPackage Event before touching the MLS engine:
          • Prefer local plaintext index "mls_keypackage_index" to get keypackage_ref by member npub + device_id.
-         • If ref exists: fetch exact event by id; else: fetch latest Kind::MlsKeyPackage by author.
+         • If ref exists: fetch exact event by id; else: fetch latest KeyPackage (kind 30443 or legacy 443) by author.
          • Any member device with no resolvable KeyPackage event, or an npub that fails bech32
            parsing, is recorded as a `SkippedMember` and left out — it never reaches the engine.
       3) Inside the no-await engine scope, validate every candidate event with
@@ -698,10 +736,15 @@ impl MlsService {
                     }
                 }
             } else {
-                // Fallback: fetch latest KeyPackage by author from the trusted relay set
+                // Fallback: fetch latest KeyPackage by author across both the spec (30443)
+                // and legacy (443) kinds, preferring the newest event this engine can
+                // actually parse — a stale duplicate under one kind must not beat a fresh,
+                // parseable one under the other. If nothing parses, fall back to the newest
+                // candidate anyway so the validation pass below reports the real rejection
+                // reason instead of a generic "not found".
                 let filter = Filter::new()
                     .author(member_pk)
-                    .kind(Kind::MlsKeyPackage)
+                    .kinds(mls_key_package_kinds())
                     .limit(50);
                 match get_nostr_client()
                     .unwrap()
@@ -713,8 +756,12 @@ impl MlsService {
                     .await
                 {
                     Ok(events) => {
-                        // Heuristic: pick newest by created_at
-                        let selected = events.into_iter().max_by_key(|e| e.created_at.as_secs());
+                        let candidates = sort_keypackage_candidates(events.into_iter().collect());
+                        let selected = candidates
+                            .iter()
+                            .find(|&e| self.key_package_event_usable(e).is_ok())
+                            .cloned()
+                            .or_else(|| candidates.into_iter().next());
                         if selected.is_none() {
                             eprintln!("[MLS] No KeyPackage events found for {}", member_npub);
                         }
@@ -1114,7 +1161,7 @@ impl MlsService {
                 RESTORE_KEYPACKAGE_RETRY_ATTEMPTS,
                 move || {
                     let retry_client = retry_client.clone();
-                    async move { Self::fetch_latest_keypackage(&retry_client, member_pk).await }
+                    async move { self.fetch_latest_keypackage(&retry_client, member_pk).await }
                 },
                 |delay| tokio::time::sleep(delay),
             )
@@ -1143,7 +1190,7 @@ impl MlsService {
 
             // Fallback: fetch latest from network
             if kp_event.is_none() {
-                kp_event = Self::fetch_latest_keypackage(&client, member_pk).await;
+                kp_event = self.fetch_latest_keypackage(&client, member_pk).await;
             }
 
             kp_event
@@ -1348,9 +1395,15 @@ impl MlsService {
         Ok(())
     }
 
-    /// Fetch the newest published KeyPackage (Kind:443) for a pubkey directly from the network,
-    /// bypassing the local keypackage index/cache.
+    /// Fetch the newest published KeyPackage for a pubkey directly from the network,
+    /// bypassing the local keypackage index/cache. Matches both the spec (30443) and legacy
+    /// (443) kinds during the dual-publish transition, preferring the spec kind on a tie and
+    /// preferring an event this engine can actually parse. Falls back to the newest
+    /// candidate even if unparseable when nothing parses, so the caller's own validation
+    /// (e.g. `add_members`) surfaces the real rejection reason instead of a generic
+    /// "not found".
     async fn fetch_latest_keypackage(
+        &self,
         client: &nostr_sdk::Client,
         member_pk: PublicKey,
     ) -> Option<nostr_sdk::Event> {
@@ -1358,17 +1411,22 @@ impl MlsService {
 
         let filter = Filter::new()
             .author(member_pk)
-            .kind(Kind::MlsKeyPackage)
+            .kinds(mls_key_package_kinds())
             .limit(50);
-        client
+        let events = client
             .fetch_events_from(
                 crate::trusted_relays::trusted_relays().to_vec(),
                 filter,
                 std::time::Duration::from_secs(10),
             )
             .await
-            .ok()
-            .and_then(|events| events.into_iter().max_by_key(|e| e.created_at.as_secs()))
+            .ok()?;
+        let candidates = sort_keypackage_candidates(events.into_iter().collect());
+        candidates
+            .iter()
+            .find(|&e| self.key_package_event_usable(e).is_ok())
+            .cloned()
+            .or_else(|| candidates.into_iter().next())
     }
 
     /// Leave a group voluntarily
@@ -2770,6 +2828,8 @@ impl MlsService {
             owner_pubkey: owner_pubkey.to_string(),
             device_id: device_id.to_string(),
             keypackage_ref: keypackage_ref.to_string(),
+            keypackage_ref_secondary: None,
+            keypackage_d_tag: None,
             fetched_at: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -4012,6 +4072,142 @@ mod mls_key_package_validity_tests {
             err.contains("encoding tag"),
             "expected an encoding-tag error, got: {}",
             err
+        );
+    }
+
+    /// Golden vector: `create_key_package_for_event` must hand back a 30443 tag set carrying
+    /// the addressable `d` tag and a 443 tag set that is identical minus that tag, both
+    /// sharing the same base64 `content` — and the current engine must parse an event built
+    /// from either kind/tag-set pair (dual publish).
+    #[tokio::test]
+    async fn create_key_package_for_event_yields_parseable_tags_for_both_kinds() {
+        let engine = MDK::new(
+            MdkSqliteStorage::new_with_key(":memory:", EncryptionConfig::new([24u8; 32])).unwrap(),
+        );
+        let keys = Keys::generate();
+        let relay_url = RelayUrl::parse("wss://relay.test").unwrap();
+        let kp = engine
+            .create_key_package_for_event(&keys.public_key(), [relay_url])
+            .expect("create keypackage");
+
+        assert!(
+            kp.tags_30443.iter().any(|t| t.kind() == TagKind::d()),
+            "30443 tag set must carry the addressable `d` tag"
+        );
+        assert!(
+            !kp.tags_443.iter().any(|t| t.kind() == TagKind::d()),
+            "legacy 443 tag set must not carry the `d` tag"
+        );
+        let expected_443: Vec<Tag> = kp
+            .tags_30443
+            .iter()
+            .filter(|t| t.kind() != TagKind::d())
+            .cloned()
+            .collect();
+        assert_eq!(
+            kp.tags_443, expected_443,
+            "443 tag set must be exactly the 30443 set minus the `d` tag, unchanged otherwise"
+        );
+
+        let event_30443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, kp.content.clone())
+            .tags(kp.tags_30443)
+            .build(keys.public_key())
+            .sign(&keys)
+            .await
+            .expect("sign 30443 keypackage");
+        let event_443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, kp.content)
+            .tags(kp.tags_443)
+            .build(keys.public_key())
+            .sign(&keys)
+            .await
+            .expect("sign 443 keypackage");
+
+        engine
+            .parse_key_package(&event_30443)
+            .expect("30443 event must parse");
+        engine
+            .parse_key_package(&event_443)
+            .expect("443 event must parse");
+    }
+
+    /// The dual-publish fetch filter must accept events of either kind, and reject an unrelated
+    /// one.
+    #[test]
+    fn key_package_filter_matches_both_kinds() {
+        let keys = Keys::generate();
+        let filter = Filter::new().author(keys.public_key()).kinds(mls_key_package_kinds());
+
+        let event_30443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, "content")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let event_443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "content")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let unrelated = EventBuilder::new(Kind::TextNote, "content")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        assert!(filter.match_event(&event_30443, MatchEventOptions::default()));
+        assert!(filter.match_event(&event_443, MatchEventOptions::default()));
+        assert!(!filter.match_event(&unrelated, MatchEventOptions::default()));
+    }
+
+    /// `sort_keypackage_candidates` breaks a created_at tie by preferring the spec kind
+    /// (30443) over the legacy one ("prefer the newest usable 30443 when both exist").
+    #[test]
+    fn sort_keypackage_candidates_prefers_30443_on_tie() {
+        let keys = Keys::generate();
+        let now = Timestamp::now();
+        let event_443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "content")
+            .custom_created_at(now)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let event_30443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, "content")
+            .custom_created_at(now)
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let sorted = sort_keypackage_candidates(vec![event_443, event_30443]);
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].kind, MLS_KEY_PACKAGE_KIND_30443);
+    }
+
+    /// The primary sort key is `created_at`, newest first — the kind tie-break only applies
+    /// when timestamps are equal. Pins that a newer event of either kind beats an older one
+    /// of the *other* kind, so a stale duplicate under one kind can never beat a fresh,
+    /// parseable one under the other.
+    #[test]
+    fn sort_keypackage_candidates_orders_by_created_at_first() {
+        let keys = Keys::generate();
+        let older = Timestamp::now();
+        let newer = Timestamp::from_secs(older.as_secs() + 60);
+
+        // Same kind: newer must win regardless of the tie-break.
+        let same_kind_old = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, "content-a")
+            .custom_created_at(older)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let same_kind_new = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, "content-b")
+            .custom_created_at(newer)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let sorted = sort_keypackage_candidates(vec![same_kind_old, same_kind_new.clone()]);
+        assert_eq!(sorted[0].id, same_kind_new.id);
+
+        // Mixed kind: a newer legacy (443) event must still beat an older spec (30443) one —
+        // the 30443 tie-break must not override a real timestamp difference.
+        let older_30443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_30443, "content-c")
+            .custom_created_at(older)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let newer_443 = EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, "content-d")
+            .custom_created_at(newer)
+            .sign_with_keys(&keys)
+            .unwrap();
+        let sorted = sort_keypackage_candidates(vec![older_30443, newer_443.clone()]);
+        assert_eq!(
+            sorted[0].id, newer_443.id,
+            "a newer legacy event must beat an older spec-kind one"
         );
     }
 }


### PR DESCRIPTION
## Summary

Pacto only published and fetched MLS KeyPackages on the legacy Nostr kind 443. Every other NIP-EE client (Amethyst, MDK-based clients) publishes on the addressable spec kind 30443 instead, so a squad invite to any of them could never resolve a KeyPackage — and MDK's own upstream acceptance window for legacy 443 has already lapsed. This dual-publishes both kinds from the same KeyPackage content and widens every fetch path to accept either, so Pacto can invite and be invited by any NIP-EE client during the transition, while still resolving KeyPackages from installs that haven't upgraded.

## Changes

- `regenerate_device_keypackage` now signs and publishes both a kind:30443 (addressable, spec) and kind:443 (legacy) event from the same KeyPackage content, sharing one timestamp so the "prefer 30443" kind tie-break actually applies.
- The 30443 event reuses the device's stored `d` tag across rotations, so NIP-33 replacement actually retires the previous event on relays instead of leaving every past KeyPackage permanently live and addressable.
- Every fetch path — `create_group`'s member resolution, the invite path, `refresh_keypackages_for_contact`, and self-device cache verification — now matches both kinds and prefers the newest event the engine can actually parse, falling back to the newest candidate (parseable or not) so a genuine rejection reason still surfaces instead of a generic "not found."
- Self-device cache verification now tracks both event ids per device (`keypackage_ref_secondary`) and requires both to independently verify before trusting the cache, so one kind being pruned from a relay can't fool the check on the strength of the other.
- A publish every trusted relay rejects is now a hard error instead of being silently cached as if it succeeded.
- New migration adds `keypackage_ref_secondary` and `keypackage_d_tag` to `mls_keypackages`.

## Test plan

- `cargo test --lib` — 827 passed, 0 failed, including new golden-vector, fetch-filter, and sort-order tests.
- `cargo clippy --lib --no-deps` — no new warnings.
- Two migration test fixtures (baselined pre-existing account simulations) updated to include `mls_keypackages` so the new `ALTER TABLE` runs against a real table shape instead of failing with "no such table."

## Related

Fixes #312.
Related: #337 (follow-up — sunset legacy kind:443 publish/read once fleet adoption of 30443 is universal).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
