### PR TITLE
fix: create new squad sticker packs instead of failing with pack_id is empty

### DIFF
--- a/src/components/parent/dashboard/SquadStickersSection.svelte
+++ b/src/components/parent/dashboard/SquadStickersSection.svelte
@@ -38,12 +38,14 @@
   let saving = $state(false);
   let saveError = $state('');
   let saveSuccess = $state(false);
+  let hasHydrated = false;
   let hydratedForPackId: string | null = null;
 
   $effect(() => {
     const pack = existingPack;
     const targetId = pack?.packId ?? null;
-    if (hydratedForPackId === targetId) return;
+    if (hasHydrated && hydratedForPackId === targetId) return;
+    hasHydrated = true;
     hydratedForPackId = targetId;
     packId = pack?.packId ?? crypto.randomUUID();
     packName = pack?.name ?? '';
@@ -71,7 +73,7 @@
   }
 
   const hasValidationErrors = $derived(validationEntries.some((entry) => fieldError(entry) !== ''));
-  const canSave = $derived(squadId !== '' && !saving && !isUploading && !hasValidationErrors);
+  const canSave = $derived(squadId !== '' && packId.trim() !== '' && !saving && !isUploading && !hasValidationErrors);
 
   function basenameFromPath(path: string): string {
     const normalized = path.replace(/\\/g, '/');


### PR DESCRIPTION
## Summary

Creating a squad's first sticker pack failed with a raw backend error string, `pack_id is empty`, even with a valid pack name and sticker entries filled in. The **Create pack** button stayed enabled, so the only way to discover the bug was to click it and hit the error.

Root cause: the hydration `$effect` in `SquadStickersSection.svelte` used `null` for two different meanings — "the effect hasn't run yet" and "no existing pack for this squad" — so for a brand-new pack both were `null` and the guard short-circuited before `crypto.randomUUID()` ever ran. `packId` stayed `''` all the way to `saveStickerPack`.

Fixes #285.

## Changes

- `SquadStickersSection.svelte`: added a `hasHydrated` boolean so the hydration effect always runs its body on first mount, regardless of whether an existing pack was found.
- `canSave` now also requires a non-empty `packId`, so a future regression in the hydration guard fails closed in the UI instead of round-tripping to the backend for a string error.

## Test plan

- `pnpm check`, `pnpm lint` — clean.
- `pnpm vitest run src/lib/squad/sticker-pack-validation.test.ts src/lib/api/stickers.test.ts` — 15/15 pass (pure-function coverage, unaffected by this change; no component-rendering test infra exists in this repo to unit-test the `$effect` itself).
- Manual repro via `make dev-sandbox-seeded` + Tauri MCP driver: wiped the sandbox identity so the seeded squad had no existing pack (the exact `existingPack === null` state the bug required), opened Squad Settings → Stickers, entered a pack name, clicked **Create pack**. Before the fix this exact path produced `pack_id is empty`; after the fix the UI shows "Sticker pack saved." and the `sticker_packs` table persists a real UUID `pack_id` (confirmed with a `sqlite3` query against the sandbox DB, e.g. `504b7b5e-4893-4af0-803f-bddc33264362`).
