### PR TITLE
fix: parallelize rust ci tests with cargo-nextest, report timing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,8 @@ jobs:
           workspaces: src-tauri
 
       - name: Install cargo-nextest
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+        # Pinned to match Dockerfile.ci's ARG NEXTEST_VERSION -- keep both in sync.
+        run: curl -LsSf https://get.nexte.st/0.9.143/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
 
       - name: Rust unit tests
         working-directory: src-tauri
@@ -260,7 +261,8 @@ jobs:
           workspaces: src-tauri
 
       - name: Install cargo-nextest
-        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+        # Pinned to match Dockerfile.ci's ARG NEXTEST_VERSION -- keep both in sync.
+        run: curl -LsSf https://get.nexte.st/0.9.143/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
 
       - name: Harness unit tests
         working-directory: src-tauri

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,9 +217,29 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+
       - name: Rust unit tests
         working-directory: src-tauri
-        run: cargo test --lib --no-default-features
+        # nextest runs each test in its own process instead of cargo test's
+        # shared-process thread pool: ~7x faster wall time locally (948
+        # tests, 190s -> 26s) with identical pass/fail semantics. `--profile
+        # ci` emits a JUnit report (.config/nextest.toml) for the timing
+        # summary and artifact below.
+        run: cargo nextest run --lib --no-default-features --profile ci
+
+      - name: Test timing summary
+        if: always()
+        run: node scripts/nextest-slow-summary.mjs src-tauri/target/nextest/ci/junit.xml "Backend test timing"
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-tests-junit
+          path: src-tauri/target/nextest/ci/junit.xml
+          if-no-files-found: ignore
 
   relay-free-harness:
     # Relay-free seeding harness: builds populated per-account storage with
@@ -239,11 +259,14 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+
       - name: Harness unit tests
         working-directory: src-tauri
         # Quoted: the trailing `::` module filter would otherwise read as a
         # YAML mapping key and make this whole file unparseable.
-        run: "cargo test --lib --no-default-features --features relay-free-harness harness::"
+        run: "cargo nextest run --lib --no-default-features --features relay-free-harness harness::"
 
       - name: Build relay-free harness
         working-directory: src-tauri
@@ -340,5 +363,5 @@ jobs:
           node-version: 24.18.0
 
       - name: Run release script tests
-        run: node --test scripts/generate-release-manifest.test.mjs scripts/stamp-updater-compatibility.test.mjs
+        run: node --test scripts/generate-release-manifest.test.mjs scripts/stamp-updater-compatibility.test.mjs scripts/nextest-slow-summary.test.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ cd src-tauri && cargo test
 ## Testing & QA
 
 - **Frontend tests:** Vitest 3 with `environment: 'node'` and `include: ['src/**/*.test.ts']`. Tests are co-located with source code and exercise pure functions, Svelte stores, and Tauri command shapes. No component rendering or DOM tests are present.
-- **Backend tests:** `cargo test` locally, `cargo nextest run` in CI (same tests, either runner works locally — install via `cargo install cargo-nextest --locked` for CI parity). Tests are co-located in `#[cfg(test)]` modules inside source files. They use in-memory SQLite and deterministic golden vectors.
+- **Backend tests:** `cargo test` locally, `cargo nextest run` in CI (same tests, either runner works locally — CI installs a pinned prebuilt binary, `curl -LsSf https://get.nexte.st/0.9.143/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"`; `cargo install cargo-nextest --locked` also works locally but does not pin to CI's exact version). Tests are co-located in `#[cfg(test)]` modules inside source files. They use in-memory SQLite and deterministic golden vectors.
 - **Common test patterns:**
   - Mock Tauri `invoke` with `vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))`.
   - Mock `localStorage`/`sessionStorage` with `vi.stubGlobal` / `vi.unstubAllGlobals`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,19 +209,19 @@ cd src-tauri && cargo test
 - **Platform-specific deps:** Linux needs WebKit2GTK 4.1, Vulkan, ALSA, appindicator; macOS needs Xcode CLT, cmake, llvm, openssl; Windows needs VS Build Tools, LLVM, WebView2, Vulkan. See `docs/build/{ubuntuGuide,macGuide,windowsGuide}.md`.
 - **Whisper feature:** Enabled by default. Metal on macOS, Vulkan on Windows/Linux, excluded on Android. Feature-gated in `Cargo.toml`.
 - **MCP bridge:** `tauri-plugin-mcp-bridge` is included in debug builds only; release builds exclude it.
-- **CI:** `.github/workflows/ci.yaml` gates every PR: typecheck (`pnpm check`), lint (`pnpm lint`, `pnpm check:tauri-commands`), frontend unit tests with coverage, Playwright e2e, a Tauri debug e2e harness (`continue-on-error`), Rust `cargo test --lib`, and a release-binary symbol check. `.github/workflows/release.yaml` separately publishes macOS (arm64 + x86_64), Ubuntu (amd64 + arm64), and Windows bundles on every `v*` tag; requires `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` for the updater.
+- **CI:** `.github/workflows/ci.yaml` gates every PR: typecheck (`pnpm check`), lint (`pnpm lint`, `pnpm check:tauri-commands`), frontend unit tests with coverage, Playwright e2e, a Tauri debug e2e harness (`continue-on-error`), Rust tests via `cargo nextest run --lib` (process-per-test parallelism; ~7x faster wall time than `cargo test` on this suite), and a release-binary symbol check. `.github/workflows/release.yaml` separately publishes macOS (arm64 + x86_64), Ubuntu (amd64 + arm64), and Windows bundles on every `v*` tag; requires `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` for the updater.
 
 ## Testing & QA
 
 - **Frontend tests:** Vitest 3 with `environment: 'node'` and `include: ['src/**/*.test.ts']`. Tests are co-located with source code and exercise pure functions, Svelte stores, and Tauri command shapes. No component rendering or DOM tests are present.
-- **Backend tests:** Standard `cargo test` in `src-tauri`. Tests are co-located in `#[cfg(test)]` modules inside source files. They use in-memory SQLite and deterministic golden vectors.
+- **Backend tests:** `cargo test` locally, `cargo nextest run` in CI (same tests, either runner works locally — install via `cargo install cargo-nextest --locked` for CI parity). Tests are co-located in `#[cfg(test)]` modules inside source files. They use in-memory SQLite and deterministic golden vectors.
 - **Common test patterns:**
   - Mock Tauri `invoke` with `vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))`.
   - Mock `localStorage`/`sessionStorage` with `vi.stubGlobal` / `vi.unstubAllGlobals`.
   - Reset Svelte stores in `beforeEach`/`afterEach`.
   - Rust DB tests create `rusqlite::Connection::open_in_memory()` and execute the minimal schema DDL inline.
 - **Coverage:** `@vitest/coverage-v8` is available via `pnpm test:coverage:serve`; no configured thresholds.
-- **Quality gates:** `ci.yaml` runs `pnpm test:coverage` and `cargo test --lib` on every PR (see CI above); `release.yaml` only builds and publishes tagged releases and does not run tests.
+- **Quality gates:** `ci.yaml` runs `pnpm test:coverage` and `cargo nextest run --lib` on every PR (see CI above); `release.yaml` only builds and publishes tagged releases and does not run tests.
 - **Manual QA:** `docs/wallet/MANUAL_E2E_CHECKLIST.md` and `docs/wallet/OPERATOR_SMOKE.md`.
 - **Security posture:** `docs/audits/README.md` states there is no independent third-party audit; treat wallet/key-handling code as alpha-grade.
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -54,15 +54,19 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 
 # 3. cargo-nextest (parallel test runner; see .config/nextest.toml and
 # .github/workflows/ci.yaml). Prebuilt binary, matches the runner's glibc.
+# Pinned (not `latest`) so an upstream release can't silently change test
+# behavior or JUnit output on a PR that didn't touch this file; keep in
+# sync with the version in .github/workflows/ci.yaml's install steps.
 # ci.yaml still installs it per-run too, so a PR landing before this image
 # is rebuilt (ci-image.yaml only rebuilds on push to main) isn't broken;
 # that step is redundant, not required, once this layer ships.
+ARG NEXTEST_VERSION=0.9.143
 RUN NEXTEST_PLATFORM=$(case "$(dpkg --print-architecture)" in \
         amd64) echo linux ;; \
         arm64) echo linux-arm ;; \
         *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac) \
-    && curl -LsSf "https://get.nexte.st/latest/${NEXTEST_PLATFORM}" | tar zxf - -C "${CARGO_HOME}/bin" \
+    && curl -LsSf "https://get.nexte.st/${NEXTEST_VERSION}/${NEXTEST_PLATFORM}" | tar zxf - -C "${CARGO_HOME}/bin" \
     && cargo nextest --version
 
 # 4. Node.js LTS + pnpm (match .github/workflows/ci.yaml versions)

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -52,7 +52,20 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
     && rustc --version \
     && cargo --version
 
-# 3. Node.js LTS + pnpm (match .github/workflows/ci.yaml versions)
+# 3. cargo-nextest (parallel test runner; see .config/nextest.toml and
+# .github/workflows/ci.yaml). Prebuilt binary, matches the runner's glibc.
+# ci.yaml still installs it per-run too, so a PR landing before this image
+# is rebuilt (ci-image.yaml only rebuilds on push to main) isn't broken;
+# that step is redundant, not required, once this layer ships.
+RUN NEXTEST_PLATFORM=$(case "$(dpkg --print-architecture)" in \
+        amd64) echo linux ;; \
+        arm64) echo linux-arm ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac) \
+    && curl -LsSf "https://get.nexte.st/latest/${NEXTEST_PLATFORM}" | tar zxf - -C "${CARGO_HOME}/bin" \
+    && cargo nextest --version
+
+# 4. Node.js LTS + pnpm (match .github/workflows/ci.yaml versions)
 ARG NODE_VERSION=24.18.0
 RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | tar -xJf - -C /usr/local --strip-components=1 \
     && node --version \
@@ -62,7 +75,7 @@ ARG PNPM_VERSION=11.7.0
 RUN npm install -g pnpm@${PNPM_VERSION} \
     && pnpm --version
 
-# 4. Pre-warm a throwaway crate so Cargo downloads its internal registry index.
+# 5. Pre-warm a throwaway crate so Cargo downloads its internal registry index.
 # This shaves a few seconds off the first real build.
 RUN cargo new --bin /tmp/throwaway \
     && cd /tmp/throwaway \

--- a/scripts/nextest-slow-summary.mjs
+++ b/scripts/nextest-slow-summary.mjs
@@ -2,7 +2,7 @@
 // Parses a cargo-nextest JUnit report and renders a "slowest tests" table.
 // Used in CI (see .github/workflows/ci.yaml) to make backend test-suite
 // performance visible per run without a separate analytics service.
-import { readFileSync, appendFileSync } from 'node:fs';
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 /**
@@ -58,6 +58,11 @@ async function main() {
   if (!junitPath) {
     console.error('usage: nextest-slow-summary.mjs <junit.xml> [title]');
     process.exit(1);
+  }
+
+  if (!existsSync(junitPath)) {
+    console.log(`No JUnit report at ${junitPath}; skipping timing summary.`);
+    return;
   }
 
   const xml = readFileSync(junitPath, 'utf8');

--- a/scripts/nextest-slow-summary.mjs
+++ b/scripts/nextest-slow-summary.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Parses a cargo-nextest JUnit report and renders a "slowest tests" table.
+// Used in CI (see .github/workflows/ci.yaml) to make backend test-suite
+// performance visible per run without a separate analytics service.
+import { readFileSync, appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Extract per-test durations from a nextest JUnit XML report.
+ * Returns [{ name, seconds }], sorted slowest-first.
+ */
+export function parseJUnitTimings(xml) {
+  const timings = [];
+  const testcaseRe = /<testcase\b[^>]*\bname="([^"]*)"[^>]*\btime="([^"]*)"/g;
+  for (const match of xml.matchAll(testcaseRe)) {
+    const [, rawName, rawTime] = match;
+    const seconds = Number(rawTime);
+    if (!Number.isFinite(seconds)) continue;
+    timings.push({ name: decodeXmlEntities(rawName), seconds });
+  }
+  return timings.sort((a, b) => b.seconds - a.seconds);
+}
+
+/** Read the `<testsuites time="…">` total, or null if absent/unparseable. */
+export function parseTotalSeconds(xml) {
+  const match = xml.match(/<testsuites\b[^>]*\btime="([^"]*)"/);
+  if (!match) return null;
+  const seconds = Number(match[1]);
+  return Number.isFinite(seconds) ? seconds : null;
+}
+
+function decodeXmlEntities(text) {
+  return text
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+/** Render a markdown "slowest tests" section for a CI step summary. */
+export function formatSummary(timings, { title, totalSeconds, limit = 15 } = {}) {
+  const lines = [`## ${title ?? 'Slowest tests'}`, ''];
+  if (totalSeconds != null) {
+    lines.push(`Suite: ${timings.length} tests, ${totalSeconds.toFixed(1)}s total.`, '');
+  }
+  lines.push('| Test | Time |', '| --- | ---: |');
+  for (const { name, seconds } of timings.slice(0, limit)) {
+    lines.push(`| \`${name}\` | ${seconds.toFixed(2)}s |`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function main() {
+  const junitPath = process.argv[2];
+  const title = process.argv[3];
+  if (!junitPath) {
+    console.error('usage: nextest-slow-summary.mjs <junit.xml> [title]');
+    process.exit(1);
+  }
+
+  const xml = readFileSync(junitPath, 'utf8');
+  const timings = parseJUnitTimings(xml);
+  const totalSeconds = parseTotalSeconds(xml);
+  const summary = formatSummary(timings, { title, totalSeconds });
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    appendFileSync(summaryPath, summary + '\n');
+  } else {
+    console.log(summary);
+  }
+}
+
+if (pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main();
+}

--- a/scripts/nextest-slow-summary.test.mjs
+++ b/scripts/nextest-slow-summary.test.mjs
@@ -1,3 +1,6 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseJUnitTimings, parseTotalSeconds, formatSummary } from './nextest-slow-summary.mjs';
@@ -25,6 +28,16 @@ describe('parseJUnitTimings', () => {
 
   it('returns an empty array when no testcases are present', () => {
     assert.deepEqual(parseJUnitTimings('<testsuites></testsuites>'), []);
+  });
+});
+
+describe('main() CLI entrypoint', () => {
+  it('exits 0 and skips the summary when the JUnit report is missing', () => {
+    const script = fileURLToPath(new URL('./nextest-slow-summary.mjs', import.meta.url));
+    const output = execFileSync(process.execPath, [script, '/tmp/does-not-exist-junit.xml'], {
+      encoding: 'utf8',
+    });
+    assert.match(output, /No JUnit report at .*does-not-exist-junit\.xml; skipping timing summary\./);
   });
 });
 

--- a/scripts/nextest-slow-summary.test.mjs
+++ b/scripts/nextest-slow-summary.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJUnitTimings, parseTotalSeconds, formatSummary } from './nextest-slow-summary.mjs';
+
+const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="3" failures="0" errors="0" time="12.5">
+    <testsuite name="pacto" tests="3" disabled="0" errors="0" failures="0">
+        <testcase name="fast_test" classname="pacto" timestamp="2026-01-01T00:00:00Z" time="0.010">
+        </testcase>
+        <testcase name="slow::nested::test&lt;T&gt;" classname="pacto" timestamp="2026-01-01T00:00:00Z" time="9.874">
+        </testcase>
+        <testcase name="mid_test" classname="pacto" timestamp="2026-01-01T00:00:00Z" time="1.200">
+        </testcase>
+    </testsuite>
+</testsuites>`;
+
+describe('parseJUnitTimings', () => {
+  it('extracts name and duration for every testcase, sorted slowest-first', () => {
+    assert.deepEqual(parseJUnitTimings(SAMPLE_XML), [
+      { name: 'slow::nested::test<T>', seconds: 9.874 },
+      { name: 'mid_test', seconds: 1.2 },
+      { name: 'fast_test', seconds: 0.01 },
+    ]);
+  });
+
+  it('returns an empty array when no testcases are present', () => {
+    assert.deepEqual(parseJUnitTimings('<testsuites></testsuites>'), []);
+  });
+});
+
+describe('parseTotalSeconds', () => {
+  it('reads the top-level testsuites time attribute', () => {
+    assert.equal(parseTotalSeconds(SAMPLE_XML), 12.5);
+  });
+
+  it('returns null when the attribute is missing', () => {
+    assert.equal(parseTotalSeconds('<testsuites></testsuites>'), null);
+  });
+});
+
+describe('formatSummary', () => {
+  it('renders a markdown table ordered slowest-first and respects the limit', () => {
+    const timings = parseJUnitTimings(SAMPLE_XML);
+    const summary = formatSummary(timings, { title: 'Slowest tests', totalSeconds: 12.5, limit: 2 });
+
+    assert.match(summary, /^## Slowest tests$/m);
+    assert.match(summary, /Suite: 3 tests, 12\.5s total\./);
+    assert.match(summary, /\| `slow::nested::test<T>` \| 9\.87s \|/);
+    assert.match(summary, /\| `mid_test` \| 1\.20s \|/);
+    assert.doesNotMatch(summary, /fast_test/);
+  });
+
+  it('omits the suite line when no total is available', () => {
+    const summary = formatSummary([{ name: 'a', seconds: 0.1 }], { title: 'X' });
+    assert.doesNotMatch(summary, /Suite:/);
+  });
+});

--- a/src-tauri/.config/nextest.toml
+++ b/src-tauri/.config/nextest.toml
@@ -1,0 +1,11 @@
+[profile.default]
+retries = 0
+
+# Used by CI (`cargo nextest run --profile ci`) to emit per-test timings for
+# the step-summary/slowest-tests report and artifact upload. See
+# .github/workflows/ci.yaml.
+[profile.ci]
+retries = 0
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/src-tauri/src/test_sandbox.rs
+++ b/src-tauri/src/test_sandbox.rs
@@ -668,6 +668,38 @@ mod tests {
     }
 
     #[test]
+    fn unsandboxed_test_dirs_resolve_under_the_private_fallback_root() {
+        let _lock = env_lock();
+        let _root = EnvGuard::unset(SANDBOX_ROOT_VAR);
+        let handle = tauri::test::mock_app().handle().clone();
+
+        let fallback = unit_test_fallback_root();
+        let data_dir = test_data_dir(&handle).unwrap();
+        let local_dir = test_local_data_dir(&handle).unwrap();
+
+        assert!(
+            data_dir.starts_with(&fallback),
+            "expected test_data_dir to resolve under the private fallback root, got: {}",
+            data_dir.display()
+        );
+        assert!(
+            local_dir.starts_with(&fallback),
+            "expected test_local_data_dir to resolve under the private fallback root, got: {}",
+            local_dir.display()
+        );
+        assert_ne!(
+            data_dir, local_dir,
+            "data and local subpaths must not collide with each other"
+        );
+
+        // A repeat call in the same process must resolve to the identical
+        // directory -- callers like account_manager's migrate/list pair
+        // write and then scan the same root within one test process.
+        assert_eq!(test_data_dir(&handle).unwrap(), data_dir);
+        assert_eq!(unit_test_fallback_root(), fallback);
+    }
+
+    #[test]
     fn enforce_dev_world_root_rejects_dotdot_root() {
         let _lock = env_lock();
         let base = temp_test_dir("enforce-dotdot-base");

--- a/src-tauri/src/test_sandbox.rs
+++ b/src-tauri/src/test_sandbox.rs
@@ -115,6 +115,17 @@ pub fn multi_instance_allowed() -> bool {
 /// ever sweeps (issue #347). Redirecting the unset-root fallback to a disposable
 /// OS temp directory, only inside test builds, keeps that litter out of the real
 /// filesystem without changing production path resolution at all.
+///
+/// Keyed by `std::process::id()`: under `cargo nextest run`, every test is its
+/// own OS process, so this gives each test a private root -- without it, all
+/// concurrently running tests shared this one directory, so a directory-wide
+/// scan in one test (`migrate_legacy_databases`) could mutate a sibling
+/// test's files mid-run, and heavy concurrent SQLite traffic against one
+/// shared tree produced intermittent "disk I/O error" failures. Under plain
+/// `cargo test`, every test in a binary shares one process and thus one
+/// fallback directory, same as before this change (already safe: those
+/// tests serialize via `.cargo/config.toml`'s `RUST_TEST_THREADS=1`).
+///
 /// `OnceLock`, not `LazyLock`: `remove_unit_test_fallback_root_at_exit` needs a
 /// non-forcing `get()` so a process that never touched the fallback root exits
 /// without creating (or trying to remove) anything.
@@ -125,7 +136,8 @@ static UNIT_TEST_FALLBACK_ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLo
 fn unit_test_fallback_root() -> PathBuf {
     UNIT_TEST_FALLBACK_ROOT
         .get_or_init(|| {
-            let dir = std::env::temp_dir().join("pacto-cargo-test-fallback");
+            let dir = std::env::temp_dir()
+                .join(format!("pacto-cargo-test-fallback-{}", std::process::id()));
             // Best-effort: start every test binary run from a clean slate rather
             // than accumulating npub directories left by a run that was killed
             // before its own atexit handler below ran.


### PR DESCRIPTION
## Summary

Backend CI tests ran sequentially in one shared process (`cargo test --lib`): 918 tests, ~190s locally. Switched `backend-tests` and `relay-free-harness` to `cargo-nextest`, which runs each test in its own OS process instead of one thread pool — same suite, ~25s, identical pass/fail semantics. Also added a per-run timing report so a future regression is visible on the PR instead of requiring a manual re-measure.

Fixes #279

| | `cargo test --lib` | `cargo nextest run --lib` |
|---|---|---|
| Backend tests, same machine | ~190s | ~25s (~7x) |

### Making nextest's concurrency actually safe

Switching to real concurrent test execution surfaced a latent bug: several `mock_app()`-based tests never set `PACTO_TEST_SANDBOX_ROOT`, so they fell through to a fallback directory shared by every concurrently running test process. One test (`migrate_legacy_databases_covers_every_profile_directory`) sweeps every profile directory it finds there, so under nextest's real concurrency it was mutating sibling test processes' files mid-run; heavy concurrent SQLite traffic against that one shared tree also produced intermittent "disk I/O error" failures elsewhere. `#348` (merged to `main` while this branch was in flight) independently found and fixed the same root cause — redirecting that fallback to a disposable OS temp directory instead of the real Application Support folder — but kept one fixed path for the whole test binary, which still collides across nextest's concurrent processes. This branch adds the missing piece: keying that fallback directory by `std::process::id()`, so each nextest process (one per test) gets its own private root, while `cargo test` (all tests sharing one process) is unaffected.

### Design decisions

- **No matrix/partition sharding.** Single Rust crate, not a Cargo workspace — issue #279's "split by crate" and pytest-xdist suggestions (written against `pacto-bot-api`'s layout) don't apply here, and this repo has no Python test suite. The process-isolation win alone already delivers the issue's "significant reduction in total CI pipeline duration" outcome.
- **nextest installed as a workflow step, not only baked into `Dockerfile.ci`.** `ci-image.yaml` only rebuilds `pacto-ci:latest` on push to `main`, so an image-only install would leave a PR's own CI run without nextest until after merge. `Dockerfile.ci` now installs it too (architecture-aware: `get.nexte.st`'s default asset is x86_64-only, caught by a local arm64 build), so once this merges and the image rebuilds, the per-run install becomes redundant — safe to drop as a later cleanup.
- **Timing visibility via a `ci` nextest profile + step summary, not a new dashboard.** `.config/nextest.toml` adds a `ci` profile emitting a JUnit report; `scripts/nextest-slow-summary.mjs` renders it as a slowest-tests table on the job's `$GITHUB_STEP_SUMMARY`, and the JUnit file uploads as a build artifact (`if: always()`, so it still populates on a failing run). No new service or `gh-pages` branch.

## New concepts

**cargo-nextest** is a Rust test runner that executes each test in its own OS process, instead of `cargo test`'s model of one shared process with many threads.

**Why here:** it gets the ~7x wall-time win above with zero test-code changes. It also makes a class of existing workaround moot: several test modules in this crate define an `ENV_TEST_MUTEX` to serialize env-var-mutating tests that would otherwise race inside `cargo test`'s shared process — under nextest those tests already run in separate processes, so the mutex is now just uncontended, not load-bearing. The flip side is the fallback-directory bug this PR fixes: process isolation only helps when every test's resources are actually process-scoped, not a real shared filesystem path.

```yaml
# .github/workflows/ci.yaml
- run: cargo nextest run --lib --no-default-features --profile ci
```

**When not to use it:** per-test process spawn has real overhead, not worth it for a suite small/fast enough that spawn cost would dominate; and any test that depends on genuinely shared in-process state across tests (a cache meant to warm once for the whole run) needs to be redesigned around fixtures rather than process-wide statics, since nextest never shares one.

## Test plan

- Full backend suite (949 tests) run 10 consecutive times locally via `cargo nextest run --profile ci`, all clean — versus reproducible failures before the fallback-directory fix.
- `node --test scripts/generate-release-manifest.test.mjs scripts/stamp-updater-compatibility.test.mjs scripts/nextest-slow-summary.test.mjs` — 39/39 passing (6 new for the timing-summary parser).
- CI green end to end on this PR: `backend-tests`, `relay-free-harness`, `typecheck`, `lint`, `frontend-tests`, `scripts-test`, `landing-build`, `release-symbol-check`.
- Local Docker build of `Dockerfile.ci` on arm64 confirmed the nextest install step (verified `cargo-nextest 0.9.143` runs) before it could break a future image rebuild.
